### PR TITLE
Fix CI with latest nightly

### DIFF
--- a/src/exts.rs
+++ b/src/exts.rs
@@ -1,10 +1,11 @@
 //! Utility functions for the most common UEFI patterns.
 
 use alloc_api::{
-    alloc::{handle_alloc_error, AllocRef, Global},
+    alloc::{alloc, handle_alloc_error},
     boxed::Box,
 };
 use core::alloc::Layout;
+use core::slice;
 
 /// Creates a boxed byte buffer using the standard allocator.
 ///
@@ -16,10 +17,12 @@ pub fn allocate_buffer(layout: Layout) -> Box<[u8]> {
         handle_alloc_error(layout);
     }
     unsafe {
-        let mut slice = match Global.alloc(layout) {
-            Ok(slice) => slice,
-            Err(_) => handle_alloc_error(layout),
-        };
+        let data =  alloc(layout);
+        if data.is_null() {
+            handle_alloc_error(layout);
+        }
+        let len = layout.size();
+        let slice = slice::from_raw_parts_mut(data, len);
         Box::from_raw(slice.as_mut())
     }
 }

--- a/src/exts.rs
+++ b/src/exts.rs
@@ -17,12 +17,12 @@ pub fn allocate_buffer(layout: Layout) -> Box<[u8]> {
         handle_alloc_error(layout);
     }
     unsafe {
-        let data =  alloc(layout);
+        let data = alloc(layout);
         if data.is_null() {
             handle_alloc_error(layout);
         }
         let len = layout.size();
         let slice = slice::from_raw_parts_mut(data, len);
-        Box::from_raw(slice.as_mut())
+        Box::from_raw(slice)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! therefore all the network protocols will be unavailable.
 
 #![cfg_attr(feature = "exts", feature(allocator_api, alloc_layout_extra))]
-#![feature(optin_builtin_traits)]
+#![feature(auto_traits)]
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]

--- a/src/result/status.rs
+++ b/src/result/status.rs
@@ -125,6 +125,7 @@ impl Status {
 
     /// Converts this status code into a result with a given value.
     #[inline]
+    #[allow(clippy::clippy::result_unit_err)]
     pub fn into_with_val<T>(self, val: impl FnOnce() -> T) -> Result<T, ()> {
         if !self.is_error() {
             Ok(Completion::new(self, val()))

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -144,9 +144,9 @@ impl Time {
         time_zone: i16,
         daylight: Daylight,
     ) -> Self {
-        assert!(year >= 1900 && year <= 9999);
-        assert!(month >= 1 && month <= 12);
-        assert!(day >= 1 && day <= 31);
+        assert!((1900..=9999).contains(&year));
+        assert!((1..=12).contains(&month));
+        assert!((1..=31).contains(&day));
         assert!(hour <= 23);
         assert!(minute <= 59);
         assert!(second <= 59);


### PR DESCRIPTION
Renames an unstable feature, updates to the latest `alloc` API changes, and then fixes clippy and format issues.