### PR TITLE
Replace `cargo-xbuild` with `build-std` feature

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,4 +77,5 @@ jobs:
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
+          args: --target x86_64-unknown-uefi
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
         with:
             profile: minimal
             toolchain: nightly
-            components: rustfmt, clippy
+            components: rustfmt, clippy, rust-src
             override: true
 
       - name: Run cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,10 +45,6 @@ jobs:
           components: rust-src
       # TODO: cache Rust binaries
 
-    - name: Install cargo-xbuild
-      run: hash cargo-xbuild || cargo install cargo-xbuild
-      # TODO: cache the built cargo-xbuild binary
-
     - name: Build
       run: ./build.py build
       working-directory: ./uefi-test-runner

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,11 +23,12 @@ The following steps allow you to build a simple UEFI app.
   #[entry]
   fn efi_main(handle: Handle, system_table: SystemTable<Boot>) -> Status;
   ```
-  You will also want to add a dependency to the
-  [`compiler-builtins`](https://github.com/rust-lang/compiler-builtins) crate,
+  You will also want to add a dependency to the [`rlibc`](https://docs.rs/rlibc/) crate,
   to avoid linking errors.
 
-- Build using `cargo xbuild --target x86_64-unknown-uefi`.
+- Build using a `nightly` version of the compiler and activate the
+  [`build-std`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std)
+  Cargo feature: `cargo build -Z build-std --target x86_64-unknown-uefi`.
 
 - The `target` directory will contain a `x86_64-unknown-uefi` subdirectory,
   where you will find the `uefi_app.efi` file - a normal UEFI executable.

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -11,6 +11,11 @@ uefi-services = { path = "../uefi-services" }
 
 log = { version = "0.4.8", default-features = false }
 
+# When building using Cargo's `build-std` feature, the `mem` feature of `compiler-builtins`
+# does not automatically get enabled. Therefore, we have to manually add support for
+# the memory functions.
+rlibc = "1"
+
 [features]
 # This feature should only be enabled in our CI, it disables some tests
 # which currently fail in that environment (see #103 for discussion).

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -65,8 +65,8 @@ def esp_dir():
     'Returns the directory where we will build the emulated UEFI system partition'
     return build_dir() / 'esp'
 
-def run_xtool(tool, *flags):
-    'Runs cargo-x<tool> with certain arguments.'
+def run_tool(tool, *flags):
+    'Runs cargo-<tool> with certain arguments.'
 
     target = get_target_triple()
     # Custom targets need to be given by relative path, instead of only by name
@@ -81,29 +81,29 @@ def run_xtool(tool, *flags):
 
     sp.run(cmd, check=True)
 
-def run_xbuild(*flags):
-    'Runs cargo-xbuild with certain arguments.'
-    run_xtool('xbuild', *flags)
+def run_build(*flags):
+    'Runs cargo-build with certain arguments.'
+    run_tool('build', *flags)
 
-def run_xclippy(*flags):
-    'Runs cargo-xclippy with certain arguments.'
-    run_xtool('xclippy', *flags)
+def run_clippy(*flags):
+    'Runs cargo-clippy with certain arguments.'
+    run_tool('clippy', *flags)
 
 def build(*test_flags):
     'Builds the test crate.'
 
-    xbuild_args = [
+    build_args = [
         '--package', 'uefi-test-runner',
         *test_flags,
     ]
 
     if SETTINGS['config'] == 'release':
-        xbuild_args.append('--release')
+        build_args.append('--release')
 
     if SETTINGS['ci']:
-        xbuild_args.extend(['--features', 'ci'])
+        build_args.extend(['--features', 'ci'])
 
-    run_xbuild(*xbuild_args)
+    run_build(*build_args)
 
     # Copy the built test runner file to the right directory for running tests.
     built_file = build_dir() / 'uefi-test-runner.efi'
@@ -122,7 +122,7 @@ def build(*test_flags):
 def clippy():
     'Runs Clippy on all projects'
 
-    run_xclippy('--all')
+    run_clippy('--all')
 
 def doc():
     'Generates documentation for the library crates.'

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -8,6 +8,9 @@ extern crate log;
 #[macro_use]
 extern crate alloc;
 
+// Keep this line to ensure the `mem*` functions are linked in.
+extern crate rlibc;
+
 use core::mem;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;


### PR DESCRIPTION
Updates the crate to use [the recently added Cargo support](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std) for automatically building `core` in cross-compiling scenarios.

Based on the instructions in the [`cargo-xbuild` README](https://github.com/rust-osdev/cargo-xbuild#alternative-the-build-std-feature-of-cargo)