### PR TITLE
system table can get debug-formatted (including boot and runtime services)

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -5,7 +5,7 @@
 use core::{ffi::c_void, mem::MaybeUninit};
 
 /// Opaque handle to an UEFI entity (protocol, image...)
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
 pub struct Handle(*mut c_void);
 

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::proto::Protocol;
 use crate::{unsafe_guid, CStr16, Char16, Completion, Result, Status};
 use core::fmt;
+use core::fmt::{Debug, Formatter};
 
 /// Interface for text-based output devices.
 ///
@@ -194,6 +195,35 @@ impl<'boot> fmt::Write for Output<'boot> {
 
         // Flush the remainder of the buffer
         flush_buffer(&mut buf, &mut i)
+    }
+}
+
+impl<'boot> Debug for Output<'boot> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Output")
+            .field("reset (fn ptr)", &(self.reset as *const u64))
+            .field(
+                "output_string (fn ptr)",
+                &(self.output_string as *const u64),
+            )
+            .field("test_string (fn ptr)", &(self.test_string as *const u64))
+            .field("query_mode (fn ptr)", &(self.query_mode as *const u64))
+            .field("set_mode (fn ptr)", &(self.set_mode as *const u64))
+            .field(
+                "set_attribute (fn ptr)",
+                &(self.set_attribute as *const u64),
+            )
+            .field("clear_screen (fn ptr)", &(self.clear_screen as *const u64))
+            .field(
+                "set_cursor_position (fn ptr)",
+                &(self.set_cursor_position as *const u64),
+            )
+            .field(
+                "enable_cursor (fn ptr)",
+                &(self.enable_cursor as *const u64),
+            )
+            .field("data", &self.data)
+            .finish()
     }
 }
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -11,6 +11,7 @@ use alloc_api::vec::Vec;
 use bitflags::bitflags;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
+use core::fmt::{Debug, Formatter};
 use core::mem::{self, MaybeUninit};
 use core::{ptr, slice};
 
