### PR TITLE
Fix typo in regular.rs

### DIFF
--- a/src/proto/media/file/regular.rs
+++ b/src/proto/media/file/regular.rs
@@ -3,7 +3,7 @@ use crate::{Result, Status};
 
 /// A `FileHandle` that is also a regular (data) file.
 ///
-/// Use `FileHandle::into_kind` or `RegularFile::new` to create a `RegularFile`.
+/// Use `FileHandle::into_type` or `RegularFile::new` to create a `RegularFile`.
 /// In addition to supporting the normal `File` operations, `RegularFile`
 /// supports direct reading and writing.
 #[repr(transparent)]


### PR DESCRIPTION
- `into_kind` doesn't exist. should be typo for `into_type`