### PR TITLE
better CStr16 to String and str

### DIFF
--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -3,6 +3,8 @@ use core::convert::TryInto;
 use core::fmt;
 use core::iter::Iterator;
 use core::result::Result;
+#[cfg(feature = "exts")]
+use crate::alloc_api::string::String;
 use core::slice;
 
 /// Errors which can occur during checked `[uN]` -> `CStrN` conversions
@@ -161,6 +163,45 @@ impl CStr16 {
             inner: self,
             pos: 0,
         }
+    }
+
+    /// Write a string slice into the provided buffer. If it fails, then most probably, because
+    /// the buffer is not big enough. In that case, the buffer will contain the correct string
+    /// until the point, where the size was not enough.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use uefi::data_types::ArrayString;
+    /// use uefi::{CStr16, Char16};
+    /// let firmware_vendor_c16_str: CStr16 = ...;
+    /// // crate "arrayvec" uses stack-allocated arrays for Strings => no heap
+    /// let mut buf = arrayvec::ArrayString::<128>::new();
+    /// firmware_vendor_c16_str.as_str_in_buf(&mut buf);
+    /// log::info!("as rust str: {}", buf.as_str());
+    /// ```
+    pub fn as_str_in_buf(&self, buf: &mut dyn core::fmt::Write) -> Result<(), ()> {
+        for c16 in self.iter() {
+            let res = buf.write_char(char::from(*c16));
+            if let Err(err) = res {
+                log::error!("Failed to write CStr16 as &str into buffer. Buffer too small? ({})", err);
+                return Err(())
+            }
+        }
+        Ok(())
+    }
+
+    /// Transforms the C16Str to a regular Rust String.
+    /// **WARNING** This will require **heap allocation**, i.e. you need an global allocator.
+    /// If the UEFI boot services are exited, your OS/Kernel needs to provide another allocation
+    /// mechanism!
+    #[cfg(feature = "exts")]
+    pub fn as_string(&self) -> String {
+        let mut buf = String::with_capacity(self.0.len() * 2);
+        for c16 in self.iter() {
+            buf.push(char::from(*c16));
+        }
+        buf
     }
 }
 

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -165,28 +165,23 @@ impl CStr16 {
         }
     }
 
-    /// Write a string slice into the provided buffer. If it fails, then most probably, because
-    /// the buffer is not big enough. In that case, the buffer will contain the correct string
-    /// until the point, where the size was not enough.
+    /// Writes each [`Char16`] as a [´char´] (4 bytes long in Rust language) into the buffer.
+    /// It is up the the implementer of [`core::fmt::Write`] to convert the char to a string
+    /// with proper encoding/charset. For example, in the case of [`core::alloc::string::String`]
+    /// all Rust chars (UTF-32) get converted to UTF-8.
     ///
     /// ## Example
     ///
-    /// ```rust
-    /// use uefi::data_types::ArrayString;
-    /// use uefi::{CStr16, Char16};
+    /// ```ignore
     /// let firmware_vendor_c16_str: CStr16 = ...;
-    /// // crate "arrayvec" uses stack-allocated arrays for Strings => no heap
+    /// // crate "arrayvec" uses stack-allocated arrays for Strings => no heap allocations
     /// let mut buf = arrayvec::ArrayString::<128>::new();
     /// firmware_vendor_c16_str.as_str_in_buf(&mut buf);
     /// log::info!("as rust str: {}", buf.as_str());
     /// ```
