### PR TITLE
Bump x86_64 dependency version to fix build on latest nightlies

### DIFF
--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -15,7 +15,7 @@ is-it-maintained-issue-resolution = { repository = "rust-osdev/uefi-rs" }
 is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 
 [dependencies]
-x86_64 = "0.8.3"
+x86_64 = "0.11.0"
 
 uefi = { version = "0.4.5", features = ["alloc", "logger"] }
 log = { version = "0.4.8", default-features = false }


### PR DESCRIPTION
rust-lang/rust#69171 was merged a couple of days ago, which finally dropped support of the old deprecated `asm!` syntax. `uefi-services` depends on an old version of `x86_64`, so that it won't be built successfully on latest nightlies.

Signed-off-by: imtsuki <me@qjx.app>