### PR TITLE
UEFI MP Services Protocol support

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -29,3 +29,4 @@ pub use uefi_macros::Protocol;
 pub mod console;
 pub mod debug;
 pub mod media;
+pub mod pi;

--- a/src/proto/pi/mod.rs
+++ b/src/proto/pi/mod.rs
@@ -1,0 +1,6 @@
+//! Platform Initialization protocols.
+//!
+//! Contains protocols defined in UEFI's
+//! Platform Initialization (PI) Specification.
+
+pub mod mp;

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -1,0 +1,199 @@
+//! Multi-processor management protocols.
+
+use crate::proto::Protocol;
+use crate::{unsafe_guid, Result, Status};
+use bitflags::bitflags;
+use core::convert::TryInto;
+use core::ffi::c_void;
+use core::ptr;
+use core::time::Duration;
+
+/// Callback to be called on the AP.
+pub type Procedure = extern "win64" fn(*mut c_void);
+
+bitflags! {
+    /// Flags indicating if the processor is BSP or AP,
+    /// if the processor is enabled or disabled, and if
+    /// the processor is healthy.
+    #[derive(Default)]
+    pub struct StatusFlag: u32 {
+        /// Processor is playing the role of BSP.
+        const PROCESSOR_AS_BSP_BIT = 0b00000001;
+        /// Processor is enabled.
+        const PROCESSOR_ENABLED_BIT = 0b00000010;
+        /// Processor is healthy.
+        const PROCESSOR_HEALTH_STATUS_BIT = 0b00000100;
+    }
+}
+
+/// Information about number of logical processors on the platform.
+#[derive(Default, Debug)]
+pub struct ProcessorCount {
+    /// Total number of processors (including BSP).
+    pub total: usize,
+    /// Number of processors (including BSP) that are currently enabled.
+    pub enabled: usize,
+}
+
+/// Information about processor on the platform.
+#[repr(C)]
+#[derive(Default, Debug)]
+pub struct ProcessorInformation {
+    /// Unique processor ID determined by system hardware.
+    pub processor_id: u64,
+    /// Flags indicating BSP, enabled and healthy status.
+    pub status_flag: StatusFlag,
+    /// Physical location of the processor.
+    pub location: CPUPhysicalLocation,
+}
+
+/// Information about physical location of the processor.
+#[repr(C)]
+#[derive(Default, Debug)]
+pub struct CPUPhysicalLocation {
+    /// Zero-based physical package number that identifies
+    /// the cartridge of the processor.
+    pub package: u32,
+    /// Zero-based physical core number within package of the processor.
+    pub core: u32,
+    /// Zero-based logical thread number within core of the processor.
+    pub thread: u32,
+}
+
+/// Protocol that provides services needed for multi-processor management.
+#[repr(C)]
+#[unsafe_guid("3fdda605-a76e-4f46-ad29-12f4531b3d08")]
+#[derive(Protocol)]
+pub struct MPServices {
+    get_number_of_processors: extern "win64" fn(
+        this: *const MPServices,
+        number_of_processors: *mut usize,
+        number_of_enabled_processors: *mut usize,
+    ) -> Status,
+    get_processor_info: extern "win64" fn(
+        this: *const MPServices,
+        processor_number: usize,
+        processor_info_buffer: *mut ProcessorInformation,
+    ) -> Status,
+    startup_all_aps: extern "win64" fn(
+        this: *const MPServices,
+        procedure: Procedure,
+        single_thread: bool,
+        wait_event: *mut c_void,
+        timeout_in_micro_seconds: usize,
+        procedure_argument: *mut c_void,
+        failed_cpu_list: *mut *mut usize,
+    ) -> Status,
+    startup_this_ap: extern "win64" fn(
+        this: *const MPServices,
+        procedure: Procedure,
+        processor_number: usize,
+        wait_event: *mut c_void,
+        timeout_in_micro_seconds: usize,
+        procedure_argument: *mut c_void,
+        finished: *mut bool,
+    ) -> Status,
+    switch_bsp: extern "win64" fn(
+        this: *const MPServices,
+        processor_number: usize,
+        enable_old_bsp: bool,
+    ) -> Status,
+    enable_disable_ap: extern "win64" fn(
+        this: *const MPServices,
+        processor_number: usize,
+        enable_ap: bool,
+        health_flag: *const u32,
+    ) -> Status,
+    who_am_i: extern "win64" fn(this: *const MPServices, processor_number: *mut usize) -> Status,
+}
+
+impl MPServices {
+    /// Retrieves the number of logical processors and the number of enabled logical processors in the system.
+    pub fn get_number_of_processors(&self) -> Result<ProcessorCount> {
+        let mut total: usize = 0;
+        let mut enabled: usize = 0;
+        (self.get_number_of_processors)(self, &mut total, &mut enabled)
+            .into_with_val(|| ProcessorCount { total, enabled })
+    }
+
+    /// Gets detailed information on the requested processor at the instant this call is made.
+    pub fn get_processor_info(&self, processor_number: usize) -> Result<ProcessorInformation> {
+        let mut pi: ProcessorInformation = Default::default();
+        (self.get_processor_info)(self, processor_number, &mut pi).into_with_val(|| pi)
+    }
+
+    /// Executes provided function on all APs in blocking mode.
+    pub fn startup_all_aps(
+        &self,
+        single_thread: bool,
+        procedure: Procedure,
+        procedure_argument: *mut c_void,
+        timeout: Option<Duration>,
+    ) -> Result {
+        let timeout_arg = match timeout {
+            Some(timeout) => timeout.as_micros().try_into().unwrap(),
+            None => 0,
+        };
+
+        (self.startup_all_aps)(
+            self,
+            procedure,
+            single_thread,
+            ptr::null_mut(),
+            timeout_arg,
+            procedure_argument,
+            ptr::null_mut(),
+        )
+        .into()
+    }
+
+    /// Executes provided function on a specific AP in blocking mode.
+    pub fn startup_this_ap(
+        &self,
+        processor_number: usize,
+        procedure: Procedure,
+        procedure_argument: *mut c_void,
+        timeout: Option<Duration>,
+    ) -> Result {
+        let timeout_arg = match timeout {
+            Some(timeout) => timeout.as_micros().try_into().unwrap(),
+            None => 0,
+        };
+
+        (self.startup_this_ap)(
+            self,
+            procedure,
+            processor_number,
+            ptr::null_mut(),
+            timeout_arg,
+            procedure_argument,
+            ptr::null_mut(),
+        )
+        .into()
+    }
+
+    /// Switches the requested AP to be the BSP from that point onward.
+    pub fn switch_bsp(&self, processor_number: usize, enable_old_bsp: bool) -> Result {
+        (self.switch_bsp)(self, processor_number, enable_old_bsp).into()
+    }
+
+    /// Enables or disables an AP from this point onward.
+    pub fn enable_disable_ap(
+        &self,
+        processor_number: usize,
+        enable_ap: bool,
+        health_flag: Option<u32>,
+    ) -> Result {
+        let health_flag_ptr = match health_flag {
+            Some(val) => &val,
+            None => ptr::null(),
+        };
+        (self.enable_disable_ap)(self, processor_number, enable_ap, health_flag_ptr).into()
+    }
+
+    /// Gets the handle number of the caller processor.
+    pub fn who_am_i(&self) -> Result<usize> {
+        let mut processor_number: usize = 0;
+        (self.who_am_i)(self, &mut processor_number).into_with_val(|| processor_number)
+    }
+}

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -1,4 +1,15 @@
 //! Multi-processor management protocols.
