### PR TITLE
Refactor File types to have common functionality use traits

### DIFF
--- a/src/proto/media/file/dir.rs
+++ b/src/proto/media/file/dir.rs
@@ -1,18 +1,26 @@
-use super::{File, FileInfo, FilesystemObject, FromUefi, RegularFile};
+use super::{File, FileHandle, FileInfo, FromUefi, RegularFile};
 use crate::data_types::Align;
 use crate::prelude::*;
 use crate::Result;
 use core::ffi::c_void;
 
-/// A `File` that is also a directory.
+/// A `FileHandle` that is also a directory.
 ///
-/// Use `File::into_kind` or `File::into_directory` to create a `Directory`. In
-/// addition to supporting the normal `FilesystemObject` operations, `Directory`
+/// Use `File::into_type` or `Directory::new` to create a `Directory`. In
+/// addition to supporting the normal `File` operations, `Directory`
 /// supports iterating over its contained files.
 #[repr(transparent)]
-pub struct Directory<'imp>(pub(super) RegularFile<'imp>);
+pub struct Directory(RegularFile);
 
-impl Directory<'_> {
+impl Directory {
+    /// Coverts a `FileHandle` into a `Directory` without checking the file type.
+    /// # Safety
+    /// This function should only be called on files which ARE directories,
+    /// doing otherwise is unsafe.
+    pub unsafe fn new(handle: FileHandle) -> Self {
+        Self(RegularFile::new(handle))
+    }
+
     /// Read the next directory entry
     ///
     /// Try to read the next directory entry into `buffer`. If the buffer is too small, report the
@@ -55,9 +63,9 @@ impl Directory<'_> {
     }
 }
 
-impl<'imp> FilesystemObject<'imp> for Directory<'imp> {
+impl File for Directory {
     #[inline]
-    fn file(&mut self) -> &mut File<'imp> {
-        self.0.file()
+    fn handle(&mut self) -> &mut FileHandle {
+        self.0.handle()
     }
 }

--- a/src/proto/media/file/dir.rs
+++ b/src/proto/media/file/dir.rs
@@ -1,47 +1,18 @@
-use super::{File, FileAttribute, FileInfo, FileMode, FileProtocolInfo, FromUefi};
+use super::{File, FileInfo, FilesystemObject, FromUefi, RegularFile};
 use crate::data_types::Align;
 use crate::prelude::*;
 use crate::Result;
 use core::ffi::c_void;
 
-/// `File` wrapper for handling directories
+/// A `File` that is also a directory.
 ///
-/// The `File` abstraction can handle directories, but does so in a very roundabout way.
-/// A dedicated abstraction for directory handling is therefore desirable.
-pub struct Directory<'file>(File<'file>);
+/// Use `File::into_kind` or `File::into_directory` to create a `Directory`. In
+/// addition to supporting the normal `FilesystemObject` operations, `Directory`
+/// supports iterating over its contained files.
+#[repr(transparent)]
+pub struct Directory<'imp>(pub(super) RegularFile<'imp>);
 
