### PR TITLE
Remove attribute to enable const_panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 #![feature(try_trait_v2)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
-#![feature(const_panic)]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(missing_docs, unused)]


### PR DESCRIPTION
This feature was recently stabilized in nightly, so enabling it started
producing a warning:

> warning: the feature `const_panic` has been stable since 1.57.0 and no
> longer requires an attribute to enable

This warning causes the CI to fail.