@@ -700,6 +701,108 @@ impl BootServices {
 
 impl super::Table for BootServices {
     const SIGNATURE: u64 = 0x5652_4553_544f_4f42;
+}
+
+impl Debug for BootServices {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BootServices")
+            .field("header", &self.header)
+            .field("raise_tpl (fn ptr)", &(self.raise_tpl as *const u64))
+            .field("restore_tpl (fn ptr)", &(self.restore_tpl as *const u64))
+            .field(
+                "allocate_pages (fn ptr)",
+                &(self.allocate_pages as *const u64),
+            )
+            .field(
+                "free_pages (fn ptr)",
+                &(self.free_pages as u64 as *const u64),
+            )
+            .field(
+                "get_memory_map (fn ptr)",
+                &(self.get_memory_map as *const u64),
+            )
+            .field(
+                "allocate_pool (fn ptr)",
+                &(self.allocate_pool as *const u64),
+            )
+            .field("free_pool (fn ptr)", &(self.free_pool as *const u64))
+            .field("create_event (fn ptr)", &(self.create_event as *const u64))
+            .field("set_timer (fn ptr)", &(self.set_timer as *const u64))
+            .field(
+                "wait_for_event (fn ptr)",
+                &(self.wait_for_event as *const u64),
+            )
+            .field("signal_event", &self.signal_event)
+            .field("close_event", &self.close_event)
+            .field("check_event", &self.check_event)
+            .field(
+                "install_protocol_interface",
+                &self.install_protocol_interface,
+            )
+            .field(
+                "reinstall_protocol_interface",
+                &self.reinstall_protocol_interface,
+            )
+            .field(
+                "uninstall_protocol_interface",
+                &self.uninstall_protocol_interface,
+            )
+            .field(
+                "handle_protocol (fn ptr)",
+                &(self.handle_protocol as *const u64),
+            )
+            .field("register_protocol_notify", &self.register_protocol_notify)
+            .field(
+                "locate_handle (fn ptr)",
+                &(self.locate_handle as *const u64),
+            )
+            .field(
+                "locate_device_path (fn ptr)",
+                &(self.locate_device_path as *const u64),
+            )
+            .field(
+                "install_configuration_table",
+                &self.install_configuration_table,
+            )
+            .field("load_image (fn ptr)", &(self.load_image as *const u64))
+            .field("start_image (fn ptr)", &(self.start_image as *const u64))
+            .field("exit", &self.exit)
+            .field("unload_image (fn ptr)", &(self.unload_image as *const u64))
+            .field(
+                "exit_boot_services (fn ptr)",
+                &(self.exit_boot_services as *const u64),
+            )
+            .field("get_next_monotonic_count", &self.get_next_monotonic_count)
+            .field("stall (fn ptr)", &(self.stall as *const u64))
+            .field(
+                "set_watchdog_timer (fn ptr)",
+                &(self.set_watchdog_timer as *const u64),
+            )
+            .field("connect_controller", &self.connect_controller)
+            .field("disconnect_controller", &self.disconnect_controller)
+            .field("open_protocol", &self.open_protocol)
+            .field("close_protocol", &self.close_protocol)
+            .field("open_protocol_information", &self.open_protocol_information)
+            .field("protocols_per_handle", &(self.protocols_per_handle as *const u64))
+            .field("locate_handle_buffer", &self.locate_handle_buffer)
+            .field(
+                "locate_protocol (fn ptr)",
+                &(self.locate_protocol as *const u64),
+            )
+            .field(
+                "install_multiple_protocol_interfaces",
+                &self.install_multiple_protocol_interfaces,
+            )
+            .field(
+                "uninstall_multiple_protocol_interfaces",
+                &self.uninstall_multiple_protocol_interfaces,
+            )
+            .field("calculate_crc32", &self.calculate_crc32)
+            .field("copy_mem (fn ptr)", &(self.copy_mem as *const u64))
+            .field("set_mem (fn ptr)", &(self.set_mem as *const u64))
+            .field("create_event_ex", &self.create_event_ex)
+            .finish()
+    }
 }
 
 newtype_enum! {

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -707,100 +707,124 @@ impl Debug for BootServices {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("BootServices")
             .field("header", &self.header)
-            .field("raise_tpl (fn ptr)", &(self.raise_tpl as *const u64))
-            .field("restore_tpl (fn ptr)", &(self.restore_tpl as *const u64))
+            .field("raise_tpl (fn ptr)", &(self.raise_tpl as *const usize))
+            .field("restore_tpl (fn ptr)", &(self.restore_tpl as *const usize))
             .field(
                 "allocate_pages (fn ptr)",
-                &(self.allocate_pages as *const u64),
+                &(self.allocate_pages as *const usize),
             )
-            .field("free_pages (fn ptr)", &(self.free_pages as *const u64))
+            .field("free_pages (fn ptr)", &(self.free_pages as *const usize))
             .field(
                 "get_memory_map (fn ptr)",
-                &(self.get_memory_map as *const u64),
+                &(self.get_memory_map as *const usize),
             )
             .field(
                 "allocate_pool (fn ptr)",
-                &(self.allocate_pool as *const u64),
+                &(self.allocate_pool as *const usize),
             )
-            .field("free_pool (fn ptr)", &(self.free_pool as *const u64))
-            .field("create_event (fn ptr)", &(self.create_event as *const u64))
-            .field("set_timer (fn ptr)", &(self.set_timer as *const u64))
+            .field("free_pool (fn ptr)", &(self.free_pool as *const usize))
+            .field(
+                "create_event (fn ptr)",
+                &(self.create_event as *const usize),
+            )
+            .field("set_timer (fn ptr)", &(self.set_timer as *const usize))
             .field(
                 "wait_for_event (fn ptr)",
-                &(self.wait_for_event as *const u64),
+                &(self.wait_for_event as *const usize),
             )
-            .field("signal_event", &self.signal_event)
-            .field("close_event", &self.close_event)
-            .field("check_event", &self.check_event)
+            .field("signal_event", &(self.signal_event as *const usize))
+            .field("close_event", &(self.close_event as *const usize))
+            .field("check_event", &(self.check_event as *const usize))
             .field(
                 "install_protocol_interface",
-                &self.install_protocol_interface,
+                &(self.install_protocol_interface as *const usize),
             )
             .field(
                 "reinstall_protocol_interface",
-                &self.reinstall_protocol_interface,
+                &(self.reinstall_protocol_interface as *const usize),
             )
             .field(
                 "uninstall_protocol_interface",
-                &self.uninstall_protocol_interface,
+                &(self.uninstall_protocol_interface as *const usize),
             )
             .field(
                 "handle_protocol (fn ptr)",
-                &(self.handle_protocol as *const u64),
+                &(self.handle_protocol as *const usize),
             )
-            .field("register_protocol_notify", &self.register_protocol_notify)
+            .field(
+                "register_protocol_notify",
+                &(self.register_protocol_notify as *const usize),
+            )
             .field(
                 "locate_handle (fn ptr)",
-                &(self.locate_handle as *const u64),
+                &(self.locate_handle as *const usize),
             )
             .field(
                 "locate_device_path (fn ptr)",
-                &(self.locate_device_path as *const u64),
+                &(self.locate_device_path as *const usize),
             )
             .field(
                 "install_configuration_table",
-                &self.install_configuration_table,
+                &(self.install_configuration_table as *const usize),
             )
-            .field("load_image (fn ptr)", &(self.load_image as *const u64))
-            .field("start_image (fn ptr)", &(self.start_image as *const u64))
-            .field("exit", &self.exit)
-            .field("unload_image (fn ptr)", &(self.unload_image as *const u64))
+            .field("load_image (fn ptr)", &(self.load_image as *const usize))
+            .field("start_image (fn ptr)", &(self.start_image as *const usize))
+            .field("exit", &(self.exit as *const usize))
+            .field(
+                "unload_image (fn ptr)",
+                &(self.unload_image as *const usize),
+            )
             .field(
                 "exit_boot_services (fn ptr)",
-                &(self.exit_boot_services as *const u64),
+                &(self.exit_boot_services as *const usize),
             )
-            .field("get_next_monotonic_count", &self.get_next_monotonic_count)
-            .field("stall (fn ptr)", &(self.stall as *const u64))
+            .field(
+                "get_next_monotonic_count",
+                &(self.get_next_monotonic_count as *const usize),
+            )
+            .field("stall (fn ptr)", &(self.stall as *const usize))
             .field(
                 "set_watchdog_timer (fn ptr)",
-                &(self.set_watchdog_timer as *const u64),
+                &(self.set_watchdog_timer as *const usize),
             )
-            .field("connect_controller", &self.connect_controller)
-            .field("disconnect_controller", &self.disconnect_controller)
-            .field("open_protocol", &self.open_protocol)
-            .field("close_protocol", &self.close_protocol)
-            .field("open_protocol_information", &self.open_protocol_information)
+            .field(
+                "connect_controller",
+                &(self.connect_controller as *const usize),
+            )
+            .field(
+                "disconnect_controller",
+                &(self.disconnect_controller as *const usize),
+            )
+            .field("open_protocol", &(self.open_protocol as *const usize))
+            .field("close_protocol", &(self.close_protocol as *const usize))
+            .field(
+                "open_protocol_information",
+                &(self.open_protocol_information as *const usize),
+            )
             .field(
                 "protocols_per_handle",
-                &(self.protocols_per_handle as *const u64),
+                &(self.protocols_per_handle as *const usize),
             )
-            .field("locate_handle_buffer", &self.locate_handle_buffer)
+            .field(
+                "locate_handle_buffer",
+                &(self.locate_handle_buffer as *const usize),
+            )
             .field(
                 "locate_protocol (fn ptr)",
-                &(self.locate_protocol as *const u64),
+                &(self.locate_protocol as *const usize),
             )
             .field(
                 "install_multiple_protocol_interfaces",
-                &self.install_multiple_protocol_interfaces,
+                &(self.install_multiple_protocol_interfaces as *const usize),
             )
             .field(
                 "uninstall_multiple_protocol_interfaces",
-                &self.uninstall_multiple_protocol_interfaces,
+                &(self.uninstall_multiple_protocol_interfaces as *const usize),
             )
-            .field("calculate_crc32", &self.calculate_crc32)
-            .field("copy_mem (fn ptr)", &(self.copy_mem as *const u64))
-            .field("set_mem (fn ptr)", &(self.set_mem as *const u64))
-            .field("create_event_ex", &self.create_event_ex)
+            .field("calculate_crc32", &(self.calculate_crc32 as *const usize))
+            .field("copy_mem (fn ptr)", &(self.copy_mem as *const usize))
+            .field("set_mem (fn ptr)", &(self.set_mem as *const usize))
+            .field("create_event_ex", &(self.create_event_ex as *const usize))
             .finish()
     }
 }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -713,10 +713,7 @@ impl Debug for BootServices {
                 "allocate_pages (fn ptr)",
                 &(self.allocate_pages as *const u64),
             )
