### PR TITLE
Make the `qemu-exit` dependency optional

### DIFF
--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -18,9 +18,9 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 uefi = { version = "0.11.0", features = ["alloc", "logger"] }
 log = { version = "0.4.11", default-features = false }
 cfg-if = "1.0.0"
-qemu-exit = "2.0.0"
+qemu-exit = { version = "2.0.0", optional = true }
 
 [features]
 # Enable QEMU-specific functionality
-qemu = []
+qemu = ["qemu-exit"]
 no_panic_handler = []


### PR DESCRIPTION
Makes the `qemu-exit` dependency of the `uefi-services` crate depend on the `qemu` optional feature.

Fixes #228 