### PR TITLE
contributing: remove text about protocol macro limitations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,6 @@ low-level environment that UEFI operates in:
 ## Adding new protocols
 
 You should start by [forking this repository][fork] and cloning it.
-Due to the way the proc macros for `unsafe_guid` and `derive(Protocol)`
-are implemented, it's not currently possible to add new protocols
-outside of the core `uefi` crate.
 
 UEFI protocols are represented in memory as tables of function pointers,
 each of which takes the protocol itself as first parameter.


### PR DESCRIPTION
The proc macros now work correctly outside of the uefi crate thanks to
the improvements made in https://github.com/rust-osdev/uefi-rs/pull/260.