### PR TITLE
Implement Debug&Display traits for CStr16

### DIFF
--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -174,7 +174,7 @@ impl<'a> Iterator for CStr16Iter<'a> {
     type Item = &'a Char16;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos >= self.inner.0.len() {
+        if self.pos >= self.inner.0.len() - 1 {
             None
         } else {
             self.pos += 1;
@@ -185,22 +185,13 @@ impl<'a> Iterator for CStr16Iter<'a> {
 
 impl fmt::Debug for CStr16 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for c in self.iter() {
-            if *c == NUL_16 {
-                break;
-            }
-            <Char16 as fmt::Debug>::fmt(&c, f)?;
-        }
-        Ok(())
+        write!(f, "CStr16({:?})", &self.0)
     }
 }
 
 impl fmt::Display for CStr16 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.iter() {
-            if *c == NUL_16 {
-                break;
-            }
             <Char16 as fmt::Display>::fmt(&c, f)?;
         }
         Ok(())

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -1,5 +1,7 @@
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
 use core::convert::TryInto;
+use core::fmt;
+use core::iter::Iterator;
 use core::result::Result;
 use core::slice;
 
@@ -150,5 +152,57 @@ impl CStr16 {
     /// Converts this C string to a u16 slice containing the trailing 0 char
     pub fn to_u16_slice_with_nul(&self) -> &[u16] {
         unsafe { &*(&self.0 as *const [Char16] as *const [u16]) }
+    }
+
+    /// Returns an iterator over this C string
+    pub fn iter<'a>(&'a self) -> CStr16Iter<'a> {
+        CStr16Iter {
+            inner: self,
+            pos: 0,
+        }
+    }
+}
+
+/// An iterator over `CStr16`.
+#[derive(Debug)]
+pub struct CStr16Iter<'a> {
+    inner: &'a CStr16,
+    pos: usize,
+}
+
+impl<'a> Iterator for CStr16Iter<'a> {
+    type Item = &'a Char16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.inner.0.len() {
+            None
+        } else {
+            self.pos += 1;
+            self.inner.0.get(self.pos - 1)
+        }
+    }
+}
+
+impl fmt::Debug for CStr16 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for c in self.iter() {
+            if *c == NUL_16 {
+                break;
+            }
+            <Char16 as fmt::Debug>::fmt(&c, f)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for CStr16 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for c in self.iter() {
+            if *c == NUL_16 {
+                break;
+            }
+            <Char16 as fmt::Display>::fmt(&c, f)?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
This is my attempt to implement `Debug` and `Display` traits for the `CStr16` type using the traits that have already been implemented for `Char16`.

Strangely if I try to format `\u{0}`, `Display` panics while `Debug` does not, but I don't see any essential differences between the implementations of `Char16` for `Debug` and `Display`. It seems that the following code is not working for `impl Display for Char16`:

https://github.com/rust-osdev/uefi-rs/blob/ba8cb63c395f77acd0fa64a29395af2b8b334d20/src/data_types/chars.rs#L121-L123

This is the panic output:

```
ERROR: Panic in /Users/tsuki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/result.rs at (1189, 5):
ERROR: called `Result::unwrap()` on an `Err` value: Error
```

So for now, the formatting process just ends before the null terminator. 

Closes #98 

Signed-off-by: imtsuki <me@qjx.app>