### PR TITLE
Update x86_64 requirement from 0.13.1 to 0.13.2

### DIFF
--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -337,9 +337,9 @@ struct ModeData<'info> {
 #[repr(u32)]
 pub enum PixelFormat {
     /// Each pixel is 32-bit long, with 24-bit RGB, and the last byte is reserved.
-    RGB = 0,
+    Rgb = 0,
     /// Each pixel is 32-bit long, with 24-bit BGR, and the last byte is reserved.
-    BGR,
+    Bgr,
     /// Custom pixel format, check the associated bitmask.
     Bitmask,
     /// The graphics mode does not support drawing directly to the frame buffer.

--- a/src/proto/loaded_image/device_path.rs
+++ b/src/proto/loaded_image/device_path.rs
@@ -24,10 +24,10 @@ pub struct DevicePath {
 #[derive(Debug)]
 pub enum DeviceType {
     Hardware = 0x01,
-    ACPI = 0x02,
+    Acpi = 0x02,
     Messaging = 0x03,
     Media = 0x04,
-    BIOSBootSpec = 0x05,
+    BiosBootSpec = 0x05,
     End = 0x7F,
 }
 

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -55,7 +55,7 @@ pub struct ProcessorInformation {
     /// Flags indicating BSP, enabled and healthy status.
     status_flag: StatusFlag,
     /// Physical location of the processor.
-    pub location: CPUPhysicalLocation,
+    pub location: CpuPhysicalLocation,
 }
 
 impl ProcessorInformation {
@@ -79,7 +79,7 @@ impl ProcessorInformation {
 /// Information about physical location of the processor.
 #[repr(C)]
 #[derive(Default, Debug)]
-pub struct CPUPhysicalLocation {
+pub struct CpuPhysicalLocation {
     /// Zero-based physical package number that identifies
     /// the cartridge of the processor.
     pub package: u32,
@@ -93,19 +93,19 @@ pub struct CPUPhysicalLocation {
 #[repr(C)]
 #[unsafe_guid("3fdda605-a76e-4f46-ad29-12f4531b3d08")]
 #[derive(Protocol)]
-pub struct MPServices {
+pub struct MpServices {
     get_number_of_processors: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         number_of_processors: *mut usize,
         number_of_enabled_processors: *mut usize,
     ) -> Status,
     get_processor_info: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         processor_number: usize,
         processor_info_buffer: *mut ProcessorInformation,
     ) -> Status,
     startup_all_aps: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         procedure: Procedure,
         single_thread: bool,
         wait_event: *mut c_void,
@@ -114,7 +114,7 @@ pub struct MPServices {
         failed_cpu_list: *mut *mut usize,
     ) -> Status,
     startup_this_ap: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         procedure: Procedure,
         processor_number: usize,
         wait_event: *mut c_void,
@@ -123,20 +123,20 @@ pub struct MPServices {
         finished: *mut bool,
     ) -> Status,
     switch_bsp: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         processor_number: usize,
         enable_old_bsp: bool,
     ) -> Status,
     enable_disable_ap: extern "efiapi" fn(
-        this: *const MPServices,
+        this: *const MpServices,
         processor_number: usize,
         enable_ap: bool,
         health_flag: *const u32,
     ) -> Status,
-    who_am_i: extern "efiapi" fn(this: *const MPServices, processor_number: *mut usize) -> Status,
+    who_am_i: extern "efiapi" fn(this: *const MpServices, processor_number: *mut usize) -> Status,
 }
 
-impl MPServices {
+impl MpServices {
     /// Retrieves the number of logical processors and the number of enabled logical processors in the system.
     pub fn get_number_of_processors(&self) -> Result<ProcessorCount> {
         let mut total: usize = 0;

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4.11", default-features = false }
 cfg-if = "1.0.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = "0.13.1"
+x86_64 = "0.13.2"
 
 [features]
 # Enable QEMU-specific functionality

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -64,8 +64,8 @@ fn draw_fb(gop: &mut GraphicsOutput) {
         fb.write_value(pixel_base, [rgb[2], rgb[1], rgb[0]]);
     }
     let write_pixel: PixelWriter = match mi.pixel_format() {
-        PixelFormat::RGB => write_pixel_rgb,
-        PixelFormat::BGR => write_pixel_bgr,
+        PixelFormat::Rgb => write_pixel_rgb,
+        PixelFormat::Bgr => write_pixel_bgr,
         _ => {
             info!("This pixel format is not supported by the drawing demo");
             return;

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -1,13 +1,13 @@
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
-use uefi::proto::pi::mp::MPServices;
+use uefi::proto::pi::mp::MpServices;
 use uefi::table::boot::BootServices;
 use uefi::Status;
 
 pub fn test(bt: &BootServices) {
     info!("Running UEFI multi-processor services protocol test");
-    if let Ok(mp_support) = bt.locate_protocol::<MPServices>() {
+    if let Ok(mp_support) = bt.locate_protocol::<MpServices>() {
         let mp_support = mp_support
             .expect("Warnings encountered while opening multi-processor services protocol");
         let mp_support = unsafe { &mut *mp_support.get() };
@@ -23,7 +23,7 @@ pub fn test(bt: &BootServices) {
     }
 }
 
-fn test_get_number_of_processors(mps: &MPServices) {
+fn test_get_number_of_processors(mps: &MpServices) {
     let proc_count = mps.get_number_of_processors().unwrap().unwrap();
 
     // There should be exactly 3 CPUs
@@ -33,7 +33,7 @@ fn test_get_number_of_processors(mps: &MPServices) {
     assert_eq!(proc_count.total, proc_count.enabled);
 }
 
-fn test_get_processor_info(mps: &MPServices) {
+fn test_get_processor_info(mps: &MpServices) {
     // Disable second CPU for this test
     mps.enable_disable_ap(1, false, None).unwrap().unwrap();
 
@@ -71,7 +71,7 @@ extern "efiapi" fn proc_wait_100ms(arg: *mut c_void) {
     bt.stall(100_000);
 }
 
-fn test_startup_all_aps(mps: &MPServices, bt: &BootServices) {
+fn test_startup_all_aps(mps: &MpServices, bt: &BootServices) {
     // Ensure that APs start up
     let counter = AtomicUsize::new(0);
     let counter_ptr: *mut c_void = &counter as *const _ as *mut _;
@@ -91,7 +91,7 @@ fn test_startup_all_aps(mps: &MPServices, bt: &BootServices) {
     assert_eq!(ret.map_err(|err| err.status()), Err(Status::TIMEOUT));
 }
 
-fn test_startup_this_ap(mps: &MPServices, bt: &BootServices) {
+fn test_startup_this_ap(mps: &MpServices, bt: &BootServices) {
     // Ensure that each AP starts up
     let counter = AtomicUsize::new(0);
     let counter_ptr: *mut c_void = &counter as *const _ as *mut _;
@@ -111,7 +111,7 @@ fn test_startup_this_ap(mps: &MPServices, bt: &BootServices) {
     }
 }
 
-fn test_enable_disable_ap(mps: &MPServices) {
+fn test_enable_disable_ap(mps: &MpServices) {
     // Disable second CPU
     mps.enable_disable_ap(1, false, None).unwrap().unwrap();
 
@@ -139,7 +139,7 @@ fn test_enable_disable_ap(mps: &MPServices) {
     assert_eq!(cpu1.is_healthy(), true);
 }
 
-fn test_switch_bsp_and_who_am_i(mps: &MPServices) {
+fn test_switch_bsp_and_who_am_i(mps: &MpServices) {
     // This test breaks CI. See #103.
     if cfg!(feature = "ci") {
         return;


### PR DESCRIPTION
This is needed because nightly removed the const_in_array_repeat_expressions feature.