### PR TITLE
Fix `BltPixel::from` conversion

### DIFF
--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -451,8 +451,8 @@ impl From<u32> for BltPixel {
     fn from(color: u32) -> Self {
         Self {
             blue: (color & 0x00_00_FF) as u8,
-            green: (color & 0x00_FF_00 >> 8) as u8,
-            red: (color & 0xFF_00_00 >> 16) as u8,
+            green: ((color & 0x00_FF_00) >> 8) as u8,
+            red: ((color & 0xFF_00_00) >> 16) as u8,
             _reserved: 0,
         }
     }


### PR DESCRIPTION
Small fix in the conversion from a `u32` to a `BltPixel`.

Because the precedence of the shift operator is stronger than the bitwise AND, the masks are shifted before applying, resulting in all channels being set to the blue channel.

Without the additional parenthesis, `green: (color & 0x00_FF_00 >> 8)` expands to `green: (color & 0x00_00_FF)` first.