### PR TITLE
Fix Completion documentation and add assertion that status isn't an error

### DIFF
--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -25,7 +25,7 @@ pub use self::error::Error;
 mod status;
 pub use self::status::Status;
 
-/// Return type of most UEFI functions. Both success and error payloads are optional
+/// Return type of most UEFI functions. Both success and error payloads are optional.
 pub type Result<Output = (), ErrData = ()> =
     core::result::Result<Completion<Output>, Error<ErrData>>;
 


### PR DESCRIPTION
Unfortunately, I just don't manage to bring back a working uefi-rs dev environment on my machine, so I'll let someone who can actually test this judge. But "by eye" this looks like it couldn't possibly cause any regression in code that uses Completion correctly.