### PR TITLE
Add CString16

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -51,3 +51,8 @@ mod enums;
 
 mod strs;
 pub use self::strs::{CStr16, CStr8, FromSliceWithNulError};
+
+#[cfg(feature = "exts")]
+mod owned_strs;
+#[cfg(feature = "exts")]
+pub use self::owned_strs::{CString16, FromStrError};

--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -1,0 +1,90 @@
+use super::chars::{Char16, NUL_16};
+use super::strs::CStr16;
+use crate::alloc_api::vec::Vec;
+use core::convert::TryFrom;
+use core::ops;
+
+/// Error returned by [`CString16::try_from::<&str>`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FromStrError {
+    /// Character conversion error.
+    InvalidChar,
+    /// Nul character found in the input.
+    InteriorNul,
+}
+
+/// An owned UCS-2 null-terminated string.
+///
+/// # Examples
+///
+/// Round-trip conversion from a [`&str`] to a `CString16` and back:
+///
+/// ```
+/// use core::convert::TryFrom;
+/// use uefi::CString16;
+///
+/// let s = CString16::try_from("abc").unwrap();
+/// assert_eq!(s.as_string(), "abc");
+/// ```
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CString16(Vec<Char16>);
+
+impl TryFrom<&str> for CString16 {
+    type Error = FromStrError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        // Initially allocate one Char16 for each byte of the input, plus
+        // one for the null byte. This should be a good guess for ASCII-ish
+        // input.
+        let mut output = Vec::with_capacity(input.len() + 1);
+
+        // Convert to UTF-16, then convert to UCS-2.
+        for c in input.encode_utf16() {
+            let c = Char16::try_from(c).map_err(|_| FromStrError::InvalidChar)?;
+
+            // Check for interior nul chars.
+            if c == NUL_16 {
+                return Err(FromStrError::InteriorNul);
+            }
+
+            output.push(c);
+        }
+
+        // Add trailing nul.
+        output.push(NUL_16);
+
+        Ok(CString16(output))
+    }
+}
+
+impl ops::Deref for CString16 {
+    type Target = CStr16;
+
+    fn deref(&self) -> &CStr16 {
+        unsafe { &*(self.0.as_slice() as *const [Char16] as *const CStr16) }
+    }
+}
+
+impl AsRef<CStr16> for CString16 {
+    fn as_ref(&self) -> &CStr16 {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc_api::vec;
+
+    #[test]
+    fn test_cstring16_from_str() {
+        assert_eq!(
+            CString16::try_from("x").unwrap(),
+            CString16(vec![Char16::try_from('x').unwrap(), NUL_16])
+        );
+
+        assert_eq!(CString16::try_from("😀"), Err(FromStrError::InvalidChar));
+
+        assert_eq!(CString16::try_from("x\0"), Err(FromStrError::InteriorNul));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ extern crate self as uefi;
 
 #[macro_use]
 pub mod data_types;
+#[cfg(feature = "exts")]
+pub use self::data_types::CString16;
 pub use self::data_types::{unsafe_guid, Identify};
 pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
 

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -1,28 +1,11 @@
-use alloc::vec::Vec;
+use core::convert::TryFrom;
 use log::info;
 use uefi::prelude::*;
 use uefi::table::runtime::{VariableAttributes, VariableVendor};
-use uefi::{CStr16, Guid};
-
-struct CString16(Vec<u16>);
-
-impl CString16 {
-    fn from_str(input: &str) -> CString16 {
-        let mut v: Vec<u16> = input.encode_utf16().collect();
-        v.push(0);
-        CString16(v)
-    }
-
-    fn as_cstr16(&self) -> &CStr16 {
-        match CStr16::from_u16_with_nul(&self.0) {
-            Ok(s) => s,
-            Err(_) => panic!("invalid string"),
-        }
-    }
-}
+use uefi::{CString16, Guid};
 
 fn test_variables(rt: &RuntimeServices) {
-    let name = CString16::from_str("UefiRsTestVar");
+    let name = CString16::try_from("UefiRsTestVar").unwrap();
     let test_value = b"TestValue";
     let test_attrs = VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS;
 
@@ -36,19 +19,19 @@ fn test_variables(rt: &RuntimeServices) {
     ));
 
     info!("Testing set_variable");
-    rt.set_variable(name.as_cstr16(), &vendor, test_attrs, test_value)
+    rt.set_variable(&name, &vendor, test_attrs, test_value)
         .expect_success("failed to set variable");
 
     info!("Testing get_variable_size");
     let size = rt
-        .get_variable_size(name.as_cstr16(), &vendor)
+        .get_variable_size(&name, &vendor)
         .expect_success("failed to get variable size");
     assert_eq!(size, test_value.len());
 
     info!("Testing get_variable");
     let mut buf = [0u8; 9];
     let (data, attrs) = rt
-        .get_variable(name.as_cstr16(), &vendor, &mut buf)
+        .get_variable(&name, &vendor, &mut buf)
         .expect_success("failed to get variable");
     assert_eq!(data, test_value);
     assert_eq!(attrs, test_attrs);


### PR DESCRIPTION
For now the API is quite minimal; mostly it just makes interop between
regular Rust strings and EFI strings easier. You can convert from a
`&str` to a `CString16`, and since it derefs to `&CStr16` you can call
the methods exposed by that type as well.

This type is gated by the `exts` feature since it requires allocation.