### PR TITLE
Fix procedural macros

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,11 +15,16 @@ The following steps allow you to build a simple UEFI app.
   #![feature(abi_efiapi)]
   use uefi::prelude::*;
 
+  extern crate rlibc;
+
   #[entry]
-  fn efi_main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status;
+  fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status;
   ```
-  You will also want to add a dependency to the [`rlibc`](https://docs.rs/rlibc/) crate,
-  to avoid linking errors.
+  Note that Rust EFI target requires the entry function to be exported with an `efi_main` symbol,
+  the `#[entry]` macro takes care of that, so the function name is irrelevant.
+
+  You will also want to add a dependency to the [`rlibc`](https://docs.rs/rlibc/) crate and
+  explicitly link it with `extern crate rlibc;` line to avoid linking errors.
 
 - Build using a `nightly` version of the compiler and activate the
   [`build-std`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@
 #[cfg(feature = "exts")]
 extern crate alloc as alloc_api;
 
+// allow referring to self as ::uefi for macros to work universally (from this crate and from others)
+// see https://github.com/rust-lang/rust/issues/54647
+extern crate self as uefi;
+
 #[macro_use]
 pub mod data_types;
 pub use self::data_types::{unsafe_guid, Identify};

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -3,10 +3,11 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+
+use proc_macro2::Span;
 use quote::{quote, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, DeriveInput, Generics, Ident, ItemFn, ItemType, LitStr};
-use proc_macro2::Span;
 
 /// Parses a type definition, extracts its identifier and generic parameters
 struct TypeDefinition {

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -6,6 +6,7 @@ use proc_macro::TokenStream;
 use quote::{quote, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, DeriveInput, Generics, Ident, ItemFn, ItemType, LitStr};
+use proc_macro2::Span;
 
 /// Parses a type definition, extracts its identifier and generic parameters
 struct TypeDefinition {
@@ -87,10 +88,10 @@ pub fn unsafe_guid(args: TokenStream, input: TokenStream) -> TokenStream {
     let ident = type_definition.ident.clone();
     let (impl_generics, ty_generics, where_clause) = type_definition.generics.split_for_impl();
     result.append_all(quote! {
-        unsafe impl #impl_generics crate::Identify for #ident #ty_generics #where_clause {
+        unsafe impl #impl_generics ::uefi::Identify for #ident #ty_generics #where_clause {
             #[doc(hidden)]
             #[allow(clippy::unreadable_literal)]
-            const GUID : crate::Guid = crate::Guid::from_values(
+            const GUID: ::uefi::Guid = ::uefi::Guid::from_values(
                 #time_low,
                 #time_mid,
                 #time_high_and_version,
@@ -113,7 +114,7 @@ pub fn derive_protocol(item: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
     let result = quote! {
         // Mark this as a `Protocol` implementation
-        impl #impl_generics crate::proto::Protocol for #ident #ty_generics #where_clause {}
+        impl #impl_generics ::uefi::proto::Protocol for #ident #ty_generics #where_clause {}
 
         // Most UEFI functions expect to be called on the bootstrap processor.
         impl #impl_generics !Send for #ident #ty_generics #where_clause {}
@@ -134,14 +135,15 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         panic!("This attribute accepts no arguments");
     }
 
-    let f = parse_macro_input!(input as ItemFn);
+    let mut f = parse_macro_input!(input as ItemFn);
 
-    let entry_fn_ident = &f.sig.ident;
+    // force the exported symbol to be 'efi_main'
+    f.sig.ident = Ident::new("efi_main", Span::call_site());
 
-    let result = quote!(
-        static _UEFI_ENTRY_POINT_TYPE_CHECK: extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status = #entry_fn_ident;
+    let result = quote! {
+        static _UEFI_ENTRY_POINT_TYPE_CHECK: extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status = efi_main;
         #[no_mangle]
         pub extern "efiapi" #f
-    );
+    };
     result.into()
 }


### PR DESCRIPTION
Currently procedural macros do not work outside of `uefi` crate, because they are referencing crate-local items (Guid, Protocol etc.) and when invoked from a crate other than 'uefi' those items cannot be found (well because the other crate does not have them).

This is a known (as I learned) procedural macro issue and the latest best [workaround](https://github.com/rust-lang/rust/issues/54647) is what I implemented here - allow 'uefi' to reference itself by `::uefi` and then use `::uefi` in those macros.

As an additional bonus (I can revert that if you have objections but it's neat and does not break anything) I made the 'entry' macro always make the exported entry function have the name 'efi_main', which is required by the rust efi target I think.

Anyway, with that change, users can name their entry function whatever they want (right now that leads to cryptic errors iirc), and the fact that this is an entry function is clearly marked by the `#[entry]` attribute above it.