### PR TITLE
Remove unnecessary repr(packed)

### DIFF
--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -427,7 +427,7 @@ impl<'gop> Iterator for ModeIter<'gop> {
 /// This is a BGR 24-bit format with an 8-bit padding, to keep each pixel 32-bit in size.
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct BltPixel {
     pub blue: u8,
     pub green: u8,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -564,7 +564,7 @@ pub enum MemoryType: u32 => {
 
 /// A structure describing a region of memory.
 #[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
     pub ty: MemoryType,


### PR DESCRIPTION
Both `BltPixel` and `MemoryDescriptor` are already fully packed _and_ fully aligned structures. Thus, adding `#[repr(packed}]` does nothing except:
  - makes certain field accesses unsafe
  - allow the struct to be safely misaligned in memory

This doesn't seem like the intent of the code, so removing `packed` should make using these structs easier. Really, I would want something like #[repr(perfect_alignment)] and have the compiler error if any padding would need to be inserted for #[repr(C)].