### PR TITLE
Make using the `stdio` handles require a mutable ref

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,7 +16,7 @@ The following steps allow you to build a simple UEFI app.
   use uefi::prelude::*;
 
   #[entry]
-  fn efi_main(handle: Handle, system_table: SystemTable<Boot>) -> Status;
+  fn efi_main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status;
   ```
   You will also want to add a dependency to the [`rlibc`](https://docs.rs/rlibc/) crate,
   to avoid linking errors.

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -73,22 +73,21 @@ impl<View: SystemTableView> SystemTable<View> {
 
 // These parts of the UEFI System Table interface may only be used until boot
 // services are exited and hardware control is handed over to the OS loader
-#[allow(clippy::mut_from_ref)]
 impl SystemTable<Boot> {
     /// Returns the standard input protocol.
-    pub fn stdin(&self) -> &mut text::Input {
+    pub fn stdin(&mut self) -> &mut text::Input {
         unsafe { &mut *self.table.stdin }
     }
 
     /// Returns the standard output protocol.
-    pub fn stdout(&self) -> &mut text::Output {
-        let stdout_ptr = self.table.stdout as *const _ as *mut _;
+    pub fn stdout(&mut self) -> &mut text::Output {
+        let stdout_ptr = self.table.stdout as *mut () as *mut _;
         unsafe { &mut *stdout_ptr }
     }
 
     /// Returns the standard error protocol.
-    pub fn stderr(&self) -> &mut text::Output {
-        let stderr_ptr = self.table.stderr as *const _ as *mut _;
+    pub fn stderr(&mut self) -> &mut text::Output {
+        let stderr_ptr = self.table.stderr as *mut () as *mut _;
         unsafe { &mut *stderr_ptr }
     }
 

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -81,14 +81,12 @@ impl SystemTable<Boot> {
 
     /// Returns the standard output protocol.
     pub fn stdout(&mut self) -> &mut text::Output {
-        let stdout_ptr = self.table.stdout as *mut () as *mut _;
-        unsafe { &mut *stdout_ptr }
+        unsafe { &mut *self.table.stdout.cast() }
     }
 
     /// Returns the standard error protocol.
     pub fn stderr(&mut self) -> &mut text::Output {
-        let stderr_ptr = self.table.stderr as *mut () as *mut _;
-        unsafe { &mut *stderr_ptr }
+        unsafe { &mut *self.table.stderr.cast() }
     }
 
     /// Access runtime services

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -60,7 +60,7 @@ pub fn system_table() -> NonNull<SystemTable<Boot>> {
 ///
 /// This must be called as early as possible,
 /// before trying to use logging or memory allocation capabilities.
-pub fn init(st: &SystemTable<Boot>) -> Result {
+pub fn init(st: &mut SystemTable<Boot>) -> Result {
     unsafe {
         // Avoid double initialization.
         if SYSTEM_TABLE.is_some() {
@@ -71,8 +71,8 @@ pub fn init(st: &SystemTable<Boot>) -> Result {
         SYSTEM_TABLE = Some(st.unsafe_clone());
 
         // Setup logging and memory allocation
-        let boot_services = st.boot_services();
         init_logger(st);
+        let boot_services = st.boot_services();
         uefi::alloc::init(boot_services);
 
         // Schedule these tools to be disabled on exit from UEFI boot services
@@ -90,7 +90,7 @@ pub fn init(st: &SystemTable<Boot>) -> Result {
 ///
 /// This is unsafe because you must arrange for the logger to be reset with
 /// disable() on exit from UEFI boot services.
-unsafe fn init_logger(st: &SystemTable<Boot>) {
+unsafe fn init_logger(st: &mut SystemTable<Boot>) {
     let stdout = st.stdout();
 
     // Construct the logger.

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -20,9 +20,9 @@ mod boot;
 mod proto;
 
 #[entry]
-fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
+fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
-    uefi_services::init(&st).expect_success("Failed to initialize utilities");
+    uefi_services::init(&mut st).expect_success("Failed to initialize utilities");
 
     // Reset the console before running all the other tests.
     st.stdout()
@@ -43,7 +43,7 @@ fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
     boot::test(bt);
 
     // Test all the supported protocols.
-    proto::test(&st);
+    proto::test(&mut st);
 
     // TODO: test the runtime services.
     // These work before boot services are exited, but we'd probably want to
@@ -107,7 +107,7 @@ fn check_screenshot(bt: &BootServices, name: &str) {
     }
 }
 
-fn shutdown(image: uefi::Handle, st: SystemTable<Boot>) -> ! {
+fn shutdown(image: uefi::Handle, mut st: SystemTable<Boot>) -> ! {
     use uefi::table::runtime::ResetType;
 
     // Get our text output back.

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,6 +1,6 @@
 use uefi::prelude::*;
 
-pub fn test(st: &SystemTable<Boot>) {
+pub fn test(st: &mut SystemTable<Boot>) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -2,14 +2,14 @@ use uefi::prelude::*;
 
 use uefi::proto;
 
-pub fn test(st: &SystemTable<Boot>) {
+pub fn test(st: &mut SystemTable<Boot>) {
     info!("Testing various protocols");
 
-    let bt = st.boot_services();
+    console::test(st);
 
+    let bt = st.boot_services();
     find_protocol(bt);
 
-    console::test(st);
     debug::test(bt);
     media::test(bt);
     pi::test(bt);


### PR DESCRIPTION
Updates the system table's `stdin`/`stdout`/`stderr` methods require a `&mut` reference.

Fixes #239 