### PR TITLE
Fixing various phrasing inconsistencies and spelling errors in prev PR's comments

### DIFF
--- a/src/proto/loaded_image/device_path.rs
+++ b/src/proto/loaded_image/device_path.rs
@@ -1,4 +1,4 @@
-//! Device path protocol
+//! `DevicePath` protocol
 
 use crate::{proto::Protocol, unsafe_guid};
 
@@ -12,10 +12,10 @@ pub struct DevicePath {
     pub device_type: DeviceType,
     /// Sub type of device
     pub sub_type: DeviceSubType,
-    /// Tata related to device path
+    /// Data related to device path
     ///
     /// The device_type and sub_type determine the
-    /// kind of data, and it size.
+    /// kind of data, and its size.
     pub length: [u8; 2],
 }
 

--- a/src/proto/loaded_image/mod.rs
+++ b/src/proto/loaded_image/mod.rs
@@ -1,7 +1,7 @@
-//! Loaded image protocol.
+//! `LoadedImage` protocol.
 //!
-//! This module also contains the corollary type DevicePath, which is
-//! used to emulate `EFI_DEVICE_PATH_PROTOCOL`.
+//! This module also contains the corollary type `DevicePath`, which is
+//! used to wrap an `EFI_DEVICE_PATH_PROTOCOL`.
 
 mod device_path;
 pub use self::device_path::DevicePath;
@@ -14,7 +14,7 @@ use crate::{
 };
 use core::{ffi::c_void, str};
 
-/// The Loaded Image protocol. This can be opened on any image handle using the `HandleProtocol` boot service.
+/// The LoadedImage protocol. This can be opened on any image handle using the `HandleProtocol` boot service.
 #[repr(C)]
 #[unsafe_guid("5b1b31a1-9562-11d2-8e3f-00a0c969723b")]
 #[derive(Protocol)]
@@ -38,7 +38,7 @@ pub struct LoadedImage {
     image_code_type: MemoryType,
     image_data_type: MemoryType,
     /// This is a callback that a loaded image can use to do cleanup. It is called by the
-    /// UnloadImage boot service.
+    /// `UnloadImage` boot service.
     unload: extern "efiapi" fn(image_handle: Handle) -> Status,
 }
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -751,7 +751,6 @@ bitflags! {
 pub struct MemoryMapKey(usize);
 
 /// An iterator of memory descriptors
-#[repr(C)]
 #[derive(Debug, Clone)]
 struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -751,6 +751,7 @@ bitflags! {
 pub struct MemoryMapKey(usize);
 
 /// An iterator of memory descriptors
+#[repr(C)]
 #[derive(Debug, Clone)]
 struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],


### PR DESCRIPTION
## Motivation
My [previously merged pull request](https://github.com/rust-osdev/uefi-rs/pull/187#issue-533203544)'s code comments had various spelling errors, phrasing inconsistencies, and generally bothered me with their quality—I've gone back and edited them so they match the quality I'd expect from a public crate.

## Changes
All I've edited are code comments that were made for code in my [previous pull request](https://github.com/rust-osdev/uefi-rs/pull/187#issue-533203544).