### PR TITLE
Add method to return (image_base, image_size) to LoadedImage

### DIFF
--- a/src/proto/loaded_image/mod.rs
+++ b/src/proto/loaded_image/mod.rs
@@ -59,4 +59,9 @@ impl LoadedImage {
             ucs2::decode(ucs2_slice, buffer).map_err(|_| LoadOptionsError::BufferTooSmall)?;
         core::str::from_utf8(&buffer[0..length]).map_err(|_| LoadOptionsError::NotValidUtf8)
     }
+
+    /// Get (image_base, image_size) for the loaded image.
+    pub fn image_info(&self) -> (usize, u64) {
+        (self.image_base, self.image_size)
+    }
 }


### PR DESCRIPTION
Add a method to get `image_base` and `image_size` from LoadedImage. Since these fields are private, a getter is needed to retrive them.

I'm open to suggestions on a better method name.

closes #147 