### PR TITLE
Revert "Temporarily disable a false-positive clippy lint"

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -60,8 +60,6 @@ unsafe impl GlobalAlloc for Allocator {
         let align = layout.align();
 
         if align > 8 {
-            // TODO: https://github.com/rust-osdev/uefi-rs/issues/303
-            #[allow(clippy::question_mark)]
             // allocate more space for alignment
             let ptr = if let Ok(ptr) = boot_services()
                 .as_ref()


### PR DESCRIPTION
This reverts commit cba22ccac0503b5d15f8f1544ea1899232d98caa.

Fixes #303