### PR TITLE
device path: add constants for all subtypes

### DIFF
--- a/src/proto/device_path.rs
+++ b/src/proto/device_path.rs
@@ -72,14 +72,121 @@ pub enum DeviceType: u8 => {
     END = 0x7F,
 }}
 
-newtype_enum! {
 /// Sub-type identifier for a DevicePath
-pub enum DeviceSubType: u8 => {
-    /// End This Instance of a Device Path and start a new Device Path
-    END_INSTANCE = 0x01,
-    /// End Entire Device Path
-    END_ENTIRE = 0xFF,
-}}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DeviceSubType(pub u8);
+
+impl DeviceSubType {
+    /// PCI Device Path.
+    pub const HARDWARE_PCI: DeviceSubType = DeviceSubType(0x01);
+    /// PCCARD Device Path.
+    pub const HARDWARE_PCCARD: DeviceSubType = DeviceSubType(0x02);
+    /// Memory-mapped Device Path.
+    pub const HARDWARE_MEMORY_MAPPED: DeviceSubType = DeviceSubType(0x03);
+    /// Vendor-Defined Device Path.
+    pub const HARDWARE_VENDOR: DeviceSubType = DeviceSubType(0x04);
+    /// Controller Device Path.
+    pub const HARDWARE_CONTROLLER: DeviceSubType = DeviceSubType(0x05);
+    /// BMC Device Path.
+    pub const HARDWARE_BMC: DeviceSubType = DeviceSubType(0x06);
+
+    /// ACPI Device Path.
+    pub const ACPI: DeviceSubType = DeviceSubType(0x01);
+    /// Expanded ACPI Device Path.
+    pub const ACPI_EXPANDED: DeviceSubType = DeviceSubType(0x02);
+    /// ACPI _ADR Device Path.
+    pub const ACPI_ADR: DeviceSubType = DeviceSubType(0x03);
+    /// NVDIMM Device Path.
+    pub const ACPI_NVDIMM: DeviceSubType = DeviceSubType(0x04);
+
+    /// ATAPI Device Path.
+    pub const MESSAGING_ATAPI: DeviceSubType = DeviceSubType(0x01);
+    /// SCSI Device Path.
+    pub const MESSAGING_SCSI: DeviceSubType = DeviceSubType(0x02);
+    /// Fibre Channel Device Path.
+    pub const MESSAGING_FIBRE_CHANNEL: DeviceSubType = DeviceSubType(0x03);
+    /// 1394 Device Path.
+    pub const MESSAGING_1394: DeviceSubType = DeviceSubType(0x04);
+    /// USB Device Path.
+    pub const MESSAGING_USB: DeviceSubType = DeviceSubType(0x05);
+    /// I2O Device Path.
+    pub const MESSAGING_I2O: DeviceSubType = DeviceSubType(0x06);
+    /// Infiniband Device Path.
+    pub const MESSAGING_INFINIBAND: DeviceSubType = DeviceSubType(0x09);
+    /// Vendor-Defined Device Path.
+    pub const MESSAGING_VENDOR: DeviceSubType = DeviceSubType(0x0a);
+    /// MAC Address Device Path.
+    pub const MESSAGING_MAC_ADDRESS: DeviceSubType = DeviceSubType(0x0b);
+    /// IPV4 Device Path.
+    pub const MESSAGING_IPV4: DeviceSubType = DeviceSubType(0x0c);
+    /// IPV6 Device Path.
+    pub const MESSAGING_IPV6: DeviceSubType = DeviceSubType(0x0d);
+    /// UART Device Path.
+    pub const MESSAGING_UART: DeviceSubType = DeviceSubType(0x0e);
+    /// USB Class Device Path.
+    pub const MESSAGING_USB_CLASS: DeviceSubType = DeviceSubType(0x0f);
+    /// USB WWID Device Path.
+    pub const MESSAGING_USB_WWID: DeviceSubType = DeviceSubType(0x10);
+    /// Device Logical Unit.
+    pub const MESSAGING_DEVICE_LOGICAL_UNIT: DeviceSubType = DeviceSubType(0x11);
+    /// SATA Device Path.
+    pub const MESSAGING_SATA: DeviceSubType = DeviceSubType(0x12);
+    /// iSCSI Device Path node (base information).
+    pub const MESSAGING_ISCSI: DeviceSubType = DeviceSubType(0x13);
+    /// VLAN Device Path node.
+    pub const MESSAGING_VLAN: DeviceSubType = DeviceSubType(0x14);
+    /// Fibre Channel Ex Device Path.
+    pub const MESSAGING_FIBRE_CHANNEL_EX: DeviceSubType = DeviceSubType(0x15);
+    /// Serial Attached SCSI (SAS) Ex Device Path.
+    pub const MESSAGING_SCSI_SAS_EX: DeviceSubType = DeviceSubType(0x16);
+    /// NVM Express Namespace Device Path.
+    pub const MESSAGING_NVME_NAMESPACE: DeviceSubType = DeviceSubType(0x17);
+    /// Uniform Resource Identifiers (URI) Device Path.
+    pub const MESSAGING_URI: DeviceSubType = DeviceSubType(0x18);
+    /// UFS Device Path.
+    pub const MESSAGING_UFS: DeviceSubType = DeviceSubType(0x19);
+    /// SD (Secure Digital) Device Path.
+    pub const MESSAGING_SD: DeviceSubType = DeviceSubType(0x1a);
+    /// Bluetooth Device Path.
+    pub const MESSAGING_BLUETOOTH: DeviceSubType = DeviceSubType(0x1b);
+    /// Wi-Fi Device Path.
+    pub const MESSAGING_WIFI: DeviceSubType = DeviceSubType(0x1c);
+    /// eMMC (Embedded Multi-Media Card) Device Path.
+    pub const MESSAGING_EMMC: DeviceSubType = DeviceSubType(0x1d);
+    /// BluetoothLE Device Path.
+    pub const MESSAGING_BLUETOOTH_LE: DeviceSubType = DeviceSubType(0x1e);
+    /// DNS Device Path.
+    pub const MESSAGING_DNS: DeviceSubType = DeviceSubType(0x1f);
+    /// NVDIMM Namespace Device Path.
+    pub const MESSAGING_NVDIMM_NAMESPACE: DeviceSubType = DeviceSubType(0x20);
+
+    /// Hard Drive Media Device Path.
+    pub const MEDIA_HARD_DRIVE: DeviceSubType = DeviceSubType(0x01);
+    /// CD-ROM Media Device Path.
+    pub const MEDIA_CD_ROM: DeviceSubType = DeviceSubType(0x02);
+    /// Vendor-Defined Media Device Path.
+    pub const MEDIA_VENDOR: DeviceSubType = DeviceSubType(0x03);
+    /// File Path Media Device Path.
+    pub const MEDIA_FILE_PATH: DeviceSubType = DeviceSubType(0x04);
+    /// Media Protocol Device Path.
+    pub const MEDIA_PROTOCOL: DeviceSubType = DeviceSubType(0x05);
+    /// PIWG Firmware File.
+    pub const MEDIA_PIWG_FIRMWARE_FILE: DeviceSubType = DeviceSubType(0x06);
+    /// PIWG Firmware Volume.
+    pub const MEDIA_PIWG_FIRMWARE_VOLUME: DeviceSubType = DeviceSubType(0x07);
+    /// Relative Offset Range.
+    pub const MEDIA_RELATIVE_OFFSET_RANGE: DeviceSubType = DeviceSubType(0x08);
+    /// RAM Disk Device Path.
+    pub const MEDIA_RAM_DISK: DeviceSubType = DeviceSubType(0x09);
+
+    /// BIOS Boot Specification Device Path.
+    pub const BIOS_BOOT_SPECIFICATION: DeviceSubType = DeviceSubType(0x01);
+
+    /// End this instance of a Device Path and start a new one.
+    pub const END_INSTANCE: DeviceSubType = DeviceSubType(0x01);
+    /// End entire Device Path.
+    pub const END_ENTIRE: DeviceSubType = DeviceSubType(0xff);
+}
 
 /// ACPI Device Path
 #[repr(C, packed)]


### PR DESCRIPTION
The constants are grouped and prefixed by their associated `DeviceType`.

Also changed `DeviceSubType` to not use `newtype_enum` because many of the
values have multiple names, so the `newtype_enum` implementation of `Debug`
doesn't work properly and generates warnings.