### PR TITLE
Revert "Temporarily failing test in uefi-macros"

### DIFF
--- a/uefi-macros/tests/compilation.rs
+++ b/uefi-macros/tests/compilation.rs
@@ -1,7 +1,6 @@
 use std::env;
 
 #[test]
-#[ignore = "failing in nightly due to github.com/rust-lang/rust/issues/89795"]
 fn ui() {
     let t = trybuild::TestCases::new();
 


### PR DESCRIPTION
This reverts commit a4f4fd2dc7b2d64075980e45dcfe8f3ec96e1976. The
upstream issue that was causing these tests to fail has been fixed:
https://github.com/rust-lang/rust/issues/89795

Fixes https://github.com/rust-osdev/uefi-rs/issues/299