### PR TITLE
Fix the `text::Output::current_mode` method

### DIFF
--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -88,7 +88,7 @@ impl<'boot> Output<'boot> {
     pub fn current_mode(&self) -> Result<Option<OutputMode>> {
         match self.data.mode {
             -1 => Ok(None.into()),
-            n if n > 0 => {
+            n if n >= 0 => {
                 let index = n as usize;
                 self.query_mode(index)
                     .map_inner(|dims| Some(OutputMode { index, dims }))

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -4,6 +4,7 @@ use uefi::proto::console::text::{Color, Output};
 pub fn test(stdout: &mut Output) {
     info!("Running text output protocol test");
 
+    get_current_mode(stdout);
     change_text_mode(stdout);
     change_color(stdout);
     center_text(stdout);
@@ -21,6 +22,12 @@ pub fn test(stdout: &mut Output) {
 
     // Should clean up after us.
     stdout.reset(false).unwrap_success();
+}
+
+// Retrieves and prints the current output mode.
+fn get_current_mode(stdout: &mut Output) {
+    let current_mode = stdout.current_mode().unwrap_success();
+    info!("UEFI standard output current mode: {:?}", current_mode);
 }
 
 // Switch to the maximum supported text mode.


### PR DESCRIPTION
Fixes #160 and adds a test for it.