### PR TITLE
Derive Debug for CharConversionError

### DIFF
--- a/src/data_types/chars.rs
+++ b/src/data_types/chars.rs
@@ -7,6 +7,7 @@ use core::convert::{TryFrom, TryInto};
 use core::fmt;
 
 /// Character conversion error
+#[derive(Clone, Copy, Debug)]
 pub struct CharConversionError;
 
 /// A Latin-1 character


### PR DESCRIPTION
This is needed to call `.unwrap()` on a `Result<_, CharConversionError>`.
For example: `Char16::try_from(c).unwrap()`.