### PR TITLE
Add basic AArch 64 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ exclude = [
     "uefi-macros/**",
     "uefi-services/**",
     "uefi-test-runner/**",
+    "uefi-hello-world-aarch64/**"
 ]
 description = "Safe and easy-to-use wrapper for building UEFI apps"
 repository = "https://github.com/rust-osdev/uefi-rs"
@@ -41,6 +42,7 @@ members = [
     "uefi-macros",
     "uefi-services",
     "uefi-test-runner",
+    "uefi-hello-world-aarch64"
 ]
 
 [profile.dev]

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -12,13 +12,10 @@ use super::{cfg, Header, Revision};
 pub trait SystemTableView {}
 
 /// Marker struct associated with the boot view of the UEFI System Table
-#[derive(Clone)]
 pub struct Boot;
-
 impl SystemTableView for Boot {}
 
 /// Marker struct associated with the run-time view of the UEFI System Table
-#[derive(Clone)]
 pub struct Runtime;
 impl SystemTableView for Runtime {}
 
@@ -44,7 +41,6 @@ impl SystemTableView for Runtime {}
 /// UEFI boot services in the eye of the Rust borrow checker) and a runtime view
 /// will be provided to replace it.
 #[repr(transparent)]
-#[derive(Clone)]
 pub struct SystemTable<View: SystemTableView> {
     table: &'static SystemTableImpl,
     _marker: PhantomData<View>,

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -1,19 +1,24 @@
+use core::marker::PhantomData;
+use core::slice;
+
+use crate::proto::console::text;
+use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};
+
 use super::boot::{BootServices, MemoryMapIter};
 use super::runtime::RuntimeServices;
 use super::{cfg, Header, Revision};
-use crate::proto::console::text;
-use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};
-use core::marker::PhantomData;
-use core::slice;
 
 /// Marker trait used to provide different views of the UEFI System Table
 pub trait SystemTableView {}
 
 /// Marker struct associated with the boot view of the UEFI System Table
+#[derive(Clone)]
 pub struct Boot;
+
 impl SystemTableView for Boot {}
 
 /// Marker struct associated with the run-time view of the UEFI System Table
+#[derive(Clone)]
 pub struct Runtime;
 impl SystemTableView for Runtime {}
 
@@ -39,6 +44,7 @@ impl SystemTableView for Runtime {}
 /// UEFI boot services in the eye of the Rust borrow checker) and a runtime view
 /// will be provided to replace it.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct SystemTable<View: SystemTableView> {
     table: &'static SystemTableImpl,
     _marker: PhantomData<View>,

--- a/uefi-hello-world-aarch64/.cargo/aarch64-unknown-uefi.json
+++ b/uefi-hello-world-aarch64/.cargo/aarch64-unknown-uefi.json
@@ -1,0 +1,25 @@
+{
+  "arch": "aarch64",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "default-hidden-visibility": true,
+  "emit-debug-gdb-scripts": false,
+  "exe-suffix": ".efi",
+  "executables": true,
+  "is-like-windows": true,
+  "linker": "rust-lld",
+  "linker-flavor": "lld-link",
+  "llvm-target": "aarch64-pc-windows-msvc",
+  "os": "uefi",
+  "panic-strategy": "abort",
+  "pre-link-args": {
+    "lld-link": [
+      "/subsystem:EFI_Application",
+      "/entry:efi_main",
+      "/machine:arm64"
+    ]
+  },
+  "stack_probes": true,
+  "target-c-int-width": "32",
+  "target-endian": "little",
+  "target-pointer-width": "64"
+}

--- a/uefi-hello-world-aarch64/.gitignore
+++ b/uefi-hello-world-aarch64/.gitignore
@@ -1,0 +1,6 @@
+# Python cache files.
+/__pycache__
+
+# OVMF images, which provide a UEFI firmware for QEMU.
+/OVMF_CODE.fd
+/OVMF_VARS.fd

