### PR TITLE
shim: ShimLock protocol uses "sysv64" function ABI

### DIFF
--- a/src/proto/shim/mod.rs
+++ b/src/proto/shim/mod.rs
@@ -19,7 +19,7 @@ use core::convert::TryInto;
 #[unsafe_guid("605dab50-e046-4300-abb6-3dd810dd8b23")]
 #[derive(Protocol)]
 pub struct ShimLock {
-    verify: extern "efiapi" fn(buffer: *const u8, size: u32) -> Status,
+    verify: extern "sysv64" fn(buffer: *const u8, size: u32) -> Status,
 }
 
 impl ShimLock {

--- a/src/proto/shim/mod.rs
+++ b/src/proto/shim/mod.rs
@@ -4,6 +4,37 @@ use crate::proto::Protocol;
 use crate::result::Error;
 use crate::{unsafe_guid, Result, Status};
 use core::convert::TryInto;
+use core::ffi::c_void;
+use core::mem::MaybeUninit;
+
+// The `PE_COFF_LOADER_IMAGE_CONTEXT` type. None of our methods need to inspect
+// the fields of this struct, we just need to make sure it is the right size.
+#[repr(C)]
+struct Context {
+    _image_address: u64,
+    _image_size: u64,
+    _entry_point: u64,
+    _size_of_headers: usize,
+    _image_type: u16,
+    _number_of_sections: u16,
+    _section_alignment: u32,
+    _first_section: *const c_void,
+    _reloc_dir: *const c_void,
+    _sec_dir: *const c_void,
+    _number_of_rva_and_sizes: u64,
+    _pe_hdr: *const c_void,
+}
+
+const SHA1_DIGEST_SIZE: usize = 20;
+const SHA256_DIGEST_SIZE: usize = 32;
+
+/// Authenticode hashes of some UEFI application
+pub struct Hashes {
+    /// SHA256 Authenticode Digest
+    pub sha256: [u8; SHA256_DIGEST_SIZE],
+    /// SHA1 Authenticode Digest
+    pub sha1: [u8; SHA1_DIGEST_SIZE],
+}
 
 /// The Shim lock protocol.
 ///
@@ -20,6 +51,14 @@ use core::convert::TryInto;
 #[derive(Protocol)]
 pub struct ShimLock {
     verify: extern "sysv64" fn(buffer: *const u8, size: u32) -> Status,
+    hash: extern "sysv64" fn(
+        buffer: *const u8,
+        size: u32,
+        context: *mut Context,
+        sha256: *mut [u8; SHA256_DIGEST_SIZE],
+        sha1: *mut [u8; SHA1_DIGEST_SIZE],
+    ) -> Status,
+    context: extern "sysv64" fn(buffer: *const u8, size: u32, context: *mut Context) -> Status,
 }
 
 impl ShimLock {
@@ -35,5 +74,28 @@ impl ShimLock {
             .try_into()
             .map_err(|_| Error::from(Status::BAD_BUFFER_SIZE))?;
         (self.verify)(buffer.as_ptr(), size).into()
+    }
+    /// Compute the Authenticode Hash of the provided EFI application.
+    ///
+    /// The buffer's size must fit in a `u32`; if that condition is not
+    /// met then a `BAD_BUFFER_SIZE` error will be returned and the shim
+    /// lock protocol will not be called.
+    pub fn hash(&self, buffer: &[u8], hashes: &mut Hashes) -> Result {
+        let ptr: *const u8 = buffer.as_ptr();
+        let size: u32 = buffer
+            .len()
+            .try_into()
+            .map_err(|_| Error::from(Status::BAD_BUFFER_SIZE))?;
+
+        let mut context = MaybeUninit::<Context>::uninit();
+        let comp1 = (self.context)(ptr, size, context.as_mut_ptr())?;
+        let comp2 = (self.hash)(
+            ptr,
+            size,
+            context.as_mut_ptr(),
+            &mut hashes.sha256,
+            &mut hashes.sha1,
+        )?;
+        Ok(comp1.with_status(comp2.status()))
     }
 }

--- a/src/result/status.rs
+++ b/src/result/status.rs
@@ -197,6 +197,12 @@ impl FromResidual for Status {
     }
 }
 
+impl<T> FromResidual<StatusResidual> for Result<T, ()> {
+    fn from_residual(r: StatusResidual) -> Self {
+        Err(Status(r.0.into()).into())
+    }
+}
+
 impl FromResidual<core::result::Result<Infallible, Error>> for Status {
     fn from_residual(r: core::result::Result<Infallible, Error>) -> Self {
         match r {


### PR DESCRIPTION
See the systemd-boot declaration:
  https://github.com/systemd/systemd/blob/5efbd0bf897a990ebe43d7dc69141d87c404ac9a/src/boot/efi/shim.c#L23-L31

This is because the shim is built with sysv ABI funcs by defualt.

This PR also adds bindings to the hashing functionality of the shim. For more information see:
  - [The shim's protocol declaration](https://github.com/rhboot/shim/blob/20e4d9486fcae54ee44d2323ae342ffe68c920e6/shim.h#L194-L223)
  - [The shim's context declaration](https://github.com/rhboot/shim/blob/20e4d9486fcae54ee44d2323ae342ffe68c920e6/include/peimage.h#L781)

Signed-off-by: Joe Richey <joerichey@google.com>