### PR TITLE
Update Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
       working-directory: ./uefi-test-runner
 
     - name: Run tests
-      run: ./build.py run --headless
+      run: ./build.py run --headless --ci
       working-directory: ./uefi-test-runner
 
   lints:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron:  '0 0 * * 0-6'
 
 jobs:
   build_and_test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,9 @@ jobs:
         mv -v *.fd uefi-test-runner
 
     - name: Install qemu
-      run: sudo apt-get install qemu -y
+      run: |
+        sudo apt-get update
+        sudo apt-get install qemu -y
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
@@ -74,6 +76,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - uses: actions-rs/clippy-check@v1
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -12,4 +12,7 @@ uefi-services = { path = "../uefi-services" }
 log = { version = "0.4.8", default-features = false }
 
 [features]
+# This feature should only be enabled in our CI, it disables some tests
+# which currently fail in that environment (see #103 for discussion).
+ci = []
 qemu = ["uefi-services/qemu"]

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -200,15 +200,17 @@ def run_qemu():
 
     if arch == 'x86_64':
         qemu_flags.extend([
-            # Use a modern machine, with acceleration if possible.
-            '-machine', 'q35,accel=kvm:tcg',
-
+            # Use a modern machine,.
+            '-machine', 'q35',
             # Multi-processor services protocol test needs exactly 3 CPUs.
             '-smp', '3',
 
             # Allocate some memory.
             '-m', '128M',
         ])
+        if not SETTINGS['ci']:
+            # Enable acceleration if possible.
+            qemu_flags.append('--enable-kvm')
     elif arch == 'aarch64':
         qemu_flags.extend([
             # Use a generic ARM environment. Sadly qemu can't emulate a RPi 4 like machine though

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -26,6 +26,8 @@ SETTINGS = {
     'headless': False,
     # Configuration to build.
     'config': 'debug',
+    # Disables some tests which don't work in our CI setup
+    'ci': False,
     # QEMU executable to use
     # Indexed by the `arch` setting
     'qemu_binary': {
@@ -97,6 +99,9 @@ def build(*test_flags):
 
     if SETTINGS['config'] == 'release':
         xbuild_args.append('--release')
+
+    if SETTINGS['ci']:
+        xbuild_args.extend(['--features', 'ci'])
 
     run_xbuild(*xbuild_args)
 
@@ -356,6 +361,9 @@ def main():
     parser.add_argument('--release', help='build in release mode',
                         action='store_true')
 
+    parser.add_argument('--ci', help='disables some tests which currently break CI',
+                        action='store_true')
+
     opts = parser.parse_args()
 
     SETTINGS['arch'] = opts.target
@@ -363,6 +371,7 @@ def main():
     SETTINGS['verbose'] = opts.verbose
     SETTINGS['headless'] = opts.headless
     SETTINGS['config'] = 'release' if opts.release else 'debug'
+    SETTINGS['ci'] = opts.ci
 
     verb = opts.verb
 

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -140,6 +140,11 @@ fn test_enable_disable_ap(mps: &MPServices) {
 }
 
 fn test_switch_bsp_and_who_am_i(mps: &MPServices) {
+    // This test breaks CI. See #103.
+    if cfg!(feature = "ci") {
+        return;
+    }
+
     // Normally BSP starts on on CPU 0
     let proc_number = mps.who_am_i().unwrap().unwrap();
     assert_eq!(proc_number, 0);


### PR DESCRIPTION
Fixes our current CI.

- fixes QEMU install.
- adds a new `--ci` flag and Cargo feature which will disable the failing test.
- schedules our CI to run daily, to check for issues with new nightlies.
- disables KVM acceleration in CI.

Closes #139.