### PR TITLE
Make memory map iterator clonable

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -211,7 +211,10 @@ impl BootServices {
     pub fn memory_map<'buf>(
         &self,
         buffer: &'buf mut [u8],
-    ) -> Result<(MemoryMapKey, impl Iterator<Item = &'buf MemoryDescriptor>)> {
+    ) -> Result<(
+        MemoryMapKey,
+        impl Iterator<Item = &'buf MemoryDescriptor> + Clone,
+    )> {
         let mut map_size = buffer.len();
         MemoryDescriptor::assert_aligned(buffer);
         #[allow(clippy::cast_ptr_alignment)]
@@ -734,7 +737,7 @@ bitflags! {
 pub struct MemoryMapKey(usize);
 
 /// An iterator of memory descriptors
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],
     entry_size: usize,

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -139,7 +139,7 @@ impl SystemTable<Boot> {
         mmap_buf: &'buf mut [u8],
     ) -> Result<(
         SystemTable<Runtime>,
-        impl Iterator<Item = &'buf MemoryDescriptor>,
+        impl Iterator<Item = &'buf MemoryDescriptor> + Clone,
     )> {
         unsafe {
             let boot_services = self.boot_services();


### PR DESCRIPTION
This allows iterating the list multiple times, which is for example useful for retrieving some information about the list (e.g. amount of usable memory) without destroying the iterator.
