### PR TITLE
Temporary use nightly-2019-10-04 to install clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,14 @@ install:
   - source "$HOME/.cargo/env"
   - rustc -V
   - cargo -V
+  # cannot install clippy after nightly-2019-10-05
+  # https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
+  - rustup toolchain install nightly-2019-10-04
+  - rustup default nightly-2019-10-04
   # Required by cargo-xbuild
   - rustup component add rust-src
   # Required by cargo-xclippy
-  - rustup component add clippy --toolchain=nightly || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+  - rustup component add clippy --toolchain=nightly-2019-10-04 || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
   # For checking the code's formatting
   - rustup component add rustfmt
   # Try installing cargo-xbuild if it's not already installed


### PR DESCRIPTION
Recent tests are failing because after nightly-2019-10-05 toolchain couldn't install clippy.
This commit fix it.

References:
- Failed test
 - https://travis-ci.org/rust-osdev/uefi-rs/builds/589883701
- status of rustup components
 - https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html