### PR TITLE
Manually run clippy instead of relying on custom action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
           args: --all -- --check
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
+          command: clippy
           args: --target x86_64-unknown-uefi
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `clippy-check` action currently has a [pretty big caveat](https://github.com/actions-rs/clippy-check#limitations), in the sense that it cannot print the status on PRs from forked repositories. This is not exactly desired, so this PR opts for the simpler option of just running clippy directly.