### PR TITLE
device path: add iter method and test

### DIFF
--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -1,0 +1,27 @@
+use uefi::prelude::*;
+use uefi::proto::device_path::DevicePath;
+use uefi::proto::loaded_image::LoadedImage;
+use uefi::table::boot::BootServices;
+
+pub fn test(image: Handle, bt: &BootServices) {
+    info!("Running device path protocol test");
+
+    let loaded_image = bt
+        .handle_protocol::<LoadedImage>(image)
+        .expect_success("Failed to open LoadedImage protocol");
+    let loaded_image = unsafe { &*loaded_image.get() };
+
+    let device_path = bt
+        .handle_protocol::<DevicePath>(loaded_image.device())
+        .expect_success("Failed to open DevicePath protocol");
+    let device_path = unsafe { &*device_path.get() };
+
+    for path in device_path.iter() {
+        info!(
+            "path: type={:?}, subtype={:?}, length={}",
+            path.device_type(),
+            path.sub_type(),
+            path.length(),
+        );
+    }
+}

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -13,6 +13,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     test_protocols_per_handle(image, bt);
 
     debug::test(bt);
+    device_path::test(image, bt);
     media::test(bt);
     pi::test(bt);
 
@@ -54,6 +55,7 @@ fn test_protocols_per_handle(image: Handle, bt: &BootServices) {
 
 mod console;
 mod debug;
+mod device_path;
 mod media;
 mod pi;
 #[cfg(any(


### PR DESCRIPTION
Device paths are variable length structures packed into an array, so usually
you have a pointer to the head of the array and advance through the elements by
adding the length from the header to the pointer. The new `DevicePath::iter`
method provides a more convenient way of doing this.