### PR TITLE
Change Handle representation to be non-nullable so that Option<Handle> is FFI-safe

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -2,18 +2,14 @@
 //!
 //! This module defines the basic data types that are used throughout uefi-rs
 
-use core::{ffi::c_void, mem::MaybeUninit};
+use core::{ffi::c_void, ptr::NonNull};
 
-/// Opaque handle to an UEFI entity (protocol, image...)
+/// Opaque handle to an UEFI entity (protocol, image...), guaranteed to be non-null.
+///
+/// If you need to have a nullable handle (for a custom UEFI FFI for example) use `Option<Handle>`.
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct Handle(*mut c_void);
-
-impl Handle {
-    pub(crate) unsafe fn uninitialized() -> Self {
-        MaybeUninit::zeroed().assume_init()
-    }
-}
+pub struct Handle(NonNull<c_void>);
 
 /// Handle to an event structure
 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,10 @@
 //! For example, a PC with no network card might not contain a network driver,
 //! therefore all the network protocols will be unavailable.
 
-#![cfg_attr(feature = "exts", feature(allocator_api, alloc_layout_extra))]
+#![cfg_attr(
+    feature = "exts",
+    feature(allocator_api, alloc_layout_extra, vec_into_raw_parts)
+)]
 #![feature(auto_traits)]
 #![feature(control_flow_enum)]
 #![feature(try_trait_v2)]


### PR DESCRIPTION
While I rewrote the OUT pointers in UEFI methods to use `MaybeUninit` (which actually looks very clean and logical) to avoid ever having null handles, the reason for the repr change is so that whenever an UEFI method accepts a handle - by the docs it can be optional or not, and this can be expressed by just having either `Handle` or `Option<Handle>` in the fn-pointer args, which is very clean and removes the need for null handles (`Handle::unitialized()`) to ever exist on Rust side.

I spent a night debugging my impls of (dis)connect_controller (that I will make a PR for too at some point) only to realize that I automatically assumed that whatever I did in the PR was already there ¯\_(ツ)_/¯
