### PR TITLE
device path: change the length type to u16

### DIFF
--- a/src/proto/device_path.rs
+++ b/src/proto/device_path.rs
@@ -32,7 +32,7 @@ pub struct DevicePath {
     /// Data related to device path
     ///
     /// The `device_type` and `sub_type` determine the kind of data, and its size.
-    pub length: [u8; 2],
+    pub length: u16,
 }
 
 newtype_enum! {


### PR DESCRIPTION
Although the spec defines the length field as `UINT8 Length[2]`, it is always
treated as a `u16` and is more convenient to access that way.