### PR TITLE
Temporarily failing test in uefi-macros

### DIFF
--- a/uefi-macros/tests/compilation.rs
+++ b/uefi-macros/tests/compilation.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 #[test]
+#[ignore = "failing in nightly due to github.com/rust-lang/rust/issues/89795"]
 fn ui() {
     let t = trybuild::TestCases::new();
 


### PR DESCRIPTION
This test is failing in nightly due to:
https://github.com/rust-lang/rust/issues/89795

Disabling the test for now to get the CI happy again. Will keep
https://github.com/rust-osdev/uefi-rs/issues/299 open as a reminder to
re-enable the test once the underlying issue has been fixed.