-impl<'file> Directory<'file> {
-    /// Wrap a File handle into a Directory
-    ///
-    /// You should have made sure that the file is indeed a directory beforehand, using
-    /// `file.get_info<FileInfo>(...)`. We cannot do it for you because this requires an unbounded
-    /// amount of memory and we refrain from calling the UEFI allocator implicitly.
-    pub unsafe fn from_file(file: File<'file>) -> Self {
-        Directory(file)
-    }
-
-    /// Try to open a file relative to this directory.
-    ///
-    /// This simply forwards to the underlying `File::open` implementation
-    pub fn open(
-        &mut self,
-        filename: &str,
-        open_mode: FileMode,
-        attributes: FileAttribute,
-    ) -> Result<File> {
-        self.0.open(filename, open_mode, attributes)
-    }
-
-    /// Close this directory handle. Same as dropping this structure.
-    pub fn close(self) {}
-
-    /// Closes and deletes this directory
-    ///
-    /// This simply forwards to the underlying `File::delete` implementation
-    pub fn delete(self) -> Result {
-        self.0.delete()
-    }
-
+impl Directory<'_> {
     /// Read the next directory entry
     ///
     /// Try to read the next directory entry into `buffer`. If the buffer is too small, report the
@@ -82,28 +53,11 @@ impl<'file> Directory<'file> {
     pub fn reset_entry_readout(&mut self) -> Result {
         self.0.set_position(0)
     }
+}
 
-    /// Queries some information about a directory
-    ///
-    /// This simply forwards to the underlying `File::get_info` implementation
-    pub fn get_info<'buf, Info: FileProtocolInfo + ?Sized>(
-        &mut self,
-        buffer: &'buf mut [u8],
-    ) -> Result<&'buf mut Info, Option<usize>> {
-        self.0.get_info::<Info>(buffer)
-    }
-
-    /// Sets some information about a directory
-    ///
-    /// This simply forwards to the underlying `File::set_info` implementation
-    pub fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
-        self.0.set_info(info)
-    }
-
-    /// Flushes all modified data associated with the directory to the device
-    ///
-    /// This simply forwards to the underlying `File::flush` implementation
-    pub fn flush(&mut self) -> Result {
-        self.0.flush()
+impl<'imp> FilesystemObject<'imp> for Directory<'imp> {
+    #[inline]
+    fn file(&mut self) -> &mut File<'imp> {
+        self.0.file()
     }
 }

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -9,7 +9,7 @@ use core::mem;
 use core::slice;
 
 /// Common trait for data structures that can be used with
-/// `FilesystemObject::set_info()` or `FilesystemObject::get_info()`.
+/// `File::set_info()` or `File::get_info()`.
 ///
 /// The long-winded name is needed because "FileInfo" is already taken by UEFI.
 pub trait FileProtocolInfo: Align + Identify + FromUefi {}

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -9,7 +9,7 @@ use core::mem;
 use core::slice;
 
 /// Common trait for data structures that can be used with
-/// `File::set_info()` or `File::set_info()`.
+/// `FilesystemObject::set_info()` or `FilesystemObject::get_info()`.
 ///
 /// The long-winded name is needed because "FileInfo" is already taken by UEFI.
 pub trait FileProtocolInfo: Align + Identify + FromUefi {}

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -1,12 +1,14 @@
-//! This module provides the `File` structure, representing an opaque handle to a
-//! directory / file, as well as providing functions for opening new files.
+//! This module provides the `File` structure as well as the more specific `RegularFile` and
+//! `Directory` structures. This module also provides functions for opening, querying, creating,
+//! reading, and writing files.
 //!
-//! Usually a file system implementation will return a "root" file, representing
-//! `/` on that volume, and with that file it is possible to enumerate and open
+//! Usually a file system implementation will return a "root" directory, representing
+//! `/` on that volume. With that directory, it is possible to enumerate and open
 //! all the other files on that volume.
 
 mod dir;
 mod info;
+mod regular;
 
 use crate::prelude::*;
 use crate::{CStr16, Char16, Guid, Result, Status};
@@ -16,30 +18,22 @@ use core::mem;
 use core::ptr;
 use ucs2;
 
-pub use self::dir::Directory;
 pub use self::info::{FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi};
+pub use self::{dir::Directory, regular::RegularFile};
 
-/// A file represents an abstraction of some contiguous block of data residing
-/// on a volume.
+/// Common interface to `File`, `RegularFile`, and `Directory`.
 ///
-/// Dropping this structure will result in the file handle being closed.
-///
-/// Files have names, and a fixed size.
-///
-/// A `File` may also be used to access a directory, but the interface for doing
-/// so is awkward. If you know that a file is a directory, consider wrapping it
-/// into a `Directory` for improved ergonomics.
-pub struct File<'imp>(&'imp mut FileImpl);
+/// `FilesystemObject` continas all funcationality that is safe to perform on
+/// any kind of file handle.
+pub trait FilesystemObject<'imp>: Sized {
+    /// Access the underlying file handle.
+    #[doc(hidden)]
+    fn file(&mut self) -> &mut File<'imp>;
 
