### PR TITLE
map_size is already the required size in bytes for the buffer.

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -193,7 +193,7 @@ impl BootServices {
         };
         assert_eq!(status, Status::BUFFER_TOO_SMALL);
 
-        map_size * entry_size
+        map_size
     }
 
     /// Retrieves the current memory map.


### PR DESCRIPTION
(sorry, messed up the other pr)
From the spec:

> A pointer to the size, in bytes, of the MemoryMap buffer. On input, this is the size of the buffer allocated by the caller. On output, it is the size of the buffer returned by the firmware if the buffer was large enough, or the size of the buffer needed to contain the map if the buffer was too small. 

Also, the `pub fn memory_map<'buf>()` fn already takes this into account when creating the iterator, and sets the length as `map_size / entry_size`.