### PR TITLE
Better logger that includes filename and line

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -56,7 +56,13 @@ impl<'boot> log::Log for Logger {
     fn log(&self, record: &log::Record) {
         if let Some(mut ptr) = self.writer {
             let writer = unsafe { ptr.as_mut() };
-            let result = DecoratedLog::write(writer, record.level(), record.args());
+            let result = DecoratedLog::write(
+                writer,
+                record.level(),
+                record.args(),
+                record.file().unwrap_or("<unknown file>"),
+                record.line().unwrap_or(0),
+            );
 
             // Some UEFI implementations, such as the one used by VirtualBox,
             // may intermittently drop out some text from SimpleTextOutput and
@@ -97,25 +103,29 @@ unsafe impl Send for Logger {}
 ///
 /// Therefore, we need to inject ourselves in the middle of the fmt::Write
 /// machinery and intercept the strings that it sends to the Writer.
-struct DecoratedLog<'writer, W: fmt::Write> {
+struct DecoratedLog<'writer, 'a, W: fmt::Write> {
     writer: &'writer mut W,
     log_level: log::Level,
     at_line_start: bool,
+    file: &'a str,
+    line: u32,
 }
 
-impl<'writer, W: fmt::Write> DecoratedLog<'writer, W> {
+impl<'writer, 'a, W: fmt::Write> DecoratedLog<'writer, 'a, W> {
     // Call this method to print a level-annotated log
-    fn write(writer: &'writer mut W, log_level: log::Level, args: &fmt::Arguments) -> fmt::Result {
+    fn write(writer: &'writer mut W, log_level: log::Level, args: &fmt::Arguments, file: &'a str, line: u32) -> fmt::Result {
         let mut decorated_writer = Self {
             writer,
             log_level,
             at_line_start: true,
+            file,
+            line,
         };
         writeln!(decorated_writer, "{}", *args)
     }
 }
 
-impl<'writer, W: fmt::Write> fmt::Write for DecoratedLog<'writer, W> {
+impl<'writer, 'a, W: fmt::Write> fmt::Write for DecoratedLog<'writer, 'a, W> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         // Split the input string into lines
         let mut lines = s.lines();
@@ -125,7 +135,7 @@ impl<'writer, W: fmt::Write> fmt::Write for DecoratedLog<'writer, W> {
         // beginning of a line of output.
         let first = lines.next().unwrap_or("");
         if self.at_line_start {
-            write!(self.writer, "{}: ", self.log_level)?;
+            write!(self.writer, "[{:>5}]: {:>12}@{:03}: ", self.log_level, self.file, self.line)?;
             self.at_line_start = false;
         }
         write!(self.writer, "{}", first)?;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -113,7 +113,13 @@ struct DecoratedLog<'writer, 'a, W: fmt::Write> {
 
 impl<'writer, 'a, W: fmt::Write> DecoratedLog<'writer, 'a, W> {
     // Call this method to print a level-annotated log
-    fn write(writer: &'writer mut W, log_level: log::Level, args: &fmt::Arguments, file: &'a str, line: u32) -> fmt::Result {
+    fn write(
+        writer: &'writer mut W,
+        log_level: log::Level,
+        args: &fmt::Arguments,
+        file: &'a str,
+        line: u32,
+    ) -> fmt::Result {
         let mut decorated_writer = Self {
             writer,
             log_level,
@@ -135,7 +141,11 @@ impl<'writer, 'a, W: fmt::Write> fmt::Write for DecoratedLog<'writer, 'a, W> {
         // beginning of a line of output.
         let first = lines.next().unwrap_or("");
         if self.at_line_start {
-            write!(self.writer, "[{:>5}]: {:>12}@{:03}: ", self.log_level, self.file, self.line)?;
+            write!(
+                self.writer,
+                "[{:>5}]: {:>12}@{:03}: ",
+                self.log_level, self.file, self.line
+            )?;
             self.at_line_start = false;
         }
         write!(self.writer, "{}", first)?;


### PR DESCRIPTION
I enhanced the logger to include filename and line. What do you think?
![image](https://user-images.githubusercontent.com/5737016/124164441-ed8d1200-daa0-11eb-807b-56d7d48c4724.png)
