### PR TITLE
Clarify how new protocols can be defined

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,11 @@ low-level environment that UEFI operates in:
 
 ## Adding new protocols
 
+You should start by [forking this repository][fork] and cloning it.
+Due to the way the proc macros for `unsafe_guid` and `derive(Protocol)`
+are implemented, it's not currently possible to add new protocols
+outside of the core `uefi` crate.
+
 UEFI protocols are represented in memory as tables of function pointers,
 each of which takes the protocol itself as first parameter.
 
@@ -127,3 +132,5 @@ impl NewProtocol {
   }
 }
 ```
+
+[fork]: https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo


### PR DESCRIPTION
Adds a mention to `CONTRIBUTING.md` that new protocols can only be defined in the `uefi` crate.

Should help with issues like #184