### PR TITLE
Implement `BootServices::protocols_per_handle`

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -44,7 +44,7 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     boot::test(bt);
 
     // Test all the supported protocols.
-    proto::test(&mut st);
+    proto::test(image, &mut st);
 
     // TODO: runtime services work before boot services are exited, but we'd
     // probably want to test them after exit_boot_services. However,

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -1,14 +1,16 @@
 use uefi::prelude::*;
 
-use uefi::proto;
+use uefi::proto::loaded_image::LoadedImage;
+use uefi::{proto, Identify};
 
-pub fn test(st: &mut SystemTable<Boot>) {
+pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     info!("Testing various protocols");
 
     console::test(st);
 
     let bt = st.boot_services();
     find_protocol(bt);
+    test_protocols_per_handle(image, bt);
 
     debug::test(bt);
     media::test(bt);
@@ -34,6 +36,20 @@ fn find_protocol(bt: &BootServices) {
         handles.len() > 1,
         "There should be at least one implementation of Simple Text Output (stdout)"
     );
+}
+
+fn test_protocols_per_handle(image: Handle, bt: &BootServices) {
+    let pph = bt
+        .protocols_per_handle(image)
+        .expect_success("Failed to get protocols for image handle");
+
+    info!("Image handle has {} protocols", pph.protocols().len());
+
+    // Check that one of the image's protocols is `LoadedImage`.
+    assert!(pph
+        .protocols()
+        .iter()
+        .any(|guid| **guid == LoadedImage::GUID));
 }
 
 mod console;


### PR DESCRIPTION
This function gets a list of all the protocol GUIDs that are installed on a
handle.