### PR TITLE
Fix docstring tests and test them in the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,9 +52,34 @@ jobs:
       run: ./build.py build
       working-directory: ./uefi-test-runner
 
-    - name: Run tests
+    - name: Run VM tests
       run: ./build.py run --headless --ci
       working-directory: ./uefi-test-runner
+
+  test:
+    name: Run tests and documentation tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: nightly
+            components: rust-src
+            override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        env:
+          # This works around "duplicate item in crate core" errors:
+          # https://github.com/rust-lang/wg-cargo-std-aware/issues/56
+          CARGO_PROFILE_DEV_PANIC: unwind
+        with:
+          command: test
+          args: -Zbuild-std=std --target x86_64-unknown-linux-gnu
 
   lints:
     name: Lints

--- a/src/data_types/enums.rs
+++ b/src/data_types/enums.rs
@@ -30,8 +30,9 @@
 ///
 /// Usage example:
 /// ```
+/// use uefi::newtype_enum;
 /// newtype_enum! {
-/// #[derive(Cmp, PartialCmp)]
+/// #[derive(Ord, PartialOrd)]
 /// pub enum UnixBool: i32 => #[allow(missing_docs)] {
 ///     FALSE          =  0,
 ///     TRUE           =  1,

--- a/src/data_types/guid.rs
+++ b/src/data_types/guid.rs
@@ -97,8 +97,9 @@ impl fmt::Display for Guid {
 /// textual format as an argument, and is used in the following way:
 ///
 /// ```
+/// use uefi::unsafe_guid;
 /// #[unsafe_guid("12345678-9abc-def0-1234-56789abcdef0")]
-/// type Emptiness = ();
+/// struct Emptiness;
 /// ```
 pub unsafe trait Identify {
     /// Unique protocol identifier.

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -18,6 +18,8 @@ use crate::Identify;
 /// protocol's GUID using the following syntax:
 ///
 /// ```
+/// #![feature(negative_impls)]
+/// use uefi::{proto::Protocol, unsafe_guid};
 /// #[unsafe_guid("12345678-9abc-def0-1234-56789abcdef0")]
 /// #[derive(Protocol)]
 /// struct DummyProtocol {}


### PR DESCRIPTION
The first commit fixes up various compilation issues in existing doctests. The second commit adds a `cargo test` step to the github actions that runs on the x86_64-unknown-linux-gnu target instead of a UEFI target so that the doctests don't bitrot. (Regular `#[test]` unit tests could potentially be added later too for things that don't need to run on a UEFI target, e.g. for code under `src/data_types`.)

Running the tests on the host can be done like this:

    CARGO_PROFILE_DEV_PANIC=unwind \
        cargo test -Zbuild-std=std --target x86_64-unknown-linux-gnu
    
Changing panic to unwind avoids https://github.com/rust-lang/wg-cargo-std-aware/issues/56. (The comments there suggest that `-Zbuild-std=panic_abort` would work instead of changing the panic type, but I kept getting the duplicate lang item errors.)