### PR TITLE
Add discard_errdata() method to Result

### DIFF
--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -45,6 +45,9 @@ pub trait ResultExt<Output, ErrData: Debug> {
 
     /// Transform the inner output, if any
     fn map_inner<Mapped>(self, f: impl FnOnce(Output) -> Mapped) -> Result<Mapped, ErrData>;
+
+    /// Transform the ErrData value to ()
+    fn discard_errdata(self) -> Result<Output>;
 }
 
 /// Extension trait for results with no error payload
@@ -75,6 +78,13 @@ impl<Output, ErrData: Debug> ResultExt<Output, ErrData> for Result<Output, ErrDa
 
     fn map_inner<Mapped>(self, f: impl FnOnce(Output) -> Mapped) -> Result<Mapped, ErrData> {
         self.map(|completion| completion.map(f))
+    }
+
+    fn discard_errdata(self) -> Result<Output> {
+        match self {
+            Ok(o) => Ok(o),
+            Err(e) => Err(e.status().into()),
+        }
     }
 }
 


### PR DESCRIPTION
Most functions in the uefi package return a `Result<Output>`,  but some return `Result<Output, ErrData>`. This makes it challenging to write your own methods returning `Resut<T>`, especially because [the `Error` type is not exported](https://github.com/rust-osdev/uefi-rs/blob/b57af64d905decb43fe458641eb5976d378874dc/src/lib.rs#L40).

An easy way to fix this is to just add a method converting a `Result<Output, ErrData>` to a `Result<Output>`, keeping the status but discarding the data.