### PR TITLE
Add helper function for retrieving the boot FS

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1,8 +1,11 @@
 //! UEFI services available during boot.
 
 use super::Header;
+use crate::proto::{
+    loaded_image::{DevicePath, LoadedImage},
+    Protocol,
+};
 use crate::{data_types::Align, proto::media::fs::SimpleFileSystem};
-use crate::proto::{loaded_image::{DevicePath, LoadedImage}, Protocol};
 use crate::{Event, Guid, Handle, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::vec::Vec;
@@ -565,18 +568,24 @@ impl BootServices {
     ///
     /// You can retrieve the SFS protocol associated with the boot partition
     /// by passing the image handle received by the UEFI entry point to this function.
-    pub fn get_image_file_system(&self, image_handle: Handle) -> Result<&UnsafeCell<SimpleFileSystem>> {
-        let loaded_image = self.handle_protocol::<LoadedImage>(image_handle)?
+    pub fn get_image_file_system(
+        &self,
+        image_handle: Handle,
+    ) -> Result<&UnsafeCell<SimpleFileSystem>> {
+        let loaded_image = self
+            .handle_protocol::<LoadedImage>(image_handle)?
             .expect("Failed to retrieve `LoadedImage` protocol from handle");
         let loaded_image = unsafe { &*loaded_image.get() };
 
         let device_handle = loaded_image.device();
 
-        let device_path = self.handle_protocol::<DevicePath>(device_handle)?
+        let device_path = self
+            .handle_protocol::<DevicePath>(device_handle)?
             .expect("Failed to retrieve `DevicePath` protocol from image's device handle");
         let device_path = unsafe { &mut *device_path.get() };
 
-        let device_handle = self.locate_device_path::<SimpleFileSystem>(device_path)?
+        let device_handle = self
+            .locate_device_path::<SimpleFileSystem>(device_path)?
             .expect("Failed to locate `SimpleFileSystem` protocol on device path");
 
         self.handle_protocol::<SimpleFileSystem>(device_handle)

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1,8 +1,8 @@
 //! UEFI services available during boot.
 
 use super::Header;
-use crate::data_types::Align;
-use crate::proto::{loaded_image::DevicePath, Protocol};
+use crate::{data_types::Align, proto::media::fs::SimpleFileSystem};
+use crate::proto::{loaded_image::{DevicePath, LoadedImage}, Protocol};
 use crate::{Event, Guid, Handle, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::vec::Vec;
@@ -558,6 +558,28 @@ impl BootServices {
         status1
             .into_with_val(|| buffer)
             .map(|completion| completion.with_status(status2))
+    }
+
+    /// Retrieves the `SimpleFileSystem` protocol associated with
+    /// the device the given image was loaded from.
+    ///
+    /// You can retrieve the SFS protocol associated with the boot partition
+    /// by passing the image handle received by the UEFI entry point to this function.
+    pub fn get_image_file_system(&self, image_handle: Handle) -> Result<&UnsafeCell<SimpleFileSystem>> {
+        let loaded_image = self.handle_protocol::<LoadedImage>(image_handle)?
+            .expect("Failed to retrieve `LoadedImage` protocol from handle");
+        let loaded_image = unsafe { &*loaded_image.get() };
+
+        let device_handle = loaded_image.device();
+
+        let device_path = self.handle_protocol::<DevicePath>(device_handle)?
+            .expect("Failed to retrieve `DevicePath` protocol from image's device handle");
+        let device_path = unsafe { &mut *device_path.get() };
+
+        let device_handle = self.locate_device_path::<SimpleFileSystem>(device_path)?
+            .expect("Failed to locate `SimpleFileSystem` protocol on device path");
+
+        self.handle_protocol::<SimpleFileSystem>(device_handle)
     }
 }
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -34,6 +34,12 @@ fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
 
     // Test all the boot services.
     let bt = st.boot_services();
+
+    // Try retrieving a handle to the file system the image was booted from.
+    bt.get_image_file_system(image)
+        .expect("Failed to retrieve boot file system")
+        .unwrap();
+
     boot::test(bt);
 
     // Test all the supported protocols.


### PR DESCRIPTION
Prevents issues like #175, since getting the boot device is a common task.