### PR TITLE
Rename `image_info` to `info`

### DIFF
--- a/src/proto/loaded_image/mod.rs
+++ b/src/proto/loaded_image/mod.rs
@@ -60,8 +60,8 @@ impl LoadedImage {
         core::str::from_utf8(&buffer[0..length]).map_err(|_| LoadOptionsError::NotValidUtf8)
     }
 
-    /// Get (image_base, image_size) for the loaded image.
-    pub fn image_info(&self) -> (usize, u64) {
+    /// Returns the base address and the size in bytes of the loaded image.
+    pub fn info(&self) -> (usize, u64) {
         (self.image_base, self.image_size)
     }
 }


### PR DESCRIPTION
It seems this change was lost during the rebase.