### PR TITLE
Use UEFI's locate_protocol to replace find_protocol

### DIFF
--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -1,4 +1,3 @@
-use core::cell::UnsafeCell;
 use uefi::proto::Protocol;
 use uefi::table::boot::{BootServices, SearchType};
 use uefi::{Handle, Result};

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -14,7 +14,6 @@ use core::mem;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
 use uefi::table::boot::MemoryDescriptor;
-use uefi_exts::BootServicesExt;
 
 mod boot;
 mod proto;
@@ -67,7 +66,7 @@ fn check_screenshot(bt: &BootServices, name: &str) {
     if cfg!(feature = "qemu") {
         // Access the serial port (in a QEMU environment, it should always be there)
         let serial = bt
-            .find_protocol::<Serial>()
+            .locate_protocol::<Serial>()
             .expect_success("Could not find serial port");
         let serial = unsafe { &mut *serial.get() };
 

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -1,11 +1,10 @@
 use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::BootServices;
-use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running graphics output protocol test");
-    if let Ok(gop) = bt.find_protocol::<GraphicsOutput>() {
+    if let Ok(gop) = bt.locate_protocol::<GraphicsOutput>() {
         let gop = gop.expect("Warnings encountered while opening GOP");
         let gop = unsafe { &mut *gop.get() };
 

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -2,11 +2,9 @@ use uefi::prelude::*;
 use uefi::proto::console::pointer::Pointer;
 use uefi::table::boot::BootServices;
 
-use uefi_exts::BootServicesExt;
-
 pub fn test(bt: &BootServices) {
     info!("Running pointer protocol test");
-    if let Ok(pointer) = bt.find_protocol::<Pointer>() {
+    if let Ok(pointer) = bt.locate_protocol::<Pointer>() {
         let pointer = pointer.expect("Warnings encountered while opening pointer protocol");
         let pointer = unsafe { &mut *pointer.get() };
 

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -1,11 +1,10 @@
 use uefi::prelude::*;
 use uefi::proto::console::serial::{ControlBits, Serial};
 use uefi::table::boot::BootServices;
-use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running serial protocol test");
-    if let Ok(serial) = bt.find_protocol::<Serial>() {
+    if let Ok(serial) = bt.locate_protocol::<Serial>() {
         let serial = serial.expect("Warnings encountered while opening serial protocol");
         let serial = unsafe { &mut *serial.get() };
 

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -1,11 +1,9 @@
 use uefi::proto::debug::DebugSupport;
 use uefi::table::boot::BootServices;
 
-use uefi_exts::BootServicesExt;
-
 pub fn test(bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
-    if let Ok(debug_support) = bt.find_protocol::<DebugSupport>() {
+    if let Ok(debug_support) = bt.locate_protocol::<DebugSupport>() {
         let debug_support =
             debug_support.expect("Warnings encountered while opening debug support protocol");
         let debug_support = unsafe { &mut *debug_support.get() };


### PR DESCRIPTION
Fixes #79 
This change lets users avoid allocating when they just want to find a single implementer of a protocol.