### PR TITLE
Add support for the LoadedImage protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ logger = []
 [dependencies]
 bitflags = "1.1.0"
 log = { version = "0.4.8", default-features = false }
-ucs2 = "0.2.0"
+ucs2 = "0.3.0"
 uefi-macros = "0.3.0"
 
 [workspace]

--- a/src/proto/loaded_image/mod.rs
+++ b/src/proto/loaded_image/mod.rs
@@ -1,0 +1,58 @@
+//! Loaded image protocol.
+
+use crate::{
+    data_types::{CStr16, Char16},
+    proto::Protocol,
+    table::boot::MemoryType,
+    unsafe_guid,
+    Handle,
+    Status,
+};
+use core::ffi::c_void;
+
+/// The Loaded Image protocol. This can be opened on any image handle using the `HandleProtocol` boot service.
+#[repr(C)]
+#[unsafe_guid("5b1b31a1-9562-11d2-8e3f-00a0c969723b")]
+#[derive(Protocol)]
+pub struct LoadedImage {
+    revision: u32,
+    parent_handle: Handle,
+    system_table: *const c_void,
+
+    // Source location of the image
+    device_handle: Handle,
+    _file_path: *const c_void, // TODO: not supported yet
+    _reserved: *const c_void,
+
+    // Image load options
+    load_options_size: u32,
+    load_options: *const Char16,
+
+    // Location where image was loaded
+    image_base: usize,
+    image_size: u64,
+    image_code_type: MemoryType,
+    image_data_type: MemoryType,
+    /// This is a callback that a loaded image can use to do cleanup. It is called by the
+    /// UnloadImage boot service.
+    unload: extern "efiapi" fn(image_handle: Handle) -> Status,
+}
+
+/// Errors that can be raised during parsing of the load options.
+#[derive(Debug)]
+pub enum LoadOptionsError {
+    /// The passed buffer is not large enough to contain the load options.
+    BufferTooSmall,
+    /// The load options are not valid UTF-8.
+    NotValidUtf8,
+}
+
+impl LoadedImage {
+    /// Get the load options of the given image. If the image was executed from the EFI shell, or from a boot
+    /// option, this is the command line that was used to execute it as a string.
+    pub fn load_options<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a str, LoadOptionsError> {
+        let ucs2_slice = unsafe { CStr16::from_ptr(self.load_options).to_u16_slice() };
+        let length = ucs2::decode(ucs2_slice, buffer).map_err(|_| LoadOptionsError::BufferTooSmall)?;
+        core::str::from_utf8(&buffer[0..length]).map_err(|_| LoadOptionsError::NotValidUtf8)
+    }
+}

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -28,5 +28,6 @@ pub use uefi_macros::Protocol;
 
 pub mod console;
 pub mod debug;
+pub mod loaded_image;
 pub mod media;
 pub mod pi;


### PR DESCRIPTION
Mainly, this allows applications to access command line arguments passed from the EFI shell or a boot option.

Note: this relies on the changes in GabrielMajeri/ucs2-rs#7. When that is merged and a new version published, I can update this to use the new version of `ucs2`.