### PR TITLE
refactored logger: use arrayvec and original formatting functionality + much simplified code 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 default = []
 alloc = []
 exts = []
-logger = []
+logger = ["arrayvec"]
 # Ignore text output errors in logger as a workaround for firmware issues that
 # were observed on the VirtualBox UEFI implementation (see uefi-rs#121)
 ignore-logger-errors = []
@@ -35,6 +35,8 @@ bitflags = "1.2.1"
 log = { version = "0.4.11", default-features = false }
 ucs2 = "0.3.1"
 uefi-macros = "0.3.2"
+# stack-allocated array (to format strings without heap allocation)
+arrayvec = { version = "0.7.1", default-features = false, optional = true }
 
 [workspace]
 members = [

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -14,7 +14,7 @@
 
 use crate::proto::console::text::Output;
 
-use core::fmt::{self, Write};
+use core::fmt::Write;
 use core::ptr::NonNull;
 
 /// Logging implementation which writes to a UEFI output stream.
@@ -86,7 +86,7 @@ impl<'boot> log::Log for Logger {
             }
 
             // Actually write the data to UEFI stdout.
-            let result = unsafe { self.writer.unwrap().as_mut() }.write_str(buf.as_str());
+            let result = unsafe { ptr.as_mut() }.write_str(buf.as_str());
             if !cfg!(feature = "ignore-logger-errors") {
                 result.unwrap()
             }


### PR DESCRIPTION
When I created the other PR (https://github.com/rust-osdev/uefi-rs/pull/246) I wondered why the logger implementation is so complicated. Of course, we must prevent any heap allocation. Why not use a stack allocated array and let the regular formatter/writer implementation do all the work? I suggest the `arrayvec` crate for this.

I'd love to hear your comments.

POC in my QEMU setup:

![image](https://user-images.githubusercontent.com/5737016/124166557-478ed700-daa3-11eb-8ea1-19aeb4be233d.png)
