### PR TITLE
Implement missing `Event`-related functions

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -13,6 +13,7 @@ use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
 use core::mem::{self, MaybeUninit};
+use core::ptr::NonNull;
 use core::{ptr, slice};
 
 /// Contains pointers to all of the boot services.
@@ -48,8 +49,8 @@ pub struct BootServices {
         ty: EventType,
         notify_tpl: Tpl,
         notify_func: Option<EventNotifyFn>,
-        notify_ctx: *mut c_void,
-        event: *mut Event,
+        notify_ctx: Option<NonNull<c_void>>,
+        out_event: *mut Event,
     ) -> Status,
     set_timer: unsafe extern "efiapi" fn(event: Event, ty: u32, trigger_time: u64) -> Status,
     wait_for_event: unsafe extern "efiapi" fn(
@@ -149,7 +150,14 @@ pub struct BootServices {
     set_mem: unsafe extern "efiapi" fn(buffer: *mut u8, len: usize, value: u8),
 
     // New event functions (UEFI 2.0 or newer)
-    create_event_ex: usize,
+    create_event_ex: unsafe extern "efiapi" fn(
+        ty: EventType,
+        notify_tpl: Tpl,
+        notify_fn: Option<EventNotifyFn>,
+        notify_ctx: Option<NonNull<c_void>>,
+        event_group: Option<NonNull<Guid>>,
+        out_event: *mut Event,
+    ) -> Status,
 }
 
 impl BootServices {
@@ -307,31 +315,72 @@ impl BootServices {
         &self,
         event_ty: EventType,
         notify_tpl: Tpl,
-        notify_fn: Option<fn(Event)>,
+        notify_fn: Option<
+            unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>),
+        >,
+        notify_ctx: Option<NonNull<c_void>>,
     ) -> Result<Event> {
         // Prepare storage for the output Event
         let mut event = MaybeUninit::<Event>::uninit();
-
-        // Use a trampoline to handle the impedance mismatch between Rust & C
-        unsafe extern "efiapi" fn notify_trampoline(e: Event, ctx: *mut c_void) {
-            let notify_fn: fn(Event) = mem::transmute(ctx);
-            notify_fn(e); // SAFETY: Aborting panics are assumed here
-        }
-        let (notify_func, notify_ctx) = notify_fn
-            .map(|notify_fn| {
-                (
-                    Some(notify_trampoline as EventNotifyFn),
-                    notify_fn as fn(Event) as *mut c_void,
-                )
-            })
-            .unwrap_or((None, ptr::null_mut()));
 
         // Now we're ready to call UEFI
         (self.create_event)(
             event_ty,
             notify_tpl,
-            notify_func,
+            notify_fn,
             notify_ctx,
+            event.as_mut_ptr(),
+        )
+        .into_with_val(|| event.assume_init())
+    }
+
+    /// Creates a new `Event` of type `event_type`. The event's notification function, context,
+    /// and task priority are specified by `notify_fn`, `notify_ctx`, and `notify_tpl`, respectively.
+    /// The `Event` will be added to the group of `Event`s identified by `event_group`.
+    ///
+    /// If no group is specified by `event_group`, this function behaves as if the same parameters
+    /// had been passed to `create_event()`.
+    ///
+    /// Event groups are collections of events identified by a shared `Guid` where, when one member
+    /// event is signaled, all other events are signaled and their individual notification actions
+    /// are taken. All events are guaranteed to be signaled before the first notification action is
+    /// taken. All notification functions will be executed in the order specified by their `Tpl`.
+    ///
+    /// A single event can only be part of a single event group. An event may be removed from an
+    /// event group by using `close_event()`.
+    ///
+    /// The `EventType` of an event uses the same values as `create_event()`, except that
+    /// `EventType::SIGNAL_EXIT_BOOT_SERVICES` and `EventType::SIGNAL_VIRTUAL_ADDRESS_CHANGE`
+    /// are not valid.
+    ///
+    /// If `event_type` has `EventType::NOTIFY_SIGNAL` or `EventType::NOTIFY_WAIT`, then `notify_fn`
+    /// mus be `Some` and `notify_tpl` must be a valid task priority level, otherwise these parameters
+    /// are ignored.
+    ///
+    /// More than one event of type `EventType::TIMER` may be part of a single event group. However,
+    /// there is no mechanism for determining which of the timers was signaled.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure they are passing a valid `Guid`, if applicable.
+    pub unsafe fn create_event_ex(
+        &self,
+        event_type: EventType,
+        notify_tpl: Tpl,
+        notify_fn: Option<
+            unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>),
+        >,
+        notify_ctx: Option<NonNull<c_void>>,
+        event_group: Option<NonNull<Guid>>,
+    ) -> Result<Event> {
+        let mut event = MaybeUninit::<Event>::uninit();
+
+        (self.create_event_ex)(
+            event_type,
+            notify_tpl,
+            notify_fn,
+            notify_ctx,
+            event_group,
             event.as_mut_ptr(),
         )
         .into_with_val(|| event.assume_init())
@@ -1147,7 +1196,7 @@ bitflags! {
 }
 
 /// Raw event notification function
-type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: *mut c_void);
+type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>);
 
 /// Timer events manipulation
 pub enum TimerTrigger {

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,3 +1,7 @@
+use core::ffi::c_void;
+use core::ptr::NonNull;
+
+use uefi::proto::console::text::Output;
 use uefi::table::boot::{BootServices, EventType, TimerTrigger, Tpl};
 use uefi::{prelude::*, Event};
 
@@ -6,12 +10,13 @@ pub fn test(bt: &BootServices) {
     test_timer(bt);
     info!("Testing events...");
     test_event_callback(bt);
+    test_callback_with_ctx(bt);
     info!("Testing watchdog...");
     test_watchdog(bt);
 }
 
 fn test_timer(bt: &BootServices) {
-    let timer_event = unsafe { bt.create_event(EventType::TIMER, Tpl::APPLICATION, None) }
+    let timer_event = unsafe { bt.create_event(EventType::TIMER, Tpl::APPLICATION, None, None) }
         .expect_success("Failed to create TIMER event");
     let mut events = [timer_event];
     bt.set_timer(timer_event, TimerTrigger::Relative(5_0 /*00 ns */))
@@ -21,11 +26,39 @@ fn test_timer(bt: &BootServices) {
 }
 
 fn test_event_callback(bt: &BootServices) {
-    fn callback(_event: Event) {
+    extern "efiapi" fn callback(_event: Event, _ctx: Option<NonNull<c_void>>) {
         info!("Inside the event callback");
     }
-    let event = unsafe { bt.create_event(EventType::NOTIFY_WAIT, Tpl::CALLBACK, Some(callback)) }
-        .expect_success("Failed to create custom event");
+
+    let event =
+        unsafe { bt.create_event(EventType::NOTIFY_WAIT, Tpl::CALLBACK, Some(callback), None) }
+            .expect_success("Failed to create custom event");
+    bt.check_event(event)
+        .expect_success("Failed to check event");
+}
+
+fn test_callback_with_ctx(bt: &BootServices) {
+    extern "efiapi" fn callback(_event: Event, ctx: Option<NonNull<c_void>>) {
+        info!("Inside the event callback with context");
+        unsafe {
+            let ctx = &mut *(ctx.unwrap().as_ptr() as *mut Output);
+            // Clear the screen as a quick test that we successfully passed context
+            ctx.clear().expect_success("Failed to clear screen");
+        }
+    }
+
+    let ctx = unsafe { &mut *(bt.locate_protocol::<Output>().unwrap().unwrap().get()) };
+
+    let event = unsafe {
+        bt.create_event(
+            EventType::NOTIFY_WAIT,
+            Tpl::CALLBACK,
+            Some(callback),
+            Some(NonNull::new_unchecked(ctx as *mut _ as *mut c_void)),
+        )
+        .expect_success("Failed to create event with context")
+    };
+
     bt.check_event(event)
         .expect_success("Failed to check event");
 }


### PR DESCRIPTION
This is currently a draft; there are a few things I'm still unsure about or want to refine, but comments are more than welcome.

I've implemented the missing `close_event()`, `signal_event()`, and `create_event_ex()` functions. I've also adjusted the `create_event()` implementation to allow passing of the `notify_ctx` parameter, which is an opaque pointer to a struct that the `notify_fn` needs, commonly some kind of protocol interface. There is a new test, `test_callback_with_ctx()` that demonstrates this.

You'll see a few instances where I've used an `Option<NonNull<T>>` instead of `Option<*mut T>`, this is so we ensure that the `None` variant is equivalent to `null`, thus FFI-safe. 

There is an issue I'm having with the safety around `close_event()`. Once an event is closed, the specification says that it and any reference to it are invalid. I'm not sure about other fw implementation, but EDK2/OVMF actually free the memory for an `Event` during this call. I've marked the function as `unsafe` and have noted this in the safety docs, but is there a way to leverage the type system here instead of trusting the caller to never use that `Event` again? I had thought about removing `Copy` and `Clone` from `Event` so that it has move semantics, but that would require quite a bit of refactoring and I'm not entirely confident it would actually work. 

Thank you for looking at this! I've been having a lot of fun hacking on this project! :)