### PR TITLE
Made panic_handler optional

### DIFF
--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -25,3 +25,4 @@ x86_64 = "0.12.1"
 [features]
 # Enable QEMU-specific functionality
 qemu = []
+no_panic_handler = []

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -126,6 +126,7 @@ fn exit_boot_services(_e: Event) {
 #[lang = "eh_personality"]
 fn eh_personality() {}
 
+#[cfg(not(feature = "no_panic_handler"))]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     if let Some(location) = info.location() {


### PR DESCRIPTION
With this PR, the `uefi-services` crate's `panic_handler` can now be toggled off with the `no_panic_handler` feature.

Hope I'm doing this right as this is my first PR.