### PR TITLE
Hide the `MemoryMapIter` type from the API

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -205,10 +205,13 @@ impl BootServices {
     ///
     /// The returned key is a unique identifier of the current configuration of memory.
     /// Any allocations or such will change the memory map's key.
+    ///
+    /// If you want to store the resulting memory map without having to keep
+    /// the buffer around, you can use `.copied().collect()` on the iterator.
     pub fn memory_map<'buf>(
         &self,
         buffer: &'buf mut [u8],
-    ) -> Result<(MemoryMapKey, MemoryMapIter<'buf>)> {
+    ) -> Result<(MemoryMapKey, impl Iterator<Item = &'buf MemoryDescriptor>)> {
         let mut map_size = buffer.len();
         MemoryDescriptor::assert_aligned(buffer);
         #[allow(clippy::cast_ptr_alignment)]
@@ -722,12 +725,8 @@ bitflags! {
 pub struct MemoryMapKey(usize);
 
 /// An iterator of memory descriptors
-///
-/// This type is only exposed in interfaces due to current limitations of
-/// `impl Trait` which may be lifted in the future. It is therefore recommended
-/// that you refrain from directly manipulating it in your code.
 #[derive(Debug)]
-pub struct MemoryMapIter<'buf> {
+struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],
     entry_size: usize,
     index: usize,

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -4,7 +4,7 @@ use core::slice;
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};
 
-use super::boot::{BootServices, MemoryMapIter};
+use super::boot::{BootServices, MemoryDescriptor};
 use super::runtime::RuntimeServices;
 use super::{cfg, Header, Revision};
 
@@ -137,7 +137,10 @@ impl SystemTable<Boot> {
         self,
         image: Handle,
         mmap_buf: &'buf mut [u8],
-    ) -> Result<(SystemTable<Runtime>, MemoryMapIter<'buf>)> {
+    ) -> Result<(
+        SystemTable<Runtime>,
+        impl Iterator<Item = &'buf MemoryDescriptor>,
+    )> {
         unsafe {
             let boot_services = self.boot_services();
 

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -97,16 +97,19 @@ fn memory_map(bt: &BootServices) {
         buffer.set_len(buf_sz);
     }
 
-    let (_key, mut desc_iter) = bt
+    let (_key, desc_iter) = bt
         .memory_map(&mut buffer)
         .expect_success("Failed to retrieve UEFI memory map");
 
+    // Collect the descriptors into a vector
+    let descriptors = desc_iter.copied().collect::<Vec<_>>();
+
     // Ensured we have at least one entry.
     // Real memory maps usually have dozens of entries.
-    assert!(desc_iter.len() > 0, "Memory map is empty");
+    assert!(!descriptors.is_empty(), "Memory map is empty");
 
     // This is pretty much a sanity test to ensure returned memory isn't filled with random values.
-    let first_desc = desc_iter.next().unwrap();
+    let first_desc = descriptors[0];
 
     #[cfg(target_arch = "x86_64")]
     {


### PR DESCRIPTION
Fixes #152 