### PR TITLE
Fix optin_builtin_traits feature rename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! therefore all the network protocols will be unavailable.
 
 #![cfg_attr(feature = "exts", feature(allocator_api, alloc_layout_extra))]
-#![feature(optin_builtin_traits)]
+#![feature(auto_traits)]
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]


### PR DESCRIPTION
The feature `optin_builtin_traits` was renamed to `auto_traits` which broke this package. it's an extremely easy fix; I just had to change the name.