### PR TITLE
Fix compilation on latest nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
+#![feature(negative_impls)]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(missing_docs, unused)]


### PR DESCRIPTION
Add the negative_impls feature.

(In case this gets merged do you mind releasing a new version for uefi and uefi-services?)