### PR TITLE
Implement image loading/starting

### DIFF
--- a/src/proto/loaded_image.rs
+++ b/src/proto/loaded_image.rs
@@ -65,6 +65,20 @@ impl LoadedImage {
         }
     }
 
+    /// Set the load options for the image. This can be used prior to
+    /// calling `BootServices.start_image` to control the command line
+    /// passed to the image.
+    ///
+    /// # Safety
+    ///
+    /// This function takes `options` as a raw pointer because the
+    /// load options data is not owned by `LoadedImage`. The caller
+    /// must ensure that the memory lives long enough.
+    pub unsafe fn set_load_options(&mut self, options: *const Char16, size: u32) {
+        self.load_options = options;
+        self.load_options_size = size;
+    }
+
     /// Returns the base address and the size in bytes of the loaded image.
     pub fn info(&self) -> (usize, u64) {
         (self.image_base, self.image_size)

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -5,7 +5,7 @@ use crate::data_types::Align;
 use crate::proto::{device_path::DevicePath, Protocol};
 #[cfg(feature = "exts")]
 use crate::proto::{loaded_image::LoadedImage, media::fs::SimpleFileSystem};
-use crate::{Event, Guid, Handle, Result, Status};
+use crate::{Char16, Event, Guid, Handle, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::vec::Vec;
 use bitflags::bitflags;
@@ -83,10 +83,21 @@ pub struct BootServices {
     install_configuration_table: usize,
 
     // Image services
-    load_image: usize,
-    start_image: usize,
+    load_image: unsafe extern "efiapi" fn(
+        boot_policy: u8,
+        parent_image_handle: Handle,
+        device_path: *const DevicePath,
+        source_buffer: *const u8,
+        source_size: usize,
+        *mut Handle,
+    ) -> Status,
+    start_image: unsafe extern "efiapi" fn(
+        image_handle: Handle,
+        exit_data_size: *mut usize,
+        exit_data: &mut *mut Char16,
+    ) -> Status,
     exit: usize,
-    unload_image: usize,
+    unload_image: extern "efiapi" fn(image_handle: Handle) -> Status,
     exit_boot_services:
         unsafe extern "efiapi" fn(image_handle: Handle, map_key: MemoryMapKey) -> Status,
 
@@ -429,6 +440,44 @@ impl BootServices {
             let mut device_path_ptr = device_path as *mut DevicePath;
             (self.locate_device_path)(&P::GUID, &mut device_path_ptr, &mut handle)
                 .into_with_val(|| handle)
+        }
+    }
+
+    /// Load an EFI image from a buffer.
+    pub fn load_image_from_buffer(
+        &self,
+        parent_image_handle: Handle,
+        source_buffer: &[u8],
+    ) -> Result<Handle> {
+        unsafe {
+            let boot_policy = 0;
+            let device_path = ptr::null();
+            let source_size = source_buffer.len();
+            let mut image_handle = Handle::uninitialized();
+            (self.load_image)(
+                boot_policy,
+                parent_image_handle,
+                device_path,
+                source_buffer.as_ptr(),
+                source_size,
+                &mut image_handle,
+            )
+            .into_with_val(|| image_handle)
+        }
+    }
+
+    /// Unload an EFI image.
+    pub fn unload_image(&self, image_handle: Handle) -> Result {
+        (self.unload_image)(image_handle).into()
+    }
+
+    /// Transfer control to a loaded image's entry point.
+    pub fn start_image(&self, image_handle: Handle) -> Result {
+        unsafe {
+            // TODO: implement returning exit data to the caller.
+            let mut exit_data_size: usize = 0;
+            let mut exit_data: *mut Char16 = ptr::null_mut();
+            (self.start_image)(image_handle, &mut exit_data_size, &mut exit_data).into()
         }
     }
 


### PR DESCRIPTION
This adds code to load, unload, and start images, as well as set the
command-line of the image.

I didn't add anything to uefi-test-runner for this since to really
test it you need a valid EFI binary to load, but I tested it in a
separate project and verified it can load a Linux kernel that has the
EFI stub built in.

A couple things are left unimplemented here:

- LoadImage supports loading from either a DevicePath or from a
  buffer. Only the latter method is implemented here.

- StartImage can provide exit data if the called image exits. I
  haven't implemented passing that back to the caller for now since I
  don't have a use case to test it against.