-            .field(
-                "free_pages (fn ptr)",
-                &(self.free_pages as u64 as *const u64),
-            )
+            .field("free_pages (fn ptr)", &(self.free_pages as *const u64))
             .field(
                 "get_memory_map (fn ptr)",
                 &(self.get_memory_map as *const u64),
@@ -783,7 +780,10 @@ impl Debug for BootServices {
             .field("open_protocol", &self.open_protocol)
             .field("close_protocol", &self.close_protocol)
             .field("open_protocol_information", &self.open_protocol_information)
-            .field("protocols_per_handle", &(self.protocols_per_handle as *const u64))
+            .field(
+                "protocols_per_handle",
+                &(self.protocols_per_handle as *const u64),
+            )
             .field("locate_handle_buffer", &self.locate_handle_buffer)
             .field(
                 "locate_protocol (fn ptr)",

--- a/src/table/header.rs
+++ b/src/table/header.rs
@@ -1,7 +1,7 @@
 use super::Revision;
+use core::fmt::{Debug, Formatter};
 
 /// All standard UEFI tables begin with a common header.
-#[derive(Debug)]
 #[repr(C)]
 pub struct Header {
     /// Unique identifier for this table.
@@ -15,4 +15,15 @@ pub struct Header {
     pub crc: u32,
     /// Reserved field that must be set to 0.
     _reserved: u32,
+}
+
+impl Debug for Header {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Header")
+            .field("signature", &(self.size as *const u64))
+            .field("revision", &self.revision)
+            .field("size", &self.size)
+            .field("crc", &self.crc)
+            .finish()
+    }
 }

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -9,9 +9,9 @@ use crate::{CStr16, Char16, Guid, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::{vec, vec::Vec};
 use bitflags::bitflags;
-use core::fmt::Formatter;
 #[cfg(feature = "exts")]
 use core::mem;
+use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::{fmt, ptr};
 
@@ -248,6 +248,21 @@ impl RuntimeServices {
 
 impl super::Table for RuntimeServices {
     const SIGNATURE: u64 = 0x5652_4553_544e_5552;
+}
+
+impl Debug for RuntimeServices {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RuntimeServices")
+            .field("header", &self.header)
+            .field("get_time", &(self.get_time as *const u64))
+            .field("set_time", &(self.set_time as *const u64))
+            .field(
+                "set_virtual_address_map",
+                &(self.set_virtual_address_map as *const u64),
+            )
+            .field("reset", &(self.reset as *const u64))
+            .finish()
+    }
 }
 
 /// The current time information

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -9,9 +9,9 @@ use crate::{CStr16, Char16, Guid, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::{vec, vec::Vec};
 use bitflags::bitflags;
+use core::fmt::{Debug, Formatter};
 #[cfg(feature = "exts")]
 use core::mem;
-use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::{fmt, ptr};
 

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use core::{slice, ptr};
+use core::{ptr, slice};
 
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};


### PR DESCRIPTION
Hey! This PR makes it possible to debug-format the UEFI system table. I'd love to see this functionality upstream. What do you think?

Example output (I can proof that it works in my QEMU setup)
```
UefiSystemTable {
    header: Header {
        signature: 6076298535811760713,
        revision: 2.7.0,
        size: 120,
        crc: 3701267086,
        _reserved: 0,
    },
    fw_vendor: "EDK II",
    fw_revision: 1.0.0,
    stdin_handle: Handle(
        0x000000000701a818,
    ),
    stdin: 0x0000000006de5b90,
    stdout_handle: Handle(
        0x0000000007019f18,
    ),
    stdout: 0x0000000006de5fd0,
    stderr_handle: Handle(
        0x0000000007018018,
    ),
    stderr: 0x0000000006de5a30,
    runtime: RuntimeServices {
        header: Header {
            signature: 6220110259551098194,
            revision: 2.7.0,
            size: 136,
            crc: 2242073619,
            _reserved: 0,
        },
        get_time: 0x0000000007abd56b,
        set_time: 0x0000000007abda01,
        set_virtual_address_map: 0x0000000007add013,
        reset: 0x0000000007ad7421,
    },
    boot: BootServices {
        header: Header {
            signature: 6220110259551162178,
            revision: 2.7.0,
            size: 376,
            crc: 4111088378,
            _reserved: 0,
        },
        raise_tpl (fn ptr): 0x0000000007eb05de,
        restore_tpl (fn ptr): 0x0000000007eb155a,
        allocate_pages (fn ptr): 0x0000000007eb490a,
        free_pages (fn ptr): 0x0000000007eb4826,
        get_memory_map (fn ptr): 0x0000000007eb70e2,
        allocate_pool (fn ptr): 0x0000000007eb4be2,
        free_pool (fn ptr): 0x0000000007eb4c5c,
        create_event (fn ptr): 0x0000000007eb2261,
        set_timer (fn ptr): 0x0000000007eb25b4,
        wait_for_event (fn ptr): 0x0000000007eb252e,
        signal_event: 132850730,
        close_event: 132861071,
        check_event: 132846796,
        install_protocol_interface: 132885880,
        reinstall_protocol_interface: 132890366,
        uninstall_protocol_interface: 132889596,
        handle_protocol (fn ptr): 0x0000000007ebaab2,
        register_protocol_notify: 132882914,
        locate_handle (fn ptr): 0x0000000007eb9f65,
        locate_device_path (fn ptr): 0x0000000007ebad9a,
        install_configuration_table: 132879987,
        load_image (fn ptr): 0x0000000007eb986e,
        start_image (fn ptr): 0x0000000007ebf541,
        exit: 132903955,
        unload_image (fn ptr): 0x0000000007ebe611,
        exit_boot_services (fn ptr): 0x0000000007eafe14,
        get_next_monotonic_count: 128680095,
        stall (fn ptr): 0x0000000007eb97db,
        set_watchdog_timer (fn ptr): 0x0000000007eb8b72,
        connect_controller: 132887446,
        disconnect_controller: 132883122,
        open_protocol: 132884407,
        close_protocol: 132881999,
        open_protocol_information: 132881682,
        protocols_per_handle: 132881409,
        locate_handle_buffer: 132882677,
        locate_protocol (fn ptr): 0x0000000007ebb2ab,
        install_multiple_protocol_interfaces: 132890020,
        uninstall_multiple_protocol_interfaces: 132889860,
        calculate_crc32: 128830808,
        copy_mem (fn ptr): 0x0000000007ea77d8,
        set_mem (fn ptr): 0x0000000007ea8258,
        create_event_ex: 132850204,
    },
    nf_cfg: 10,
    cfg_table: 0x00000000079eec98,
}
```