### PR TITLE
Add shim lock protocol

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -32,3 +32,4 @@ pub mod device_path;
 pub mod loaded_image;
 pub mod media;
 pub mod pi;
+pub mod shim;

--- a/src/proto/shim/mod.rs
+++ b/src/proto/shim/mod.rs
@@ -1,0 +1,39 @@
+//! Shim lock protocol.
+
+use crate::proto::Protocol;
+use crate::result::Error;
+use crate::{unsafe_guid, Result, Status};
+use core::convert::TryInto;
+
+/// The Shim lock protocol.
+///
+/// This protocol is not part of the UEFI specification, but is
+/// installed by the [Shim bootloader](https://github.com/rhboot/shim)
+/// which is commonly used by Linux distributions to support UEFI
+/// Secure Boot. Shim is built with an embedded certificate that is
+/// used to validate another EFI application before running it. That
+/// application may itself be a bootloader that needs to validate
+/// another EFI application before running it, and the shim lock
+/// protocol exists to support that.
+#[repr(C)]
+#[unsafe_guid("605dab50-e046-4300-abb6-3dd810dd8b23")]
+#[derive(Protocol)]
+pub struct ShimLock {
+    verify: extern "efiapi" fn(buffer: *const u8, size: u32) -> Status,
+}
+
+impl ShimLock {
+    /// Verify that an EFI application is signed by the certificate
+    /// embedded in shim.
+    ///
+    /// The buffer's size must fit in a `u32`; if that condition is not
+    /// met then a `BAD_BUFFER_SIZE` error will be returned and the shim
+    /// lock protocol will not be called.
+    pub fn verify(&self, buffer: &[u8]) -> Result {
+        let size: u32 = buffer
+            .len()
+            .try_into()
+            .map_err(|_| Error::from(Status::BAD_BUFFER_SIZE))?;
+        (self.verify)(buffer.as_ptr(), size).into()
+    }
+}

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -13,6 +13,7 @@ pub fn test(st: &SystemTable<Boot>) {
     debug::test(bt);
     media::test(bt);
     pi::test(bt);
+    shim::test(bt);
 }
 
 fn find_protocol(bt: &BootServices) {
@@ -32,3 +33,4 @@ mod console;
 mod debug;
 mod media;
 mod pi;
+mod shim;

--- a/uefi-test-runner/src/proto/shim.rs
+++ b/uefi-test-runner/src/proto/shim.rs
@@ -1,0 +1,20 @@
+use uefi::proto::shim::ShimLock;
+use uefi::table::boot::BootServices;
+
+pub fn test(bt: &BootServices) {
+    info!("Running shim lock protocol test");
+
+    if let Ok(shim_lock) = bt.locate_protocol::<ShimLock>() {
+        let shim_lock = shim_lock.expect("Warnings encountered while opening shim lock protocol");
+        let shim_lock = unsafe { &*shim_lock.get() };
+
+        // An empty buffer should definitely be invalid, so expect
+        // shim to reject it.
+        let buffer = [];
+        shim_lock
+            .verify(&buffer)
+            .expect_err("shim failed to reject an invalid application");
+    } else {
+        info!("Shim lock protocol is not supported");
+    }
+}


### PR DESCRIPTION
This protocol is not part of the UEFI specification, but is installed
by the [Shim bootloader](https://github.com/rhboot/shim) which is
commonly used by Linux distributions to support UEFI Secure Boot. Shim
is built with an embedded certificate that is used to validate another
EFI application before running it. That application may itself be a
bootloader that needs to validate another EFI application before
running it, and the shim lock protocol exists to support that.