### PR TITLE
Replace ResultExt2 with a where clause

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) use self::data_types::{unsafe_guid, Identify};
 pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
 
 mod result;
-pub use self::result::{Completion, Result, ResultExt, ResultExt2, Status};
+pub use self::result::{Completion, Result, ResultExt, Status};
 
 pub mod table;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 //!
 //! This includes the system table types, `Status` codes, etc.
 
-pub use crate::{ResultExt, ResultExt2, Status};
+pub use crate::{ResultExt, Status};
 
 // Import the basic table types.
 pub use crate::table::boot::BootServices;

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -45,12 +45,11 @@ pub trait ResultExt<Output, ErrData: Debug> {
 
     /// Transform the inner output, if any
     fn map_inner<Mapped>(self, f: impl FnOnce(Output) -> Mapped) -> Result<Mapped, ErrData>;
-}
 
-/// Extension trait for results with no error payload
-pub trait ResultExt2<Output> {
     /// Treat warnings as errors
-    fn warning_as_error(self) -> core::result::Result<Output, Error<()>>;
+    fn warning_as_error(self) -> core::result::Result<Output, Error<ErrData>>
+    where
+        ErrData: Default;
 }
 
 impl<Output, ErrData: Debug> ResultExt<Output, ErrData> for Result<Output, ErrData> {
@@ -76,13 +75,14 @@ impl<Output, ErrData: Debug> ResultExt<Output, ErrData> for Result<Output, ErrDa
     fn map_inner<Mapped>(self, f: impl FnOnce(Output) -> Mapped) -> Result<Mapped, ErrData> {
         self.map(|completion| completion.map(f))
     }
-}
 
-impl<Output> ResultExt2<Output> for Result<Output, ()> {
-    fn warning_as_error(self) -> core::result::Result<Output, Error<()>> {
+    fn warning_as_error(self) -> core::result::Result<Output, Error<ErrData>>
+    where
+        ErrData: Default,
+    {
         match self.map(|comp| comp.split()) {
             Ok((Status::SUCCESS, res)) => Ok(res),
-            Ok((s, _)) => Err(s.into()),
+            Ok((s, _)) => Err(Error::new(s, Default::default())),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
In https://github.com/rust-osdev/uefi-rs/pull/78 `ResultExt2` was added to handle the special case of an Error not have an additional payload. However, this isn't necessary, as a `where` clause for `Default` can also handle this case.

As a bonus, it works fine on `Result<Output, Option<usize>>` values, it will just set the payload to `None` if a warning triggers and error.