### PR TITLE
Fix AArch64 build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,27 @@ on:
     - cron:  '0 0 * * 0-6'
 
 jobs:
+  build:
+    name: Build on AArch64
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          components: rust-src
+      # TODO: cache Rust binaries
+
+    - name: Build
+      run: ./build.py build --target aarch64
+      working-directory: ./uefi-test-runner
+
   build_and_test:
-    name: Build and run tests
+    name: Build and run tests on x86_64
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/uefi-test-runner/aarch64-unknown-uefi.json
+++ b/uefi-test-runner/aarch64-unknown-uefi.json
@@ -18,7 +18,9 @@
       "/machine:arm64"
     ]
   },
-  "stack_probes": true,
+  "stack-probes": {
+    "kind": "call"
+  },
   "target-c-int-width": "32",
   "target-endian": "little",
   "target-pointer-width": "64"

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -13,6 +13,13 @@ pub fn test(st: &mut SystemTable<Boot>) {
     debug::test(bt);
     media::test(bt);
     pi::test(bt);
+
+    #[cfg(any(
+        target_arch = "i386",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64"
+    ))]
     shim::test(bt);
 }
 
@@ -33,4 +40,10 @@ mod console;
 mod debug;
 mod media;
 mod pi;
+#[cfg(any(
+    target_arch = "i386",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64"
+))]
 mod shim;


### PR DESCRIPTION
Fixes #242 by choosing the right calling convention for Shim functions based on the target architecture.

Also updates the CI script to build the code for AArch64 as well, to prevent future regressions.