### PR TITLE
Making the CI work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
   # Required by cargo-xbuild
   - rustup component add rust-src
   # Required by cargo-xclippy
-  - rustup component add clippy-preview
+  - rustup component add clippy
   # For checking the code's formatting
-  - rustup component add rustfmt-preview
+  - rustup component add rustfmt
   # Try installing cargo-xbuild if it's not already installed
   - hash cargo-xbuild || cargo install cargo-xbuild
   # Save the current branch


### PR DESCRIPTION
The CI is broken. I think that's because the clippy and rustfmt components changed name during stabilization.