### PR TITLE
Add cargo feature for ignoring logger errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = []
 alloc = []
 exts = []
 logger = []
+# Ignore text output errors in logger as a workaround for firmware issues that
+# were observed on the VirtualBox UEFI implementation (see uefi-rs#121)
+ignore-logger-errors = []
 
 [dependencies]
 bitflags = "1.2.1"


### PR DESCRIPTION
As discussed in the context of #123 , this PR enables configuring whether logger errors should be ignored or not at compile time.

Fixes #123 .