-impl<'imp> File<'imp> {
-    pub(super) unsafe fn new(ptr: *mut FileImpl) -> Self {
-        File(&mut *ptr)
-    }
-
-    /// Try to open a file relative to this file/directory.
+    /// Try to open a file relative to this file.
     ///
     /// # Arguments
-    /// * `filename`    Path of file to open, relative to this File
+    /// * `filename`    Path of file to open, relative to this file
     /// * `open_mode`   The mode to open the file with
     /// * `attributes`  Only valid when `FILE_MODE_CREATE` is used as a mode
     ///
@@ -54,7 +48,7 @@ impl<'imp> File<'imp> {
     /// * `uefi::Status::ACCESS_DENIED`      The service denied access to the file
     /// * `uefi::Status::OUT_OF_RESOURCES`    Not enough resources to open file
     /// * `uefi::Status::VOLUME_FULL`        The volume is full
-    pub fn open(
+    fn open(
         &mut self,
         filename: &str,
         open_mode: FileMode,
@@ -70,117 +64,30 @@ impl<'imp> File<'imp> {
             let len = ucs2::encode(filename, &mut buf)?;
             let filename = unsafe { CStr16::from_u16_with_nul_unchecked(&buf[..=len]) };
 
-            unsafe { (self.0.open)(self.0, &mut ptr, filename.as_ptr(), open_mode, attributes) }
-                .into_with_val(|| unsafe { File::new(ptr) })
+            unsafe {
+                (self.file().0.open)(
+                    self.file().0,
+                    &mut ptr,
+                    filename.as_ptr(),
+                    open_mode,
+                    attributes,
+                )
+            }
+            .into_with_val(|| unsafe { File(&mut *ptr) })
         }
     }
 
     /// Close this file handle. Same as dropping this structure.
-    pub fn close(self) {}
+    fn close(self) {}
 
     /// Closes and deletes this file
     ///
     /// # Warnings
     /// * `uefi::Status::WARN_DELETE_FAILURE` The file was closed, but deletion failed
-    pub fn delete(self) -> Result {
-        let result = (self.0.delete)(self.0).into();
+    fn delete(mut self) -> Result {
+        let result = (self.file().0.delete)(self.file().0).into();
         mem::forget(self);
         result
-    }
-
-    /// Read data from file
-    ///
-    /// If the file is not a directory, try to read as much as possible into `buffer`. Returns the
-    /// number of bytes that were actually read.
-    ///
-    /// If the file is a directory, try to read the next directory entry, which is a `FileInfo`,
-    /// into `buffer`. If it is too small, report the required buffer size as part of the error.
-    /// If there are no more directory entries, report success as if zero bytes were read. You
-    /// should provide a buffer which is suitably aligned for holding a `FileInfo` in this case, or
-    /// be prepared to only manipulate your data via `ptr::read_unaligned()`.
-    ///
-    /// Because enumerating directory entries is so involved, it is recommended to wrap the `File`
-    /// into a `Directory` if you intend to do it.
-    ///
-    /// # Arguments
-    /// * `buffer`  The target buffer of the read operation
-    ///
-    /// # Errors
-    /// * `uefi::Status::NO_MEDIA`           The device has no media
-    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error, the file was deleted,
-    ///                                      or the end of the file was reached before the `read()`.
-    /// * `uefi::Status::VOLUME_CORRUPTED`   The filesystem structures are corrupted
-    /// * `uefi::Status::BUFFER_TOO_SMALL`   The buffer is too small to hold a directory entry,
-    ///                                      and the required buffer size is provided as output.
-    pub fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Option<usize>> {
-        let mut buffer_size = buffer.len();
-        unsafe { (self.0.read)(self.0, &mut buffer_size, buffer.as_mut_ptr()) }.into_with(
-            || buffer_size,
-            |s| {
-                if s == Status::BUFFER_TOO_SMALL {
-                    Some(buffer_size)
-                } else {
-                    None
-                }
-            },
-        )
-    }
-
-    /// Write data to file
-    ///
-    /// Write `buffer` to file, increment the file pointer.
-    ///
-    /// If an error occurs, returns the number of bytes that were actually written. If no error
-    /// occured, the entire buffer is guaranteed to have been written successfully.
-    ///
-    /// Opened directories cannot be written to.
-    ///
-    /// # Arguments
-    /// * `buffer`  Buffer to write to file
-    ///
-    /// # Errors
-    /// * `uefi::Status::UNSUPPORTED`        Attempted to write in a directory.
-    /// * `uefi::Status::NO_MEDIA`           The device has no media
-    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error or the file was deleted.
-    /// * `uefi::Status::VOLUME_CORRUPTED`   The filesystem structures are corrupted
-    /// * `uefi::Status::WRITE_PROTECTED`    Attempt to write to readonly file
-    /// * `uefi::Status::ACCESS_DENIED`      The file was opened read only.
-    /// * `uefi::Status::VOLUME_FULL`        The volume is full
-    pub fn write(&mut self, buffer: &[u8]) -> Result<(), usize> {
-        let mut buffer_size = buffer.len();
-        unsafe { (self.0.write)(self.0, &mut buffer_size, buffer.as_ptr()) }
-            .into_with_err(|_| buffer_size)
-    }
-
-    /// Get the file's current position
-    ///
-    /// # Errors
-    /// * `uefi::Status::UNSUPPORTED`    Attempted to get the position of an opened directory
-    /// * `uefi::Status::DEVICE_ERROR`   An attempt was made to get the position of a deleted file
-    pub fn get_position(&mut self) -> Result<u64> {
-        let mut pos = 0u64;
-        (self.0.get_position)(self.0, &mut pos).into_with_val(|| pos)
-    }
-
-    /// Sets the file's current position
-    ///
-    /// Set the position of this file handle to the absolute position specified by `position`.
-    ///
-    /// Seeking past the end of the file is allowed, it will trigger file growth on the next write.
-    ///
-    /// The special value 0xFFFF_FFFF_FFFF_FFFF may be used to seek to the end of the file.
-    ///
-    /// Seeking directories is only allowed with the special value 0, which has the effect of
-    /// resetting the enumeration of directory entries.
-    ///
-    /// # Arguments
-    /// * `position` The new absolution position of the file handle
-    ///
-    /// # Errors
-    /// * `uefi::Status::UNSUPPORTED`    Attempted a nonzero seek on a directory.
-    /// * `uefi::Status::DEVICE_ERROR`   An attempt was made to set the position of a deleted file
-    pub fn set_position(&mut self, position: u64) -> Result {
-        (self.0.set_position)(self.0, position).into()
     }
 
     /// Queries some information about a file
@@ -199,23 +106,30 @@ impl<'imp> File<'imp> {
     /// * `uefi::Status::DEVICE_ERROR`       The device reported an error
     /// * `uefi::Status::VOLUME_CORRUPTED`   The file system structures are corrupted
     /// * `uefi::Status::BUFFER_TOO_SMALL`   The buffer is too small for the requested
-    pub fn get_info<'buf, Info: FileProtocolInfo + ?Sized>(
+    fn get_info<'buf, Info: FileProtocolInfo + ?Sized>(
         &mut self,
         buffer: &'buf mut [u8],
     ) -> Result<&'buf mut Info, Option<usize>> {
         let mut buffer_size = buffer.len();
         Info::assert_aligned(buffer);
-        unsafe { (self.0.get_info)(self.0, &Info::GUID, &mut buffer_size, buffer.as_mut_ptr()) }
-            .into_with(
-                || unsafe { Info::from_uefi(buffer.as_ptr() as *mut c_void) },
-                |s| {
-                    if s == Status::BUFFER_TOO_SMALL {
-                        Some(buffer_size)
-                    } else {
-                        None
-                    }
-                },
+        unsafe {
+            (self.file().0.get_info)(
+                self.file().0,
+                &Info::GUID,
+                &mut buffer_size,
+                buffer.as_mut_ptr(),
             )
+        }
+        .into_with(
+            || unsafe { Info::from_uefi(buffer.as_ptr() as *mut c_void) },
+            |s| {
+                if s == Status::BUFFER_TOO_SMALL {
+                    Some(buffer_size)
+                } else {
+                    None
+                }
+            },
+        )
     }
 
     /// Sets some information about a file
@@ -236,10 +150,10 @@ impl<'imp> File<'imp> {
     /// * `uefi::Status::WRITE_PROTECTED`   Attempted to set information on a read-only media
     /// * `uefi::Status::ACCESS_DENIED`     Requested change is invalid for this information type
     /// * `uefi::Status::VOLUME_FULL`       Not enough space left on the volume to change the info
-    pub fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
+    fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
         let info_ptr = info as *const Info as *const c_void;
         let info_size = mem::size_of_val(&info);
-        unsafe { (self.0.set_info)(self.0, &Info::GUID, info_size, info_ptr).into() }
+        unsafe { (self.file().0.set_info)(self.file().0, &Info::GUID, info_size, info_ptr).into() }
     }
 
     /// Flushes all modified data associated with the file handle to the device
@@ -251,12 +165,63 @@ impl<'imp> File<'imp> {
     /// * `uefi::Status::WRITE_PROTECTED`    The file or medium is write protected
     /// * `uefi::Status::ACCESS_DENIED`      The file was opened read only
     /// * `uefi::Status::VOLUME_FULL`        The volume is full
-    pub fn flush(&mut self) -> Result {
-        (self.0.flush)(self.0).into()
+    fn flush(&mut self) -> Result {
+        (self.file().0.flush)(self.file().0).into()
     }
 }
 
-impl<'imp> Drop for File<'imp> {
+/// An opaque handle to some contiguous block of data on a volume.
+///
+/// A `File` is just a wrapper around a file handle. Under the hood, it can
+/// either be a `RegularFile` or a `Directory`; use the `into_kind` or the
+/// unsafe `into_*` methods to perform the conversion.
+///
+/// Dropping this structure will result in the file handle being closed.
+#[repr(transparent)]
+pub struct File<'imp>(pub(super) &'imp mut FileImpl);
+
+impl<'imp> File<'imp> {
+    /// Converts `File` into a more specific subtype based on if it is a
+    /// directory or not. It does this via a call to `get_position`.
+    pub fn into_kind(self) -> Result<FileKind<'imp>> {
+        use FileKind::*;
+
+        // get_position fails with EFI_UNSUPPORTED on directories
+        let mut pos = 0;
+        match (self.0.get_position)(self.0, &mut pos) {
+            Status::SUCCESS => unsafe { Ok(Regular(self.into_regular_file()).into()) },
+            Status::UNSUPPORTED => unsafe { Ok(Dir(self.into_directory()).into()) },
+            s => Err(s.into()),
+        }
+    }
+
+    /// Coverts a `File` into a `RegularFile` without checking the file kind.
+    /// # Safety
+    /// This function should only be called on files which ARE NOT directories,
+    /// doing otherwise is unsafe.
+    #[inline]
+    pub unsafe fn into_regular_file(self) -> RegularFile<'imp> {
+        RegularFile(self)
+    }
+
+    /// Coverts a `File` into a `Directory` without checking the file kind.
+    /// # Safety
+    /// This function should only be called on files which ARE directories,
+    /// doing otherwise is unsafe.
+    #[inline]
+    pub unsafe fn into_directory(self) -> Directory<'imp> {
+        Directory(self.into_regular_file())
+    }
+}
+
+impl<'imp> FilesystemObject<'imp> for File<'imp> {
+    #[inline]
+    fn file(&mut self) -> &mut File<'imp> {
+        self
+    }
+}
+
+impl Drop for File<'_> {
     fn drop(&mut self) {
         let result: Result = (self.0.close)(self.0).into();
         // The spec says this always succeeds.
@@ -302,6 +267,14 @@ pub(super) struct FileImpl {
         buffer: *const c_void,
     ) -> Status,
     flush: extern "win64" fn(this: &mut FileImpl) -> Status,
+}
+
+/// Disambiguates the file kind. Returned by `File::into_kind()`.
+pub enum FileKind<'file> {
+    /// The file was a regular (data) file.
+    Regular(RegularFile<'file>),
+    /// The file was a directory.
+    Dir(Directory<'file>),
 }
 
 /// Usage flags describing what is possible to do with the file.

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -23,7 +23,7 @@ pub use self::{dir::Directory, regular::RegularFile};
 
 /// Common interface to `FileHandle`, `RegularFile`, and `Directory`.
 ///
-/// `File` continas all funcationality that is safe to perform on any type of
+/// `File` contains all functionality that is safe to perform on any type of
 /// file handle.
 pub trait File: Sized {
     /// Access the underlying file handle.

--- a/src/proto/media/file/regular.rs
+++ b/src/proto/media/file/regular.rs
@@ -1,0 +1,99 @@
+use super::{File, FilesystemObject};
+use crate::{Result, Status};
+
+/// A `File` that is also a regular (data) file.
+///
+/// Use `File::into_kind` or `File::into_regular_file` to create a
+/// `RegularFile`. In addition to supporting the normal `FilesystemObject`
+/// operations, `RegularFile` supports direct reading and writing.
+#[repr(transparent)]
+pub struct RegularFile<'imp>(pub(super) File<'imp>);
+
+impl RegularFile<'_> {
+    /// Read data from file
+    ///
+    /// Try to read as much as possible into `buffer`. Returns the number of bytes that were
+    /// actually read.
+    ///
+    /// # Arguments
+    /// * `buffer`  The target buffer of the read operation
+    ///
+    /// # Errors
+    /// * `uefi::Status::NO_MEDIA`           The device has no media
+    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error, the file was deleted,
+    ///                                      or the end of the file was reached before the `read()`.
+    /// * `uefi::Status::VOLUME_CORRUPTED`   The filesystem structures are corrupted
+    /// * `uefi::Status::BUFFER_TOO_SMALL`   The buffer is too small to hold a directory entry,
+    ///                                      and the required buffer size is provided as output.
+    pub fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Option<usize>> {
+        let mut buffer_size = buffer.len();
+        unsafe { (self.file().0.read)(self.file().0, &mut buffer_size, buffer.as_mut_ptr()) }
+            .into_with(
+                || buffer_size,
+                |s| {
+                    if s == Status::BUFFER_TOO_SMALL {
+                        Some(buffer_size)
+                    } else {
+                        None
+                    }
+                },
+            )
+    }
+
+    /// Write data to file
+    ///
+    /// Write `buffer` to file, increment the file pointer.
+    ///
+    /// If an error occurs, returns the number of bytes that were actually written. If no error
+    /// occured, the entire buffer is guaranteed to have been written successfully.
+    ///
+    /// # Arguments
+    /// * `buffer`  Buffer to write to file
+    ///
+    /// # Errors
+    /// * `uefi::Status::NO_MEDIA`           The device has no media
+    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error or the file was deleted.
+    /// * `uefi::Status::VOLUME_CORRUPTED`   The filesystem structures are corrupted
+    /// * `uefi::Status::WRITE_PROTECTED`    Attempt to write to readonly file
+    /// * `uefi::Status::ACCESS_DENIED`      The file was opened read only.
+    /// * `uefi::Status::VOLUME_FULL`        The volume is full
+    pub fn write(&mut self, buffer: &[u8]) -> Result<(), usize> {
+        let mut buffer_size = buffer.len();
+        unsafe { (self.file().0.write)(self.file().0, &mut buffer_size, buffer.as_ptr()) }
+            .into_with_err(|_| buffer_size)
+    }
+
+    /// Get the file's current position
+    ///
+    /// # Errors
+    /// * `uefi::Status::UNSUPPORTED`    Attempted to get the position of an opened directory
+    /// * `uefi::Status::DEVICE_ERROR`   An attempt was made to get the position of a deleted file
+    pub fn get_position(&mut self) -> Result<u64> {
+        let mut pos = 0u64;
+        (self.file().0.get_position)(self.file().0, &mut pos).into_with_val(|| pos)
+    }
+
+    /// Sets the file's current position
+    ///
+    /// Set the position of this file handle to the absolute position specified by `position`.
+    ///
+    /// Seeking past the end of the file is allowed, it will trigger file growth on the next write.
+    ///
+    /// The special value 0xFFFF_FFFF_FFFF_FFFF may be used to seek to the end of the file.
+    ///
+    /// # Arguments
+    /// * `position` The new absolution position of the file handle
+    ///
+    /// # Errors
+    /// * `uefi::Status::DEVICE_ERROR`   An attempt was made to set the position of a deleted file
+    pub fn set_position(&mut self, position: u64) -> Result {
+        (self.file().0.set_position)(self.file().0, position).into()
+    }
+}
+
+impl<'imp> FilesystemObject<'imp> for RegularFile<'imp> {
+    #[inline]
+    fn file(&mut self) -> &mut File<'imp> {
+        &mut self.0
+    }
+}

