### PR TITLE
Fix the build error on the latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
-#![feature(const_fn)]
 #![feature(const_panic)]
 #![no_std]
 // Enable some additional warnings and lints.

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -18,7 +18,7 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 uefi = { version = "0.8.0", features = ["alloc", "logger"] }
 log = { version = "0.4.11", default-features = false }
 cfg-if = "1.0.0"
-qemu-exit = "1.0.2"
+qemu-exit = "2.0.0"
 
 [features]
 # Enable QEMU-specific functionality

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "0.4.11", default-features = false }
 # does not automatically get enabled. Therefore, we have to manually add support for
 # the memory functions.
 rlibc = "1.0.0"
-qemu-exit = "1.0.2"
+qemu-exit = "2.0.0"
 
 [features]
 # This feature should only be enabled in our CI, it disables some tests


### PR DESCRIPTION
The `qemu-exit` crate also must be fixed to build this crate with the latest nightly. I sent a patch (https://github.com/andre-richter/qemu-exit/pull/18).