### PR TITLE
Expose NamedFileProtocolInfo's Header types

### DIFF
--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -20,7 +20,8 @@ use core::mem;
 use core::ptr;
 
 pub use self::info::{
-    FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi,
+    FileInfo, FileInfoHeader, FileProtocolInfo, FileSystemInfo, FileSystemInfoHeader,
+    FileSystemVolumeLabel, FileSystemVolumeLabelHeader, FromUefi,
     NamedFileProtocolInfo,
 };
 pub use self::{dir::Directory, regular::RegularFile};

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -21,8 +21,7 @@ use core::ptr;
 
 pub use self::info::{
     FileInfo, FileInfoHeader, FileProtocolInfo, FileSystemInfo, FileSystemInfoHeader,
-    FileSystemVolumeLabel, FileSystemVolumeLabelHeader, FromUefi,
-    NamedFileProtocolInfo,
+    FileSystemVolumeLabel, FileSystemVolumeLabelHeader, FromUefi, NamedFileProtocolInfo,
 };
 pub use self::{dir::Directory, regular::RegularFile};
 


### PR DESCRIPTION
## Motivation
- To get file info, we have to pass buffer which has sufficient capacity
  * https://github.com/rust-osdev/uefi-rs/blob/master/src/proto/media/file/mod.rs#L115
- When the file-name is known, we can allocate the buffer of exactly required size
  * that is, `size_of::<Header>() + name_length`
- It'd be helpful to expose Header types so that we can calculate the buffer size based on that