### PR TITLE
Properly handle allocation failure

### DIFF
--- a/uefi-exts/Cargo.toml
+++ b/uefi-exts/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 
 [dependencies]
 uefi = { path = ".." }
-uefi-services = { path = "../uefi-services" }

--- a/uefi-exts/src/lib.rs
+++ b/uefi-exts/src/lib.rs
@@ -4,7 +4,7 @@
 //! which add utility functions to various UEFI objects.
 
 #![no_std]
-#![feature(alloc, alloc_layout_extra)]
+#![feature(alloc, alloc_layout_extra, allocator_api)]
 
 extern crate alloc;
 
@@ -13,3 +13,24 @@ mod file;
 
 pub use self::boot::BootServicesExt;
 pub use self::file::FileExt;
+
+use alloc::{
+    alloc::{handle_alloc_error, Alloc, Global, Layout},
+    boxed::Box,
+};
+use core::slice;
+
+/// Creates a boxed byte buffer using the standard allocator
+/// # Panics
+/// Calls handle_alloc_error if the layout has a size of zero or allocation fails.
+pub fn allocate_buffer(layout: Layout) -> Box<[u8]> {
+    if layout.size() == 0 {
+        handle_alloc_error(layout);
+    }
+    unsafe {
+        match Global.alloc(layout) {
+            Ok(mem) => Box::from_raw(slice::from_raw_parts_mut(mem.as_ptr(), layout.size())),
+            Err(_) => handle_alloc_error(layout),
+        }
+    }
+}


### PR DESCRIPTION
The change in #89 did not properly handle allocation failures. On
failure, `alloc()` returns a null pointer, and this is not checked.

This change moves buffer allocation to the new Alloc API, and correctly
handles allocation failure and potential unsafety with zero-sized alloc
requests.

I also removed the dependency on `uefi-services` from `uefi-alloc`. The
dependency isn't needed, and now users can use `uefi-exts` with their
own allocators.