### PR TITLE
Use `ExactSizeIterator` in `exit_boot_services`

### DIFF
--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -139,7 +139,7 @@ impl SystemTable<Boot> {
         mmap_buf: &'buf mut [u8],
     ) -> Result<(
         SystemTable<Runtime>,
-        impl Iterator<Item = &'buf MemoryDescriptor> + Clone,
+        impl ExactSizeIterator<Item = &'buf MemoryDescriptor> + Clone,
     )> {
         unsafe {
             let boot_services = self.boot_services();


### PR DESCRIPTION
Forgot to change this in #164.