-    pub fn as_str_in_buf(&self, buf: &mut dyn core::fmt::Write) -> Result<(), ()> {
+    pub fn as_str_in_buf(&self, buf: &mut dyn core::fmt::Write) -> core::fmt::Result {
         for c16 in self.iter() {
-            let res = buf.write_char(char::from(*c16));
-            if let Err(err) = res {
-                log::error!("Failed to write CStr16 as &str into buffer. Buffer too small? ({})", err);
-                return Err(())
-            }
+            buf.write_char(char::from(*c16))?;
         }
         Ok(())
     }

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -1,10 +1,10 @@
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
+#[cfg(feature = "exts")]
+use crate::alloc_api::string::String;
 use core::convert::TryInto;
 use core::fmt;
 use core::iter::Iterator;
 use core::result::Result;
-#[cfg(feature = "exts")]
-use crate::alloc_api::string::String;
 use core::slice;
 
 /// Errors which can occur during checked `[uN]` -> `CStrN` conversions

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -17,9 +17,6 @@ log = { version = "0.4.11", default-features = false }
 rlibc = "1.0.0"
 qemu-exit = "2.0.0"
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-runs_inside_qemu = "1.0.2"
-
 [features]
 # This feature should only be enabled in our CI, it disables some tests
 # which currently fail in that environment (see #103 for discussion).

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -17,6 +17,9 @@ log = { version = "0.4.11", default-features = false }
 rlibc = "1.0.0"
 qemu-exit = "2.0.0"
 
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+runs_inside_qemu = "1.0.2"
+
 [features]
 # This feature should only be enabled in our CI, it disables some tests
 # which currently fail in that environment (see #103 for discussion).

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -17,6 +17,9 @@ use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
 use uefi::table::boot::MemoryDescriptor;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use runs_inside_qemu::runs_inside_qemu;
+
 mod boot;
 mod proto;
 mod runtime;
@@ -31,6 +34,12 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // output firmware-vendor (CStr16 to Rust string)
     let mut buf = String::new();
     st.firmware_vendor().as_str_in_buf(&mut buf).unwrap();
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if runs_inside_qemu() {
+            assert_eq!("EDK II", buf.as_str());
+        }
+    }
     info!("Firmware Vendor: {}", buf.as_str());
 
     // Reset the console before running all the other tests.

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -25,6 +25,12 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
     uefi_services::init(&mut st).expect_success("Failed to initialize utilities");
 
+    /* unit tests here */
+    /*let mut buf = String::new();
+    st.firmware_vendor().as_str_in_buf(&mut buf).unwrap();
+    st.stdout().write_str(buf.as_str()).unwrap();
+    assert_eq!("EDK II", buf.as_str());*/
+
     // Reset the console before running all the other tests.
     st.stdout()
         .reset(false)

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 // Keep this line to ensure the `mem*` functions are linked in.
 extern crate rlibc;
 
+use alloc::string::String;
 use core::mem;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
@@ -25,11 +26,12 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
     uefi_services::init(&mut st).expect_success("Failed to initialize utilities");
 
-    /* unit tests here */
-    /*let mut buf = String::new();
+    // unit tests here
+
+    // output firmware-vendor (CStr16 to Rust string)
+    let mut buf = String::new();
     st.firmware_vendor().as_str_in_buf(&mut buf).unwrap();
-    st.stdout().write_str(buf.as_str()).unwrap();
-    assert_eq!("EDK II", buf.as_str());*/
+    info!("Firmware Vendor: {}", buf.as_str());
 
     // Reset the console before running all the other tests.
     st.stdout()

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -17,9 +17,6 @@ use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
 use uefi::table::boot::MemoryDescriptor;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use runs_inside_qemu::runs_inside_qemu;
-
 mod boot;
 mod proto;
 mod runtime;
@@ -34,12 +31,6 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // output firmware-vendor (CStr16 to Rust string)
     let mut buf = String::new();
     st.firmware_vendor().as_str_in_buf(&mut buf).unwrap();
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        if runs_inside_qemu() {
-            assert_eq!("EDK II", buf.as_str());
-        }
-    }
     info!("Firmware Vendor: {}", buf.as_str());
 
     // Reset the console before running all the other tests.


### PR DESCRIPTION
In my experience, the current CStr16 abstraction is really a pain when you want to use the strings in regular Rust code. As I'm developing my own OS/kernel, I'd love to have a nice way to transform these to regular Rust strings.