### PR TITLE
Add memory_map_descriptor_size function

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -196,6 +196,15 @@ impl BootServices {
         map_size
     }
 
+    /// Retrieves the size, in bytes, of each descriptor of the current memory map.
+    ///
+    /// This value is not always the same as `size_of::<MemoryDescriptor>` because each descriptor
+    /// may contain some paddings. You should use this function instead of using `size_of`.
+    pub fn memory_map_descriptor_size(&self) -> usize {
+        // Don't use vec! or box! because not everyone enables `alloc` feature of this crate.
+        unimplemented!();
+    }
+
     /// Retrieves the current memory map.
     ///
     /// The allocated buffer should be big enough to contain the memory map,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -222,7 +222,7 @@ impl BootServices {
 
         assert_eq!(status, Status::SUCCESS);
 
-        self.free_pool(buf as *mut _);
+        self.free_pool(buf as *mut _)?.unwrap();
 
         status.into_with_val(move || entry_size)
     }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -201,12 +201,12 @@ impl BootServices {
     /// This value is not always the same as `size_of::<MemoryDescriptor>` because each descriptor
     /// may contain some paddings. You should use this function instead of using `size_of`.
     pub fn memory_map_descriptor_size(&self) -> Result<usize> {
-        let mut map_size = 0;
+        let mut map_size = self.memory_map_size() * 2;
         let mut map_key = MemoryMapKey(0);
         let mut entry_size = 0;
         let mut entry_version = 0;
         let buf = self
-            .allocate_pool(MemoryType::LOADER_DATA, self.memory_map_size() * 2)?
+            .allocate_pool(MemoryType::LOADER_DATA, map_size)?
             .unwrap();
         let mut buf = buf as *mut MemoryDescriptor;
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -208,7 +208,7 @@ impl BootServices {
         let buf = self
             .allocate_pool(MemoryType::LOADER_DATA, map_size)?
             .unwrap();
-        let mut buf = buf as *mut MemoryDescriptor;
+        let buf = buf as *mut MemoryDescriptor;
 
         let status = unsafe {
             (self.get_memory_map)(


### PR DESCRIPTION
This function returns the size of each descriptor of the current memory map.