### PR TITLE
Better `fmt::Debug` for `Time` struct + `fmt::Display`

### DIFF
--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -219,13 +219,18 @@ impl Time {
 
 impl fmt::Debug for Time {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}-{}-{} ", self.year, self.month, self.day)?;
+        write!(f, "{:04}-{:02}-{:02} ", self.year, self.month, self.day)?;
         write!(
             f,
-            "{}:{}:{}.{} ",
+            "{:02}:{:02}:{:02}.{:09}",
             self.hour, self.minute, self.second, self.nanosecond
         )?;
-        write!(f, "{} {:?}", self.time_zone, self.daylight)
+        if self.time_zone == 2047 {
+            write!(f, ", Timezone=unspecified")?;
+        } else {
+            write!(f, ", Timezone={}", self.time_zone)?;
+        }
+        write!(f, ", Daylight={:?}", self.daylight)
     }
 }
 


### PR DESCRIPTION
Hi! The current `fmt::Debug` impl for the `Time` struct didn't included leading zeroes, which is a bit odd. I optimized the implementation. `fmt::Display` was completely missing,

Current debug-format looks like: `Time: 2021-07-13 21:14:46.000000000, Timezone=unspecified, Daylight=(empty)`
and current display-format looks like this: `Time: 2021-07-14 07:00:37.000 (local)` (or `Time: 2021-07-14 07:00:37.000 UTC+2`) 

I tested it inside my QEMU setup.

Furthermore I changed the debug formatting for the time zone and the daylight fields of a Time struct a bit. The current approach was strange, because for example, users got a weird number for the Timezone without explanation, that this number is the time zone.


What do you think?
