### PR TITLE
Support try operator (`?`)  on Completion.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::data_types::{unsafe_guid, Identify};
 pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
 
 mod result;
-pub use self::result::{Completion, Result, ResultExt, Status};
+pub use self::result::{Completion, Error, Result, ResultExt, Status};
 
 pub mod table;
 

--- a/src/result/completion.rs
+++ b/src/result/completion.rs
@@ -94,6 +94,30 @@ impl<T> From<T> for Completion<T> {
     }
 }
 
+/// Completions can be 'tried' using the '?' operator. Error status codes get 
+/// translated to `Result::Err(E)`, and success (possibly with warning) get 
+/// translated to `Result::Ok((Status, T))`.
+impl<T> core::ops::Try for Completion<T> {
+    type Ok = (Status, T);
+    type Error = Status;
+
+    fn into_result(self) -> Result<Self::Ok, Self::Error> {
+        if self.status.is_error() {
+            Err(self.status)
+        } else {
+            Ok((self.status, self.result))
+        }
+    }
+
+    fn from_error(_error: Status) -> Self {
+        unimplemented!()
+    }
+
+    fn from_ok(_result: (Status, T)) -> Self {
+        unimplemented!()
+    }
+}
+
 // These are separate functions to reduce the code size of the methods
 
 #[inline(never)]

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -10,14 +10,18 @@ pub struct Error<Data: Debug = ()> {
 }
 
 impl<Data: Debug> Error<Data> {
+    
+    /// Construct an error from an inner status and payload data
     pub fn new(status: Status, data: Data) -> Self {
         Self { status, data }
     }
 
+    /// Return the inner status for this error
     pub fn status(&self) -> Status {
         self.status
     }
 
+    /// Return the data for this error
     pub fn data(&self) -> &Data {
         &self.data
     }


### PR DESCRIPTION
This is an ergonomic change to add an implementation of `core::ops::Try` for `uefi::result::Completion`. This means that you can use the `?` operator on completions to handle errors.

It translates error completions into `Err(status)`. Non-errors, possibly including warnings, are translated into `Ok((status, result))`.

This simplifies code that deals with completions when you want to handle errors rather than merely using `.expect_success` to panic on errors. You can now write code that looks like this:

```
let boot_services = system_table.boot_services();
let (status, fs) = boot_services.locate_protocol::<SimpleFileSystem>()??; // one for the Result, one for the Completion.
if status.is_warning() { 
  log::warn!("UEFI warning locating protocol: {:?}", status); 
}
```