### PR TITLE
Add `set_virtual_address_map` interface in runtime services

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -633,6 +633,9 @@ pub enum MemoryType: u32 => {
     PERSISTENT_MEMORY       = 14,
 }}
 
+/// Memory descriptor version number
+pub const MEMORY_DESCRIPTOR_VERSION: u32 = 1;
+
 /// A structure describing a region of memory.
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
According to the UEFI spec, `SetVirtualAddressMap` is used by the OS loader to map the runtime service memory region to virtual addresses after `ExitBootServices` is called. A bootloader will normally map the kernel address space to the higher-half and then jump to the kernel, and we can't leave the `RUNTIME_SERVICES_CODE` and `RUNTIME_SERVICES_DATA` alone. However, this process includes some absolute address relocation done by the runtime services themselves, which is an event triggered by the `SetVirtualAddressMap` call. Thus, `SetVirtualAddressMap` may not be "useless" and this is a patch to add an interface for it.

Closes #107 

Signed-off-by: imtsuki <me@qjx.app>