--- a/uefi-hello-world-aarch64/.gitignore
+++ b/uefi-hello-world-aarch64/.gitignore
@@ -2,5 +2,5 @@
 /__pycache__
 
 # OVMF images, which provide a UEFI firmware for QEMU.
-/OVMF_CODE.fd
-/OVMF_VARS.fd
+/QEMU_EFI-pflash.raw
+/vars-template-pflash.raw

--- a/uefi-hello-world-aarch64/Cargo.toml
+++ b/uefi-hello-world-aarch64/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 uefi = { path = "..", features = ['exts'] }
 uefi-services = { path = "../uefi-services" }
 log = { version = "0.4.8", default-features = false }
-no-std-compat = "0.4.0"
 
 [features]
 qemu = ["uefi-services/qemu"]
-default = ["std"]
-std = ["no-std-compat/alloc", "no-std-compat/compat_hash", "no-std-compat/compat_sync", "no-std-compat/compat_macros"]

--- a/uefi-hello-world-aarch64/Cargo.toml
+++ b/uefi-hello-world-aarch64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uefi-hello-world-aarch64"
-version = "0.2.0"
-authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>"]
+version = "0.0.1"
+authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>", "Steve Fan <29133953+stevefan1999-personal@users.noreply.github.com>"]
 publish = false
 edition = "2018"
 

--- a/uefi-hello-world-aarch64/Cargo.toml
+++ b/uefi-hello-world-aarch64/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uefi-hello-world-aarch64"
+version = "0.2.0"
+authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>"]
+publish = false
+edition = "2018"
+
+[dependencies]
+uefi = { path = "..", features = ['exts'] }
+uefi-services = { path = "../uefi-services" }
+log = { version = "0.4.8", default-features = false }
+no-std-compat = "0.4.0"
+
+[features]
+qemu = ["uefi-services/qemu"]
+default = ["std"]
+std = ["no-std-compat/alloc", "no-std-compat/compat_hash", "no-std-compat/compat_sync", "no-std-compat/compat_macros"]

