### PR TITLE
Fix missing_safety_doc lint

### DIFF
--- a/src/data_types/guid.rs
+++ b/src/data_types/guid.rs
@@ -86,6 +86,8 @@ impl fmt::Display for Guid {
 /// for more specific traits such as `Protocol` or `FileProtocolInfo`, which
 /// indicate in which circumstances an `Identify`-tagged type should be used.
 ///
+/// # Safety
+///
 /// Implementing `Identify` is unsafe because attaching an incorrect GUID to a
 /// type can lead to type unsafety on both the Rust and UEFI side.
 ///


### PR DESCRIPTION
The CI clippy check started failing with latest nightly due to missing
`# Safety` section in the docstring for the `Identify` trait. The
docstring already documents safety well, so just add the required
section header.