### PR TITLE
Enable all `uefi-rs` features on `docs.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ members = [
 [patch.crates-io]
 uefi-macros = { path = "uefi-macros" }
 uefi = { path = "." }
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
This change should cause docs.rs to show documentation for things hidden
behind feature flags, notably the `exts` feature.

See https://docs.rs/about/metadata for details.