--- a/uefi-hello-world-aarch64/README.md
+++ b/uefi-hello-world-aarch64/README.md
@@ -9,7 +9,7 @@ Besides all the [core library requirements](https://github.com/rust-osdev/uefi-r
 - [QEMU](https://www.qemu.org/): the most recent version of QEMU is recommended.
 - [Python 3](https://www.python.org): at least version 3.6 is required.
 - [OVMF](https://github.com/tianocore/tianocore.github.io/wiki/OVMF):
-  You need to extract `OVMF_CODE.fd` and `OVMF_VARS.fd` to the same directory as the `build.py` file.
+  You need to extract `QEMU_EFI-pflash.raw` and `vars-template-pflash.raw` to the same directory as the `build.py` file.
   Alternatively, install OVMF using your distro's package manager and change the paths in the script file.
   **Note**: if your distro's OVMF version is too old / does not provide these files,
   you can download [Gerd Hoffmann's builds](https://www.kraxel.org/repos/) and extract them in the local directory.

--- a/uefi-hello-world-aarch64/README.md
+++ b/uefi-hello-world-aarch64/README.md
@@ -1,0 +1,36 @@
+# Running the tests
+
+This file documents the process of building and running the test suite.
+
+## Prerequisites
+
+Besides all the [core library requirements](https://github.com/rust-osdev/uefi-rs/blob/master/BUILDING.md#Prerequisites) for building a UEFI app, the tests have additional requirements:
+
+- [QEMU](https://www.qemu.org/): the most recent version of QEMU is recommended.
+- [Python 3](https://www.python.org): at least version 3.6 is required.
+- [OVMF](https://github.com/tianocore/tianocore.github.io/wiki/OVMF):
+  You need to extract `OVMF_CODE.fd` and `OVMF_VARS.fd` to the same directory as the `build.py` file.
+  Alternatively, install OVMF using your distro's package manager and change the paths in the script file.
+  **Note**: if your distro's OVMF version is too old / does not provide these files,
+  you can download [Gerd Hoffmann's builds](https://www.kraxel.org/repos/) and extract them in the local directory.
+
+## Steps
+
+It's as simple as running the `build.py` script with the ``run` argument:
+
+```sh
+./build.py run
+```
+
+Available commands:
+
+- `build`: only build
+- `run`: (re)build and run
+- `doc`: generate documentation
+- `clippy`: run Clippy
+
+Available options:
+
+- `--verbose`: enables verbose mode, prints commands before running them
+- `--headless`: enables headless mode, which runs QEMU without a GUI
+- `--release`: builds the code with optimizations enabled

--- a/uefi-hello-world-aarch64/build.py
+++ b/uefi-hello-world-aarch64/build.py
@@ -44,7 +44,7 @@ SETTINGS = {
     # Path to directory containing `OVMF_{CODE/VARS}.fd`.
     # `find_ovmf` function will try to find one if this isn't specified.
     'ovmf': {
-        'dir': WORKSPACE_DIR / 'arch' / ARCH / 'ovmf',  # e.g. ${WORKSPACE}/arch/aarch64/ovmf
+        'dir': CURRENT_DIR,  # e.g. ${WORKSPACE}/arch/aarch64/ovmf
         # these two firmware blobs are extracted from kraxel's repo, aka https://www.kraxel.org/repos/jenkins/edk2/
         'firmware': {
             'code': 'QEMU_EFI-pflash.raw',

--- a/uefi-hello-world-aarch64/build.py
+++ b/uefi-hello-world-aarch64/build.py
@@ -245,17 +245,8 @@ def run_qemu():
             # the UEFI stdout and stdin to that port too.
             '-serial', 'stdio',
 
-            # Map the QEMU exit signal to port f4
-            '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
-
             # Map the QEMU monitor to a pair of named pipes
             '-qmp', f'pipe:{qemu_monitor_pipe}',
-
-            # OVMF debug builds can output information to a serial `debugcon`.
-            # Only enable when debugging UEFI boot:
-            '-debugcon', 'file:debug.log',
-
-            '-global', 'isa-debugcon.iobase=0x402',
         ]
 
     # When running in headless mode we don't have video, but we can still have

--- a/uefi-hello-world-aarch64/build.py
+++ b/uefi-hello-world-aarch64/build.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+
+"""
+Script used to build, run, and showcase the code on all supported platforms.
+This is initially copied from uefi-test-runner, and it should be replaced in the final PR
+"""
+
+import argparse
+import filecmp
+import json
+import os
+import re
+import shutil
+import subprocess as sp
+import sys
+from pathlib import Path
+
+## Configurable settings
+# Path to workspace directory (which contains the top-level `Cargo.toml`)
+CURRENT_DIR = Path(__file__).resolve().parents[0]
+WORKSPACE_DIR = CURRENT_DIR.parents[0]
+
+ARCH = "aarch64"
+
+# Try changing these with command line flags, where possible
+SETTINGS = {
+    # Print commands before running them.
+    'verbose': False,
+    # Run QEMU without showing GUI
+    'headless': False,
+    # Target to build for.
+    'target': {
+        'triple': f'{ARCH}-unknown-uefi',
+        # If this is a built-in rustc target, set this to true
+        # this will render profile_path useless
+        # you can see all the built-in rustc targets by `rustc --print target-list`
+        'builtin': False,
+        'profile_path': CURRENT_DIR / '.cargo' / f'{ARCH}-unknown-uefi.json'
+    },
+    # Default configuration to build.
+    'config': 'debug',
+    # QEMU executable to use
+    'qemu_binary': f'qemu-system-{ARCH}',
+    # Path to directory containing `OVMF_{CODE/VARS}.fd`.
+    # `find_ovmf` function will try to find one if this isn't specified.
+    'ovmf': {
+        'dir': WORKSPACE_DIR / 'arch' / ARCH / 'ovmf',  # e.g. ${WORKSPACE}/arch/aarch64/ovmf
+        # these two firmware blobs are extracted from kraxel's repo, aka https://www.kraxel.org/repos/jenkins/edk2/
+        'firmware': {
+            'code': 'QEMU_EFI-pflash.raw',
+            'vars': 'vars-template-pflash.raw'
+        }
+    },
+    'efi_prefix': 'aa64'
+}
+
+# Path to target directory. If None, it will be initialized with information
+# from cargo metadata at the first time target_dir function is invoked.
+TARGET_DIR = None
+
+
+def target_dir():
+    'Returns the target directory'
+    global TARGET_DIR
+    if TARGET_DIR is None:
+        cmd = ['cargo', 'metadata', '--format-version=1']
+        result = sp.run(cmd, stdout=sp.PIPE)
+        result.check_returncode()
+        TARGET_DIR = Path(json.loads(result.stdout)['target_directory'])
+    return TARGET_DIR
+
+
+def build_dir():
+    'Returns the directory where Cargo places the build artifacts'
+    return target_dir() / SETTINGS['target']['triple'] / SETTINGS['config']
+
+
+def esp_dir():
+    'Returns the directory where we will build the emulated UEFI system partition'
+    return build_dir() / 'esp'
+
+
+def run_xtool(tool, *flags):
+    'Runs cargo-x<tool> with certain arguments.'
+
+    cmd = [
+        'cargo', '+nightly', tool,
+        '--target', str(SETTINGS['target']['triple' if SETTINGS['target']['builtin'] else 'profile_path']),
+        *flags
+    ]
+
+    if SETTINGS['verbose']:
+        print(' '.join(cmd))
+
+    sp.run(cmd).check_returncode()
+
+
+def run_xbuild(*flags):
+    'Runs cargo-xbuild with certain arguments.'
+    run_xtool('xbuild', *flags)
+
+
+def run_xclippy(*flags):
+    'Runs cargo-xclippy with certain arguments.'
+    run_xtool('xclippy', *flags)
+
+
+def build(*test_flags):
+    'Builds the tests and examples.'
+
+    xbuild_args = [
+        '--package', 'uefi-hello-world-aarch64',
+        *test_flags,
+    ]
+
+    if SETTINGS['config'] == 'release':
+        xbuild_args.append('--release')
+
+    run_xbuild(*xbuild_args)
+
+    # Copy the built test runner file to the right directory for running tests.
+    built_file = build_dir() / 'uefi-hello-world-aarch64.efi'
+
+    boot_dir = esp_dir() / 'EFI' / 'Boot'
+    boot_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = boot_dir / f'Boot{SETTINGS["efi_prefix"]}.efi'
+
+    shutil.copy2(built_file, output_file)
+
+
+def clippy():
+    'Runs Clippy on all projects'
+
+    run_xclippy('--all')
+
+
+def doc():
+    'Generates documentation for the library crates.'
+    sp.run([
+        'cargo', 'doc', '--no-deps',
+        '--package', 'uefi',
+        '--package', 'uefi-exts',
+        '--package', 'uefi-alloc',
+        '--package', 'uefi-logger',
+        '--package', 'uefi-services',
+    ])
+
+
+def ovmf_files(ovmf_dir):
+    'Returns the tuple of paths to OVMF_CODE.fd and OVMF_VARS.fd given the directory'
+    return ovmf_dir / SETTINGS['ovmf']['firmware']['code'], ovmf_dir / SETTINGS['ovmf']['firmware']['vars']
+
+
+def check_ovmf_dir(ovmf_dir):
+    'Check whether the given directory contains necessary OVMF files'
+    ovmf_code, ovmf_vars = ovmf_files(ovmf_dir)
+    return ovmf_code.is_file() and ovmf_vars.is_file()
+
+
+def find_ovmf():
+    'Find path to OVMF files'
+
+    # If the path is specified in the settings, use it.
+    if SETTINGS['ovmf']['dir'] is not None:
+        ovmf_dir = SETTINGS['ovmf']['dir']
+        if check_ovmf_dir(ovmf_dir):
+            return ovmf_dir
+        raise FileNotFoundError(f'OVMF files not found in `{ovmf_dir}`')
+
+    # Check whether the test runner directory contains the files.
+    ovmf_dir = WORKSPACE_DIR / f'uefi-hello-world-{ARCH}'
+    if check_ovmf_dir(ovmf_dir):
+        return ovmf_dir
+
+    if sys.platform.startswith('linux'):
+        possible_paths = [
+            # Most distros, including CentOS, Fedora, Debian, and Ubuntu.
+            Path('/usr/share/OVMF'),
+            # Arch Linux
+            Path('/usr/share/ovmf/x64'),
+        ]
+        for path in possible_paths:
+            if check_ovmf_dir(path):
+                return path
+
+    raise FileNotFoundError(f'OVMF files not found anywhere')
+
+
+def run_qemu():
+    'Runs the code in QEMU.'
+
+    # Rebuild all the changes.
+    build('--features', 'qemu')
+
+    ovmf_code, ovmf_vars = ovmf_files(find_ovmf())
+
+    examples_dir = build_dir() / 'examples'
+
+    qemu_monitor_pipe = 'qemu-monitor'
+
+    qemu_flags = [
+        # Disable default devices.
+        # QEMU by defaults enables a ton of devices which slow down boot.
+        # '-nodefaults',
+
+        # Use a generic ARM environment. Sadly qemu can't emulate a RPi 4 like machine though
+        '-machine', 'virt',
+
+        # a57 is a very generic 64-bit ARM CPU in the wild
+        '-cpu', 'cortex-a72',
+
+        # Multi-processor services protocol test needs exactly 3 CPUs.
+        '-smp', '4',
+
+        # Allocate some memory.
+        '-m', '512M',
+
+        # Set up OVMF.
+        '-drive', f'if=pflash,format=raw,file={ovmf_code},readonly=on',
+        '-drive', f'if=pflash,format=raw,file={ovmf_vars},readonly=on',
+
+        # Mount a local directory as a FAT partition.
+        '-drive', f'format=raw,file=fat:rw:{esp_dir()}',
+
+        # Mount the built examples directory.
+        '-drive', f'format=raw,file=fat:rw:{examples_dir}',
+    ]
+
+    if sys.platform.startswith('win'):
+        qemu_flags = qemu_flags + [
+            # there's currently no way to get debug information from qemu-system-aarch64
+            # so I commented them out just as of right now. I'm running it off Windows 10 however,
+            # if you happen to know some tricks please consider giving a helping hand
+
+            # setup a character device char0 to print a combined result of stdio
+            '-chardev', 'stdio,mux=on,id=char0',
+
+            # set the monitor to use character device char0
+            '-mon', 'chardev=char0,mode=readline',
+        ]
+    if sys.platform.startswith('linux'):
+        qemu_flags = qemu_flags + [
+            # Connect the serial port to the host. OVMF is kind enough to connect
+            # the UEFI stdout and stdin to that port too.
+            '-serial', 'stdio',
+
+            # Map the QEMU exit signal to port f4
+            '-device', 'isa-debug-exit,iobase=0xf4,iosize=0x04',
+
+            # Map the QEMU monitor to a pair of named pipes
+            '-qmp', f'pipe:{qemu_monitor_pipe}',
+
+            # OVMF debug builds can output information to a serial `debugcon`.
+            # Only enable when debugging UEFI boot:
+            '-debugcon', 'file:debug.log',
+
+            '-global', 'isa-debugcon.iobase=0x402',
+        ]
+
+    # When running in headless mode we don't have video, but we can still have
+    # QEMU emulate a display and take screenshots from it.
+    # qemu_flags.extend(['-vga', 'std'])
+    if SETTINGS['headless']:
+        # Do not attach a window to QEMU's display
+        qemu_flags.extend(['-display', 'none'])
+
+    cmd = [SETTINGS['qemu_binary']] + qemu_flags
+
+    if SETTINGS['verbose']:
+        print(' '.join(cmd))
+
+    # This regex can be used to detect and strip ANSI escape codes when
+    # analyzing the output of the test runner.
+    ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
+
+    # Setup named pipes as a communication channel with QEMU's monitor
+    monitor_input_path = f'{qemu_monitor_pipe}.in'
+    monitor_output_path = f'{qemu_monitor_pipe}.out'
+
+    if sys.platform.startswith('linux'):
+        os.mkfifo(monitor_input_path)
+        os.mkfifo(monitor_output_path)
+
+    # Start QEMU
+    qemu = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, universal_newlines=True)
+    # now, if you're on windows, please checkout to the serial monitor immediately to see your stuff running
+    # for some reason by default it is running on the qemu console page
+    try:
+        # Connect to the QEMU monitor
+        with open(monitor_input_path, mode='w') as monitor_input, \
+                open(monitor_output_path, mode='r') as monitor_output:
+            # Execute the QEMU monitor handshake, doing basic sanity checks
+            assert monitor_output.readline().startswith('{"QMP":')
+            print('{"execute": "qmp_capabilities"}', file=monitor_input, flush=True)
+            assert monitor_output.readline() == '{"return": {}}\n'
+
+            # Iterate over stdout...
+            for line in qemu.stdout:
+                # Strip ending and trailing whitespace + ANSI escape codes
+                # (This simplifies log analysis and keeps the terminal clean)
+                stripped = ansi_escape.sub('', line.strip())
+
+                # Skip lines which contain nothing else
+                if not stripped:
+                    continue
+
+                # Print out the processed QEMU output for logging & inspection
+                print(stripped)
+
+                # If the app requests a screenshot, take it
+                if stripped.startswith("SCREENSHOT: "):
+                    reference_name = stripped[12:]
+
+                    # Ask QEMU to take a screenshot
+                    monitor_command = '{"execute": "screendump", "arguments": {"filename": "screenshot.ppm"}}'
+                    print(monitor_command, file=monitor_input, flush=True)
+
+                    # Wait for QEMU's acknowledgement, ignoring events
+                    reply = json.loads(monitor_output.readline())
+                    while "event" in reply:
+                        reply = json.loads(monitor_output.readline())
+                    assert reply == {"return": {}}
+
+                    # Tell the VM that the screenshot was taken
+                    print('OK', file=qemu.stdin, flush=True)
+
+                    # Compare screenshot to the reference file specified by the user
+                    # TODO: Add an operating mode where the reference is created if it doesn't exist
+                    reference_file = WORKSPACE_DIR / 'uefi-hello-world-aarch64' / 'screenshots' / (
+                            reference_name + '.ppm')
+                    assert filecmp.cmp('screenshot.ppm', reference_file)
+
+                    # Delete the screenshot once done
+                    os.remove('screenshot.ppm')
+    finally:
+        try:
+            # Wait for QEMU to finish
+            status = qemu.wait(69)  # nice
+        except sp.TimeoutExpired:
+            print('Tests are taking too long to run, killing QEMU', file=sys.stderr)
+            qemu.kill()
+            status = -1
+
+        if sys.platform.startswith('linux'):
+            # Delete the monitor pipes
+            os.remove(monitor_input_path)
+            os.remove(monitor_output_path)
+
+        # Throw an exception if QEMU failed
+        if status != 0:
+            raise sp.CalledProcessError(cmd=cmd, returncode=status)
+
+
+def main():
+    'Runs the user-requested actions.'
+
+    # Clear any Rust flags which might affect the build.
+    os.environ['RUSTFLAGS'] = ''
+
+    usage = '%(prog)s verb [options]'
+    desc = 'Build script for UEFI programs'
+
+    parser = argparse.ArgumentParser(usage=usage, description=desc)
+
+    parser.add_argument('verb', help='command to run', type=str,
+                        choices=['build', 'run', 'doc', 'clippy'])
+
+    parser.add_argument('--verbose', '-v', help='print commands before executing them',
+                        action='store_true')
+
+    parser.add_argument('--headless', help='run QEMU without a GUI',
+                        action='store_true')
+
+    parser.add_argument('--release', help='build in release mode',
+                        action='store_true')
+
+    opts = parser.parse_args()
+
+    # Check if we need to enable verbose mode
+    SETTINGS['verbose'] = opts.verbose
+    SETTINGS['headless'] = opts.headless
+    SETTINGS['config'] = 'release' if opts.release else 'debug'
+
+    verb = opts.verb
+
+    if verb == 'build':
+        build()
+    elif verb == 'clippy':
+        clippy()
+    elif verb == 'doc':
+        doc()
+    elif verb == 'run' or verb is None or opts.verb == '':
+        # Run the program, by default.
+        run_qemu()
+    else:
+        raise ValueError(f'Unknown verb {opts.verb}')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except sp.CalledProcessError as cpe:
+        print(f'Subprocess {cpe.cmd[0]} exited with error code {cpe.returncode}')
+        sys.exit(1)

--- a/uefi-hello-world-aarch64/src/main.rs
+++ b/uefi-hello-world-aarch64/src/main.rs
@@ -2,13 +2,12 @@
 #![no_main]
 #![feature(asm)]
 #![feature(abi_efiapi)]
-#![feature(core_intrinsics)]
 
-extern crate no_std_compat as std;
+extern crate alloc;
 
-use std::collections::{BTreeMap, HashMap};
-use std::mem;
-use std::prelude::v1::*;
+use alloc::collections::BTreeMap;
+use alloc::vec;
+use core::mem;
 
 use uefi::prelude::*;
 use uefi::table::boot::MemoryDescriptor;
@@ -24,9 +23,6 @@ fn main(_image: Handle, _st: SystemTable<Boot>) -> Result {
         log::info!("{}: {}", k, v);
     }
 
-    unsafe {
-        log::info!("{}", core::intrinsics::sinf64(1337.0));
-    }
     Ok(Completion::from(()))
 }
 

--- a/uefi-hello-world-aarch64/src/main.rs
+++ b/uefi-hello-world-aarch64/src/main.rs
@@ -13,7 +13,7 @@ use uefi::prelude::*;
 use uefi::table::boot::MemoryDescriptor;
 use uefi::{Completion, Result};
 
-fn main(_image: Handle, _st: SystemTable<Boot>) -> Result {
+fn main(_image: Handle, _st: &mut SystemTable<Boot>) -> Result {
     let mut map = BTreeMap::new();
 
     map.insert("hello", "world");
@@ -27,17 +27,16 @@ fn main(_image: Handle, _st: SystemTable<Boot>) -> Result {
 }
 
 #[entry]
-fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
+fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
     uefi_services::init(&st).expect_success("Failed to initialize utilities");
 
     // Reset the console before running all the other tests.
-    st.clone()
-        .stdout()
+    st.stdout()
         .reset(false)
         .expect_success("Failed to reset stdout");
 
-    match main(image, st.clone()) {
+    match main(image, &mut st) {
         Err(err) => panic!("Received an error: {:#?}", err),
         Ok(_ret) => {
             shutdown(image, st);

--- a/uefi-hello-world-aarch64/src/main.rs
+++ b/uefi-hello-world-aarch64/src/main.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![feature(asm)]
 #![feature(abi_efiapi)]
+#![feature(core_intrinsics)]
 
 extern crate no_std_compat as std;
 
@@ -23,6 +24,9 @@ fn main(_image: Handle, _st: SystemTable<Boot>) -> Result {
         log::info!("{}: {}", k, v);
     }
 
+    unsafe {
+        log::info!("{}", core::intrinsics::sinf64(1337.0));
+    }
     Ok(Completion::from(()))
 }
 
@@ -64,5 +68,3 @@ fn shutdown(image: uefi::Handle, st: SystemTable<Boot>) -> ! {
     let rt = unsafe { st.runtime_services() };
     rt.reset(ResetType::Shutdown, Status::SUCCESS, None)
 }
-
-mod managed_main;

--- a/uefi-hello-world-aarch64/src/main.rs
+++ b/uefi-hello-world-aarch64/src/main.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(asm)]
+#![feature(abi_efiapi)]
+
+extern crate no_std_compat as std;
+
+use std::collections::{BTreeMap, HashMap};
+use std::mem;
+use std::prelude::v1::*;
+
+use uefi::prelude::*;
+use uefi::table::boot::MemoryDescriptor;
+use uefi::{Completion, Result};
+
+fn main(_image: Handle, _st: SystemTable<Boot>) -> Result {
+    let mut map = BTreeMap::new();
+
+    map.insert("hello", "world");
+    map.insert("foo", "bar");
+
+    for (k, v) in map.iter() {
+        log::info!("{}: {}", k, v);
+    }
+
+    Ok(Completion::from(()))
+}
+
+#[entry]
+fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
+    // Initialize utilities (logging, memory allocation...)
+    uefi_services::init(&st).expect_success("Failed to initialize utilities");
+
+    // Reset the console before running all the other tests.
+    st.clone()
+        .stdout()
+        .reset(false)
+        .expect_success("Failed to reset stdout");
+
+    match main(image, st.clone()) {
+        Err(err) => panic!("Received an error: {:#?}", err),
+        Ok(_ret) => {
+            shutdown(image, st);
+        }
+    }
+}
+
+fn shutdown(image: uefi::Handle, st: SystemTable<Boot>) -> ! {
+    use uefi::table::runtime::ResetType;
+
+    // Inform the user, and give the user time to read on real hardware
+    log::info!("Program successfully exit, shutting down in 10 seconds...");
+    st.boot_services().stall(10_000_000);
+
+    // Exit boot services as a proof that it works :)
+    let max_mmap_size =
+        st.boot_services().memory_map_size() + 8 * mem::size_of::<MemoryDescriptor>();
+    let mut mmap_storage = vec![0; max_mmap_size].into_boxed_slice();
+    let (st, _iter) = st
+        .exit_boot_services(image, &mut mmap_storage[..])
+        .expect_success("Failed to exit boot services");
+
+    // Shut down the system
+    let rt = unsafe { st.runtime_services() };
+    rt.reset(ResetType::Shutdown, Status::SUCCESS, None)
+}
+
+mod managed_main;

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -15,10 +15,12 @@ is-it-maintained-issue-resolution = { repository = "rust-osdev/uefi-rs" }
 is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 
 [dependencies]
-x86_64 = "0.11.1"
-
 uefi = { version = "0.4.6", features = ["alloc", "logger"] }
 log = { version = "0.4.8", default-features = false }
+cfg-if = "0.1.10"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86_64 = "0.11.1"
 
 [features]
 # Enable QEMU-specific functionality


### PR DESCRIPTION
Although coincidence and clearly overlaps (silly me I thought would be no PR on this anyway), I still decided to PR this as this can be seen as a simpler version of #120. 

It also include patches to workaround the branch evaluation on the x86_64 check but...with a much better format I think. 

A "managed" main method is also experimented on, as it panics if an error status returns, and shutdown like test runner if it succeeded. N.B. I copied the folder and removed most stuff from test runner. 

You can also see a very crude way to shadowing std crate into bare-metal environment by the use of `no-std-compat`. Most if not all things from std works, like std::collection::BTreeMap in this example (so should the rest like HashMap), yet floating point support clearly doesn't present. (I tried to calculate a silly number with sine, but it shows me I have no math related symbols, so how does motherboard manufacturers make browsers run then?)

I work on a Windows environment and so it is obviously not a great experience to begin with. os.mkfifo is missing because...Windows doesn't really have the Unix philosophy of "named pipe" that "everything is a file", instead it is a "device path" obscured and hidden from the user IIRC. This is also remediated by separating Windows and *nix specific stuff to behave differently (We have GUI in Windows, and just watch from the GTK+ serial console). This barely works but I'm very happy to see the little hello world running off aarch64 on amd64.