### PR TITLE
Remove #![feature()] for stable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! therefore all the network protocols will be unavailable.
 
 #![feature(optin_builtin_traits)]
-#![feature(try_from)]
 #![feature(try_trait)]
 #![no_std]
 // Enable some additional warnings and lints.

--- a/uefi-exts/src/lib.rs
+++ b/uefi-exts/src/lib.rs
@@ -4,7 +4,7 @@
 //! which add utility functions to various UEFI objects.
 
 #![no_std]
-#![feature(alloc, alloc_layout_extra, allocator_api)]
+#![feature(alloc_layout_extra, allocator_api)]
 
 extern crate alloc;
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(alloc)]
 #![feature(asm)]
 #![feature(const_slice_len)]
 #![feature(slice_patterns)]


### PR DESCRIPTION
`alloc` and `try_from` are now stable