### PR TITLE
Add `CStr16::from_str_with_buf`

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -50,7 +50,7 @@ pub use self::chars::{Char16, Char8};
 mod enums;
 
 mod strs;
-pub use self::strs::{CStr16, CStr8, FromSliceWithNulError};
+pub use self::strs::{CStr16, CStr8, FromSliceWithNulError, FromStrWithBufError};
 
 #[cfg(feature = "exts")]
 mod owned_strs;

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -1,11 +1,11 @@
-use core::convert::TryFrom;
 use log::info;
 use uefi::prelude::*;
 use uefi::table::runtime::{VariableAttributes, VariableVendor};
-use uefi::{CString16, Guid};
+use uefi::{CStr16, Guid};
 
 fn test_variables(rt: &RuntimeServices) {
-    let name = CString16::try_from("UefiRsTestVar").unwrap();
+    let mut buf = [0; 14];
+    let name = CStr16::from_str_with_buf("UefiRsTestVar", &mut buf).unwrap();
     let test_value = b"TestValue";
     let test_attrs = VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS;
 


### PR DESCRIPTION
This provides an easy way to convert from a UTF-8 str to a CStr16
without requiring allocation. You just have to provide a backing buffer
large enough to store the converted characters.

Also converted the runtime vars test to use this method instead of
`CString16`, since if the runtime tests are ever moved to run after
exiting boot services, they won't be able to use allocation.