### PR TITLE
Replace all usages of mem::uninitialized with mem::MaybeUninit

### DIFF
--- a/src/proto/console/text/input.rs
+++ b/src/proto/console/text/input.rs
@@ -1,6 +1,6 @@
 use crate::proto::Protocol;
 use crate::{unsafe_guid, Char16, Event, Result, Status};
-use core::mem::{self, MaybeUninit};
+use core::mem::MaybeUninit;
 
 /// Interface for text-based input devices.
 #[repr(C)]

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -7,8 +7,8 @@ use crate::{Event, Guid, Handle, Result, Status};
 use bitflags::bitflags;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
-use core::ptr;
 use core::mem::{self, MaybeUninit};
+use core::ptr;
 
 /// Contains pointers to all of the boot services.
 #[repr(C)]
@@ -284,8 +284,14 @@ impl BootServices {
             .unwrap_or((None, ptr::null_mut()));
 
         // Now we're ready to call UEFI
-        (self.create_event)(event_ty, notify_tpl, notify_func, notify_ctx, event.as_mut_ptr())
-            .into_with_val(|| event.assume_init())
+        (self.create_event)(
+            event_ty,
+            notify_tpl,
+            notify_func,
+            notify_ctx,
+            event.as_mut_ptr(),
+        )
+        .into_with_val(|| event.assume_init())
     }
 
     /// Stops execution until an event is signaled

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -30,14 +30,16 @@ impl RuntimeServices {
     /// Query the current time and date information
     pub fn get_time(&self) -> Result<Time> {
         let mut time = MaybeUninit::<Time>::uninit();
-        unsafe { (self.get_time)(time.as_mut_ptr(), ptr::null_mut()) }.into_with_val(|| unsafe { time.assume_init() })
+        unsafe { (self.get_time)(time.as_mut_ptr(), ptr::null_mut()) }
+            .into_with_val(|| unsafe { time.assume_init() })
     }
 
     /// Query the current time and date information and the RTC capabilities
     pub fn get_time_and_caps(&self) -> Result<(Time, TimeCapabilities)> {
         let mut time = MaybeUninit::<Time>::uninit();
         let mut caps = MaybeUninit::<TimeCapabilities>::uninit();
-        unsafe { (self.get_time)(time.as_mut_ptr(), caps.as_mut_ptr()) }.into_with_val(|| unsafe { (time.assume_init(), caps.assume_init()) })
+        unsafe { (self.get_time)(time.as_mut_ptr(), caps.as_mut_ptr()) }
+            .into_with_val(|| unsafe { (time.assume_init(), caps.assume_init()) })
     }
 
     /// Sets the current local time and date information


### PR DESCRIPTION
As said in the title, this PR simply replaces any uses of mem::uninitialized in the repo with mem::MaybeUninit. I've run the test-runner to make sure that everything checked there is still working, and encountered no errors. 