### PR TITLE
Upstream two changes from Pebble's fork

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
+#![feature(const_fn)]
+#![feature(const_panic)]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(missing_docs, unused)]

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -646,6 +646,15 @@ pub enum MemoryType: u32 => {
     PERSISTENT_MEMORY       = 14,
 }}
 
+impl MemoryType {
+    /// Construct a custom `MemoryType`. Values in the range `0x80000000..=0xffffffff` are free for use if you are
+    /// an OS loader.
+    pub const fn custom(value: u32) -> MemoryType {
+        assert!(value >= 0x80000000);
+        MemoryType(value)
+    }
+}
+
 /// Memory descriptor version number
 pub const MEMORY_DESCRIPTOR_VERSION: u32 = 1;
 


### PR DESCRIPTION
This upstreams two local changes from Pebble's fork of `uefi-rs`, which would allow us to use the official release:
- Fixes a bug in `LoadedImage::load_options` where a slice is created from a null pointer if no load options are passed, causing a panic. Fixed by returning an empty string if there aren't any load options. Also documents this behaviour.
- Provides a method for constructing custom `MemoryType`s, checking that it's valid.