### PR TITLE
Add method to get variable names

### DIFF
--- a/src/data_types/guid.rs
+++ b/src/data_types/guid.rs
@@ -8,7 +8,7 @@ use core::fmt;
 ///
 /// The `Display` formatter prints GUIDs in the canonical format defined by
 /// RFC 4122, which is also used by UEFI.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub struct Guid {
     /// The low field of the timestamp.

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -50,4 +50,4 @@ pub use self::chars::{Char16, Char8};
 mod enums;
 
 mod strs;
-pub use self::strs::{CStr16, CStr8};
+pub use self::strs::{CStr16, CStr8, FromSliceWithNulError};

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -5,7 +5,8 @@ use core::iter::Iterator;
 use core::result::Result;
 use core::slice;
 
-/// Errors which can occur during checked [uN] -> CStrN conversions
+/// Errors which can occur during checked `[uN]` -> `CStrN` conversions
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FromSliceWithNulError {
     /// An invalid character was encountered before the end of the slice
     InvalidChar(usize),

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -1,14 +1,19 @@
 //! UEFI services available at runtime, even after the OS boots.
 
 use super::Header;
+#[cfg(feature = "exts")]
+use crate::data_types::FromSliceWithNulError;
 use crate::result::Error;
 use crate::table::boot::MemoryDescriptor;
 use crate::{CStr16, Char16, Guid, Result, Status};
+#[cfg(feature = "exts")]
+use alloc_api::{vec, vec::Vec};
 use bitflags::bitflags;
-use core::fmt;
 use core::fmt::Formatter;
+#[cfg(feature = "exts")]
+use core::mem;
 use core::mem::MaybeUninit;
-use core::ptr;
+use core::{fmt, ptr};
 
 /// Contains pointers to all of the runtime services.
 ///
@@ -149,6 +154,64 @@ impl RuntimeServices {
             )
             .into_with_val(move || (&buf[..data_size], attributes))
         }
+    }
+
+    /// Get the names and vendor GUIDs of all currently-set variables.
+    #[cfg(feature = "exts")]
+    pub fn variable_keys(&self) -> Result<Vec<VariableKey>> {
+        let mut all_variables = Vec::new();
+
+        // The initial value of name must start with a null character. Start
+        // out with a reasonable size that likely won't need to be increased.
+        let mut name = vec![0u16; 32];
+        // The initial value of vendor is ignored.
+        let mut vendor = Guid::default();
+
+        let mut status;
+        loop {
+            let mut name_size_in_bytes = name.len() * mem::size_of::<u16>();
+            status = unsafe {
+                (self.get_next_variable_name)(
+                    &mut name_size_in_bytes,
+                    name.as_mut_ptr(),
+                    &mut vendor,
+                )
+            };
+
+            match status {
+                Status::SUCCESS => {
+                    // CStr16::from_u16_with_nul does not allow interior nulls,
+                    // so make the copy exactly the right size.
+                    let name = if let Some(nul_pos) = name.iter().position(|c| *c == 0) {
+                        name[..=nul_pos].to_vec()
+                    } else {
+                        status = Status::ABORTED;
+                        break;
+                    };
+
+                    all_variables.push(VariableKey { name, vendor });
+                }
+                Status::BUFFER_TOO_SMALL => {
+                    // The name buffer passed in was too small, resize it to be
+                    // big enough for the next variable name.
+                    name.resize(name_size_in_bytes / 2, 0);
+                }
+                Status::NOT_FOUND => {
+                    // This status indicates the end of the list. The final
+                    // variable has already been received at this point, so
+                    // no new variable should be added to the output.
+                    status = Status::SUCCESS;
+                    break;
+                }
+                _ => {
+                    // For anything else, an error has occurred so break out of
+                    // the loop and return it.
+                    break;
+                }
+            }
+        }
+
+        status.into_with_val(|| all_variables)
     }
 
     /// Set the value of a variable. This can be used to create a new variable,
@@ -412,6 +475,45 @@ pub const GLOBAL_VARIABLE: Guid = Guid::from_values(
     0xaa0d,
     [0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c],
 );
+
+/// Unique key for a variable.
+#[cfg(feature = "exts")]
+#[derive(Debug)]
+pub struct VariableKey {
+    name: Vec<u16>,
+    /// Unique identifier for the vendor.
+    pub vendor: Guid,
+}
+
+#[cfg(feature = "exts")]
+impl VariableKey {
+    /// Name of the variable.
+    pub fn name(&self) -> core::result::Result<&CStr16, FromSliceWithNulError> {
+        CStr16::from_u16_with_nul(&self.name)
+    }
+}
+
+#[cfg(feature = "exts")]
+impl fmt::Display for VariableKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "VariableKey {{ name: ")?;
+
+        match self.name() {
+            Ok(name) => write!(f, "\"{}\"", name)?,
+            Err(err) => write!(f, "Err({:?})", err)?,
+        }
+
+        write!(f, ", vendor: ")?;
+
+        if self.vendor == GLOBAL_VARIABLE {
+            write!(f, "GLOBAL_VARIABLE")?;
+        } else {
+            write!(f, "{}", self.vendor)?;
+        }
+
+        write!(f, " }}")
+    }
+}
 
 /// The type of system reset.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -52,6 +52,17 @@ fn test_variables(rt: &RuntimeServices) {
         .expect_success("failed to get variable");
     assert_eq!(data, test_value);
     assert_eq!(attrs, test_attrs);
+
+    info!("Testing variable_keys");
+    let variable_keys = rt
+        .variable_keys()
+        .expect_success("failed to get variable keys");
+    info!("Found {} variables", variable_keys.len());
+    // There are likely a bunch of variables, only print out the first one
+    // during the test to avoid spamming the log.
+    if let Some(key) = variable_keys.first() {
+        info!("First variable: {}", key);
+    }
 }
 
 pub fn test(rt: &RuntimeServices) {


### PR DESCRIPTION
This method uses the `get_next_variable_name` function of `RuntimeServices` to get each variable name and vendor GUID.