### PR TITLE
implement the `BootServices::exit` method as documented in the UEFI specification.

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -96,7 +96,7 @@ pub struct BootServices {
         exit_data_size: *mut usize,
         exit_data: &mut *mut Char16,
     ) -> Status,
-    exit: usize,
+    exit: extern "efiapi" fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: *mut Char16)
     unload_image: extern "efiapi" fn(image_handle: Handle) -> Status,
     exit_boot_services:
         unsafe extern "efiapi" fn(image_handle: Handle, map_key: MemoryMapKey) -> Status,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -480,6 +480,18 @@ impl BootServices {
             (self.start_image)(image_handle, &mut exit_data_size, &mut exit_data).into()
         }
     }
+    
+    /// Exits the UEFI application and returns control to the UEFI component
+    /// that started the UEFI application.
+    pub fn exit(
+        &self, 
+        image_handle: Handle, 
+        exit_status: Status, 
+        exit_data_size: usize, 
+        exit_data: *mut Char16
+    ) -> Result {
+        (self.exit)(image_handle, exit_status, exit_data_size, exit_data).into()
+    }
 
     /// Exits the UEFI boot services
     ///

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -487,7 +487,11 @@ impl BootServices {
     
     /// Exits the UEFI application and returns control to the UEFI component
     /// that started the UEFI application.
-    pub fn exit(
+    ///
+    /// This function is unsafe becase the caller is responsible for freeing
+    /// any resources allocated by the application before exiting and returning
+    /// control.
+    pub unsafe fn exit(
         &self, 
         image_handle: Handle, 
         exit_status: Status, 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -12,7 +12,7 @@ use bitflags::bitflags;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::mem::{self, MaybeUninit};
-use core::ptr;
+use core::{ptr, slice};
 
 /// Contains pointers to all of the boot services.
 #[repr(C)]
@@ -96,7 +96,7 @@ pub struct BootServices {
         exit_data_size: *mut usize,
         exit_data: &mut *mut Char16,
     ) -> Status,
-    exit: extern "efiapi" fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: *mut Char16) -> Status,
+    exit: extern "efiapi" fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: *mut Char16) -> !,
     unload_image: extern "efiapi" fn(image_handle: Handle) -> Status,
     exit_boot_services:
         unsafe extern "efiapi" fn(image_handle: Handle, map_key: MemoryMapKey) -> Status,
@@ -121,7 +121,11 @@ pub struct BootServices {
     open_protocol_information: usize,
 
     // Library services
-    protocols_per_handle: usize,
+    protocols_per_handle: unsafe extern "efiapi" fn(
+        handle: Handle,
+        protocol_buffer: *mut *mut *const Guid,
+        protocol_buffer_count: *mut usize,
+    ) -> Status,
     locate_handle_buffer: usize,
     locate_protocol: extern "efiapi" fn(
         proto: &Guid,
@@ -489,7 +493,7 @@ impl BootServices {
         exit_status: Status, 
         exit_data_size: usize, 
         exit_data: *mut Char16
-    ) -> Result {
+    ) -> ! {
         (self.exit)(image_handle, exit_status, exit_data_size, exit_data).into()
     }
 
@@ -558,6 +562,36 @@ impl BootServices {
             .unwrap_or((0, ptr::null_mut()));
 
         unsafe { (self.set_watchdog_timer)(timeout, watchdog_code, data_len, data) }.into()
+    }
+
+    /// Get the list of protocol interface [`Guids`][Guid] that are installed
+    /// on a [`Handle`].
+    pub fn protocols_per_handle(&self, handle: Handle) -> Result<ProtocolsPerHandle> {
+        let mut protocols = ptr::null_mut();
+        let mut count = 0;
+
+        let mut status = unsafe { (self.protocols_per_handle)(handle, &mut protocols, &mut count) };
+
+        if !status.is_error() {
+            // Ensure that protocols isn't null, and that none of the GUIDs
+            // returned are null.
+            if protocols.is_null() {
+                status = Status::OUT_OF_RESOURCES;
+            } else {
+                let protocols: &[*const Guid] = unsafe { slice::from_raw_parts(protocols, count) };
+                if protocols.iter().any(|ptr| ptr.is_null()) {
+                    status = Status::OUT_OF_RESOURCES;
+                }
+            }
+        }
+
+        status.into_with_val(|| {
+            let protocols = unsafe { slice::from_raw_parts_mut(protocols as *mut &Guid, count) };
+            ProtocolsPerHandle {
+                boot_services: self,
+                protocols,
+            }
+        })
     }
 
     /// Returns a protocol implementation, if present on the system.
@@ -944,4 +978,34 @@ pub enum TimerTrigger {
     /// Parameter is the delay in 100ns units.
     /// Delay of 0 will be signalled on next timer tick.
     Relative(u64),
+}
+
+/// Protocol interface [`Guids`][Guid] that are installed on a [`Handle`] as
+/// returned by [`BootServices::protocols_per_handle`].
+pub struct ProtocolsPerHandle<'a> {
+    // The pointer returned by `protocols_per_handle` has to be free'd with
+    // `free_pool`, so keep a reference to boot services for that purpose.
+    boot_services: &'a BootServices,
+
+    // This is mutable so that it can later be free'd with `free_pool`. Users
+    // should only get an immutable reference though, so the field is not
+    // public.
+    protocols: &'a mut [&'a Guid],
+}
+
+impl<'a> Drop for ProtocolsPerHandle<'a> {
+    fn drop(&mut self) {
+        // Ignore the result, we can't do anything about an error here.
+        let _ = self
+            .boot_services
+            .free_pool(self.protocols.as_mut_ptr() as *mut u8);
+    }
+}
+
+impl<'a> ProtocolsPerHandle<'a> {
+    /// Get the protocol interface [`Guids`][Guid] that are installed on the
+    /// [`Handle`].
+    pub fn protocols(&self) -> &[&Guid] {
+        self.protocols
+    }
 }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -96,7 +96,7 @@ pub struct BootServices {
         exit_data_size: *mut usize,
         exit_data: &mut *mut Char16,
     ) -> Status,
-    exit: extern "efiapi" fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: *mut Char16)
+    exit: extern "efiapi" fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: *mut Char16) -> Status,
     unload_image: extern "efiapi" fn(image_handle: Handle) -> Status,
     exit_boot_services:
         unsafe extern "efiapi" fn(image_handle: Handle, map_key: MemoryMapKey) -> Status,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -488,6 +488,8 @@ impl BootServices {
     /// Exits the UEFI application and returns control to the UEFI component
     /// that started the UEFI application.
     ///
+    /// # Safety
+    ///
     /// This function is unsafe becase the caller is responsible for freeing
     /// any resources allocated by the application before exiting and returning
     /// control.


### PR DESCRIPTION
This pull request implements a `BootServices::exit` method as documented in the UEFI specification as:

```c
typedef 
EFI_STATUS
(EFIAPI *EFI_EXIT) {
        IN EFI_HANDLE ImageHandle,
        IN EFI_STATUS ExitStatus,
        IN UINTN ExitDataSize,
        IN CHAR16 *ExitData OPTIONAL
};
```

Source: https://uefi.org/sites/default/files/resources/UEFI_Spec_2_9_2021_03_18.pdf, Page 298.