### PR TITLE
Handle panics by unwinding the stack and implement `check_event` method

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,10 +79,6 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
-        env:
-          # This works around "duplicate item in crate core" errors:
-          # https://github.com/rust-lang/wg-cargo-std-aware/issues/56
-          CARGO_PROFILE_DEV_PANIC: unwind
         with:
           command: test
           args: -Zbuild-std=std --target x86_64-unknown-linux-gnu --features=exts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,6 @@ members = [
     "uefi-test-runner",
 ]
 
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
-
 [patch.crates-io]
 uefi-macros = { path = "uefi-macros" }
 uefi = { path = "." }

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,17 +1,13 @@
-use uefi::prelude::*;
 use uefi::table::boot::{BootServices, EventType, TimerTrigger, Tpl};
+use uefi::{prelude::*, Event};
 
 pub fn test(bt: &BootServices) {
     info!("Testing timer...");
     test_timer(bt);
+    info!("Testing events...");
+    test_event_callback(bt);
     info!("Testing watchdog...");
     test_watchdog(bt);
-}
-
-fn test_watchdog(bt: &BootServices) {
-    // Disable the UEFI watchdog timer
-    bt.set_watchdog_timer(0, 0x10000, None)
-        .expect_success("Could not set watchdog timer");
 }
 
 fn test_timer(bt: &BootServices) {
@@ -22,4 +18,20 @@ fn test_timer(bt: &BootServices) {
         .expect_success("Failed to set timer");
     bt.wait_for_event(&mut events)
         .expect_success("Wait for event failed");
+}
+
+fn test_event_callback(bt: &BootServices) {
+    fn callback(_event: Event) {
+        info!("Inside the event callback");
+    }
+    let event = unsafe { bt.create_event(EventType::NOTIFY_WAIT, Tpl::CALLBACK, Some(callback)) }
+        .expect_success("Failed to create custom event");
+    bt.check_event(event)
+        .expect_success("Failed to check event");
+}
+
+fn test_watchdog(bt: &BootServices) {
+    // Disable the UEFI watchdog timer
+    bt.set_watchdog_timer(0, 0x10000, None)
+        .expect_success("Could not set watchdog timer");
 }


### PR DESCRIPTION
The default panic mechanism was changed to `abort` in 58a623a70b50e2a3a1da61926b531a864b787ce8, to avoid issues with event callbacks. However, as far as I can tell, since https://github.com/rust-lang/rust/pull/76570, unwinding is automatically disabled for `extern "efiapi"` functions, so there shouldn't be any issue with using `panic = unwind` by default.

I've implemented the `check_event` method and added a new test for creating a custom event, and after playing around a bit, there seemed to be no issues with panics inside the notify function.