### PR TITLE
Fix doc link and make CI lints stricter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target x86_64-unknown-uefi
+          args: --target x86_64-unknown-uefi -- -Dwarnings
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,3 +113,11 @@ jobs:
         with:
           command: clippy
           args: --target x86_64-unknown-uefi
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        with:
+          command: doc
+          args: --target x86_64-unknown-uefi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
           CARGO_PROFILE_DEV_PANIC: unwind
         with:
           command: test
-          args: -Zbuild-std=std --target x86_64-unknown-linux-gnu
+          args: -Zbuild-std=std --target x86_64-unknown-linux-gnu --features=exts
 
   lints:
     name: Lints
@@ -112,7 +112,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target x86_64-unknown-uefi -- -Dwarnings
+          args: --target x86_64-unknown-uefi --all-features -- -Dwarnings
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
@@ -120,4 +120,4 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --target x86_64-unknown-uefi
+          args: --target x86_64-unknown-uefi --all-features

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -167,7 +167,7 @@ impl CStr16 {
 
     /// Writes each [`Char16`] as a [´char´] (4 bytes long in Rust language) into the buffer.
     /// It is up the the implementer of [`core::fmt::Write`] to convert the char to a string
-    /// with proper encoding/charset. For example, in the case of [`core::alloc::string::String`]
+    /// with proper encoding/charset. For example, in the case of [`alloc::string::String`]
     /// all Rust chars (UTF-32) get converted to UTF-8.
     ///
     /// ## Example
@@ -179,6 +179,8 @@ impl CStr16 {
     /// firmware_vendor_c16_str.as_str_in_buf(&mut buf);
     /// log::info!("as rust str: {}", buf.as_str());
     /// ```
+    ///
+    /// [`alloc::string::String`]: https://doc.rust-lang.org/nightly/alloc/string/struct.String.html
     pub fn as_str_in_buf(&self, buf: &mut dyn core::fmt::Write) -> core::fmt::Result {
         for c16 in self.iter() {
             buf.write_char(char::from(*c16))?;


### PR DESCRIPTION
- Fix a doc link that rustdoc doesn't understand
- Add a `cargo doc` step to the CI to catch things like that automatically
- Also changed the clippy lint to treat warnings as errors
- Enable more of the crate's features in tests