### PR TITLE
Remove const_fn feature as its removed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 #![feature(try_trait)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
-#![feature(const_fn)]
 #![feature(const_panic)]
 #![no_std]
 // Enable some additional warnings and lints.


### PR DESCRIPTION
This pull request removes the `const_fn` feature as its removed. This should most of the project's build failing on the latest version of nightly.