+//!
+//! On any system with more than one logical processor we can categorize them as:
+//!
+//! * BSP — bootstrap processor, executes modules that are necessary for booting the system
+//! * AP — application processor, any processor other than the bootstrap processor
+//!
+//! This module contains protocols that provide a generalized way of performing the following tasks on these logical processors:
+//!
+//! * retrieving information of multi-processor environment and MP-related status of specific processors
+//! * dispatching user-provided function to APs
+//! * maintaining MP-related processor status
 
 use crate::proto::Protocol;
 use crate::{unsafe_guid, Result, Status};

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -29,11 +29,11 @@ bitflags! {
     #[derive(Default)]
     struct StatusFlag: u32 {
         /// Processor is playing the role of BSP.
-        const PROCESSOR_AS_BSP_BIT = 0b00000001;
+        const PROCESSOR_AS_BSP_BIT = 1;
         /// Processor is enabled.
-        const PROCESSOR_ENABLED_BIT = 0b00000010;
+        const PROCESSOR_ENABLED_BIT = 1 << 1;
         /// Processor is healthy.
-        const PROCESSOR_HEALTH_STATUS_BIT = 0b00000100;
+        const PROCESSOR_HEALTH_STATUS_BIT = 1 << 2;
     }
 }
 

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -16,7 +16,7 @@ bitflags! {
     /// if the processor is enabled or disabled, and if
     /// the processor is healthy.
     #[derive(Default)]
-    pub struct StatusFlag: u32 {
+    struct StatusFlag: u32 {
         /// Processor is playing the role of BSP.
         const PROCESSOR_AS_BSP_BIT = 0b00000001;
         /// Processor is enabled.
@@ -42,9 +42,27 @@ pub struct ProcessorInformation {
     /// Unique processor ID determined by system hardware.
     pub processor_id: u64,
     /// Flags indicating BSP, enabled and healthy status.
-    pub status_flag: StatusFlag,
+    status_flag: StatusFlag,
     /// Physical location of the processor.
     pub location: CPUPhysicalLocation,
+}
+
+impl ProcessorInformation {
+    /// Returns `true` if the processor is playing the role of BSP.
+    pub fn is_bsp(&self) -> bool {
+        self.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT)
+    }
+
+    /// Returns `true` if the processor is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT)
+    }
+
+    /// Returns `true` if the processor is healthy.
+    pub fn is_healthy(&self) -> bool {
+        self.status_flag
+            .contains(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT)
+    }
 }
 
 /// Information about physical location of the processor.
@@ -179,8 +197,7 @@ impl MPServices {
 
     /// Enables or disables an AP from this point onward.
     ///
-    /// The `healthy` argument can be used to specify the new health status of the AP
-    /// and has the same meaning as the `PROCESSOR_HEALTH_STATUS_BIT` flag in [StatusFlag](StatusFlag).
+    /// The `healthy` argument can be used to specify the new health status of the AP.
     pub fn enable_disable_ap(
         &self,
         processor_number: usize,

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -178,14 +178,23 @@ impl MPServices {
     }
 
     /// Enables or disables an AP from this point onward.
+    ///
+    /// The `healthy` argument can be used to specify the new health status of the AP
+    /// and has the same meaning as the `PROCESSOR_HEALTH_STATUS_BIT` flag in [StatusFlag](StatusFlag).
     pub fn enable_disable_ap(
         &self,
         processor_number: usize,
         enable_ap: bool,
-        health_flag: Option<u32>,
+        healthy: Option<bool>,
     ) -> Result {
-        let health_flag_ptr = match health_flag {
-            Some(val) => &val,
+        let health_flag_raw: u32;
+        let health_flag_ptr = match healthy {
+            Some(healthy) => {
+                let mut sf = StatusFlag::empty();
+                sf.set(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT, healthy);
+                health_flag_raw = sf.bits();
+                &health_flag_raw
+            }
             None => ptr::null(),
         };
         (self.enable_disable_ap)(self, processor_number, enable_ap, health_flag_ptr).into()

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -122,6 +122,9 @@ def run_qemu():
         # Use a modern machine, with acceleration if possible.
         '-machine', 'q35,accel=kvm:tcg',
 
+        # Multi-processor services protocol test needs exactly 3 CPUs.
+        '-smp', '3',
+
         # Allocate some memory.
         '-m', '128M',
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -12,6 +12,7 @@ pub fn test(st: &SystemTable<Boot>) {
 
     console::test(st);
     debug::test(bt);
+    pi::test(bt);
 }
 
 fn find_protocol(bt: &BootServices) {
@@ -29,3 +30,4 @@ fn find_protocol(bt: &BootServices) {
 
 mod console;
 mod debug;
+mod pi;

--- a/uefi-test-runner/src/proto/pi/mod.rs
+++ b/uefi-test-runner/src/proto/pi/mod.rs
@@ -1,0 +1,9 @@
+use uefi::prelude::*;
+
+pub fn test(bt: &BootServices) {
+    info!("Testing Platform Initialization protocols");
+
+    mp::test(bt);
+}
+
+mod mp;

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -1,0 +1,138 @@
+use core::time::Duration;
+use core::ffi::c_void;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use uefi::proto::pi::mp::{MPServices, StatusFlag};
+use uefi::table::boot::BootServices;
+use uefi::Status;
+use core::mem;
+
+pub fn test(bt: &BootServices) {
+    info!("Running UEFI multi-processor services protocol test");
+    if let Ok(mp_support) = bt.locate_protocol::<MPServices>() {
+        let mp_support =
+            mp_support.expect("Warnings encountered while opening multi-processor services protocol");
+        let mp_support = unsafe { &mut *mp_support.get() };
+
+        test_get_number_of_processors(mp_support);
+        test_get_processor_info(mp_support);
+        test_startup_all_aps(mp_support, bt);
+        test_startup_this_ap(mp_support, bt);
+        test_enable_disable_ap(mp_support);
+        test_switch_bsp_and_who_am_i(mp_support);
+    } else {
+        warn!("Multi-processor services protocol is not supported");
+    }
+}
+
+fn test_get_number_of_processors(mps: &MPServices) {
+    let proc_count = mps.get_number_of_processors().unwrap().unwrap();
+
+    // There should be exactly 3 CPUs
+    assert_eq!(proc_count.total, 3);
+
+    // All CPUs should be enabled
+    assert_eq!(proc_count.total, proc_count.enabled);
+}
+
+fn test_get_processor_info(mps: &MPServices) {
+    // Disable second CPU for this test
+    mps.enable_disable_ap(1, false, None).unwrap().unwrap();
+
+    // Retrieve processor information from each CPU
+    let cpu0 = mps.get_processor_info(0).unwrap().unwrap();
+    let cpu1 = mps.get_processor_info(1).unwrap().unwrap();
+    let cpu2 = mps.get_processor_info(2).unwrap().unwrap();
+
+    // Check that processor_id fields are sane
+    assert_eq!(cpu0.processor_id, 0);
+    assert_eq!(cpu1.processor_id, 1);
+    assert_eq!(cpu2.processor_id, 2);
+
+    // Check that only CPU 0 is BSP
+    assert_eq!(cpu0.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT), true);
+    assert_eq!(cpu1.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT), false);
+    assert_eq!(cpu2.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT), false);
+
+    // Check that only the second CPU is disabled
+    assert_eq!(cpu0.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT), true);
+    assert_eq!(cpu1.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT), false);
+    assert_eq!(cpu2.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT), true);
+
+    // Enable second CPU back
+    mps.enable_disable_ap(1, true, None).unwrap().unwrap();
+}
+
+extern "win64" fn proc_increment_atomic(arg: *mut c_void) {
+    let counter: &AtomicUsize = unsafe { mem::transmute(arg) };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+extern "win64" fn proc_wait_100ms(arg: *mut c_void) {
+    let bt: &BootServices = unsafe { mem::transmute(arg) };
+    bt.stall(100_000);
+}
+
+fn test_startup_all_aps(mps: &MPServices, bt: &BootServices) {
+    // Ensure that APs start up
+    let counter = AtomicUsize::new(0);
+    let counter_ptr: *mut c_void = unsafe { mem::transmute(&counter) };
+    mps.startup_all_aps(false, proc_increment_atomic, counter_ptr, None).unwrap().unwrap();
+    assert_eq!(counter.load(Ordering::Relaxed), 2);
+
+    // Make sure that timeout works
+    let bt_ptr: *mut c_void = unsafe { mem::transmute(bt) };
+    let ret = mps.startup_all_aps(false, proc_wait_100ms, bt_ptr, Some(Duration::from_millis(50)));
+    assert_eq!(ret.map_err(|err| err.status()), Err(Status::TIMEOUT));
+}
+
+fn test_startup_this_ap(mps: &MPServices, bt: &BootServices) {
+    // Ensure that each AP starts up
+    let counter = AtomicUsize::new(0);
+    let counter_ptr: *mut c_void = unsafe { mem::transmute(&counter) };
+    mps.startup_this_ap(1, proc_increment_atomic, counter_ptr, None).unwrap().unwrap();
+    mps.startup_this_ap(2, proc_increment_atomic, counter_ptr, None).unwrap().unwrap();
+    assert_eq!(counter.load(Ordering::Relaxed), 2);
+
+    // Make sure that timeout works for each AP
+    let bt_ptr: *mut c_void = unsafe { mem::transmute(bt) };
+    for i in 1..3 {
+        let ret = mps.startup_this_ap(i, proc_wait_100ms, bt_ptr, Some(Duration::from_millis(50)));
+        assert_eq!(ret.map_err(|err| err.status()), Err(Status::TIMEOUT));
+    }
+}
+
+fn test_enable_disable_ap(mps: &MPServices) {
+    // Disable second CPU
+    mps.enable_disable_ap(1, false, None).unwrap().unwrap();
+
+    // Ensure that one CPUs is disabled
+    let proc_count = mps.get_number_of_processors().unwrap().unwrap();
+    assert_eq!(proc_count.total - proc_count.enabled, 1);
+
+    // Enable second CPU back
+    mps.enable_disable_ap(1, true, None).unwrap().unwrap();
+
+    // Ensure that all CPUs are enabled
+    let proc_count = mps.get_number_of_processors().unwrap().unwrap();
+    assert_eq!(proc_count.total, proc_count.enabled);
+}
+
+fn test_switch_bsp_and_who_am_i(mps: &MPServices) {
+    // Normally BSP starts on on CPU 0
+    let proc_number = mps.who_am_i().unwrap().unwrap();
+    assert_eq!(proc_number, 0);
+
+    // Do a BSP switch
+    mps.switch_bsp(1, true).unwrap().unwrap();
+
+    // We now should be on CPU 1
+    let proc_number = mps.who_am_i().unwrap().unwrap();
+    assert_eq!(proc_number, 1);
+
+    // Switch back
+    mps.switch_bsp(0, true).unwrap().unwrap();
+
+    // We now should be on CPU 0 again
+    let proc_number = mps.who_am_i().unwrap().unwrap();
+    assert_eq!(proc_number, 0);
+}

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -115,6 +115,16 @@ fn test_enable_disable_ap(mps: &MPServices) {
     // Ensure that all CPUs are enabled
     let proc_count = mps.get_number_of_processors().unwrap().unwrap();
     assert_eq!(proc_count.total, proc_count.enabled);
+
+    // Mark second CPU as unhealthy and check it's status
+    mps.enable_disable_ap(1, true, Some(false)).unwrap().unwrap();
+    let pi = mps.get_processor_info(1).unwrap().unwrap();
+    assert_eq!(pi.status_flag.contains(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT), false);
+
+    // Mark second CPU as healthy again and check it's status
+    mps.enable_disable_ap(1, true, Some(true)).unwrap().unwrap();
+    let pi = mps.get_processor_info(1).unwrap().unwrap();
+    assert_eq!(pi.status_flag.contains(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT), true);
 }
 
 fn test_switch_bsp_and_who_am_i(mps: &MPServices) {


### PR DESCRIPTION
This protocol allows one to bootstrap their OS/hypervisor/whatever into MP mode using UEFI facilities instead of doing it manually.

Specification link (PDF p. 453, document p. 171): https://uefi.org/sites/default/files/resources/PI_Spec_1_6_A_final_Feb4.pdf#page=453

StartupAllAPs and StartupThisAP FFI functions currently wrapped in a blocking manner only.