### PR TITLE
Re-export `NamedFileProtocolInfo`

### DIFF
--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -19,7 +19,10 @@ use core::ffi::c_void;
 use core::mem;
 use core::ptr;
 
-pub use self::info::{FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi};
+pub use self::info::{
+    FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi,
+    NamedFileProtocolInfo,
+};
 pub use self::{dir::Directory, regular::RegularFile};
 
 /// Common interface to `FileHandle`, `RegularFile`, and `Directory`.


### PR DESCRIPTION
If `NamedFileProtocolInfo` isn't accessible, rustdoc fails to document
impl blocks of the concrete instantiations such as `FileInfo`. (Related upstream bug: https://github.com/rust-lang/rust/issues/32077)

__Before__:
![2020-03-12_17-32-03_grim](https://user-images.githubusercontent.com/2302947/76544670-b8fade80-6488-11ea-86b6-ad131353f7fe.png)

__After__:
![2020-03-12_17-31-35_grim](https://user-images.githubusercontent.com/2302947/76544669-b8624800-6488-11ea-8fa0-e689568a0773.png)