--- a/src/proto/media/file/regular.rs
+++ b/src/proto/media/file/regular.rs
@@ -10,6 +10,9 @@ use crate::{Result, Status};
 pub struct RegularFile(FileHandle);
 
 impl RegularFile {
+    /// A special position used to seek to the end of a file with `set_position()`.
+    pub const END_OF_FILE: u64 = core::u64::MAX;
+
     /// Coverts a `FileHandle` into a `RegularFile` without checking the file kind.
     /// # Safety
     /// This function should only be called on handles which ARE NOT directories,
@@ -73,7 +76,6 @@ impl RegularFile {
     /// Get the file's current position
     ///
     /// # Errors
-    /// * `uefi::Status::UNSUPPORTED`    Attempted to get the position of an opened directory
     /// * `uefi::Status::DEVICE_ERROR`   An attempt was made to get the position of a deleted file
     pub fn get_position(&mut self) -> Result<u64> {
         let mut pos = 0u64;
@@ -85,8 +87,7 @@ impl RegularFile {
     /// Set the position of this file handle to the absolute position specified by `position`.
     ///
     /// Seeking past the end of the file is allowed, it will trigger file growth on the next write.
-    ///
-    /// The special value 0xFFFF_FFFF_FFFF_FFFF may be used to seek to the end of the file.
+    /// Using a position of RegularFile::END_OF_FILE will seek to the end of the file.
     ///
     /// # Arguments
     /// * `position` The new absolution position of the file handle

--- a/src/proto/media/fs.rs
+++ b/src/proto/media/fs.rs
@@ -1,6 +1,6 @@
 //! File system support protocols.
 
-use super::file::{Directory, File, FileImpl};
+use super::file::{Directory, FileHandle, FileImpl};
 use crate::proto::Protocol;
 use crate::{unsafe_guid, Result, Status};
 use core::ptr;
@@ -31,6 +31,6 @@ impl SimpleFileSystem {
     pub fn open_volume(&mut self) -> Result<Directory> {
         let mut ptr = ptr::null_mut();
         (self.open_volume)(self, &mut ptr)
-            .into_with_val(|| unsafe { File(&mut *ptr).into_directory() })
+            .into_with_val(|| unsafe { Directory::new(FileHandle::new(ptr)) })
     }
 }

--- a/src/proto/media/fs.rs
+++ b/src/proto/media/fs.rs
@@ -31,6 +31,6 @@ impl SimpleFileSystem {
     pub fn open_volume(&mut self) -> Result<Directory> {
         let mut ptr = ptr::null_mut();
         (self.open_volume)(self, &mut ptr)
-            .into_with_val(|| unsafe { Directory::from_file(File::new(ptr)) })
+            .into_with_val(|| unsafe { File(&mut *ptr).into_directory() })
     }
 }


### PR DESCRIPTION
In `proto::media::file`, `File` and `Directory` share most of their functionality in common. In general, such common functionality is easier to deal with in rust though traits.

This change refactors the existing code into 3 structs and 1 trait
- `File` a trait containing all the functionality common to all file handles.
- `FileHandle` a basic file handle struct, allowing for conversion to the more specific structs. This is what `open()` returns.
- `RegularFile` a normal data file, allowing for direct read/write.
- `Directory` a directory file, allowing for enumerating its contents. This is returned by `open_volume()`.

There are three main questions I have about this change.
1. There isn't really any reason to have a lifetime bound on `File`, `Directory`, etc... Should I change the contained reference to `FileImpl` to be a pointer or `'static` reference? It would make the external API nicer.
2. There is a lot of repeated `self.file().0` throughout the code now. Should I add an internal helper method that just take a `File` and outputs a `&mut FileImpl`?
3. Naming of the structs/trait. I went with `File - FileHandle - Directory/RegualrFile`, but we could also use names like:
  a. `Handle`
  b. `Object`
  c. `FileTrait`
  d. `DataFile`
  e. `Base`