### PR TITLE
Improve Handle buffer handling code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 
 #![cfg_attr(
     feature = "exts",
-    feature(allocator_api, alloc_layout_extra, vec_into_raw_parts)
+    feature(allocator_api, alloc_layout_extra, vec_spare_capacity)
 )]
 #![feature(auto_traits)]
 #![feature(control_flow_enum)]


### PR DESCRIPTION
Only now, after #309 was merged, I learned that there is a cleaner ~~unstable~~ way of using a vector as an unitialized buffer and then marking it as initialized without any pointer reinterpretations.

Here is a change that implements that - check it out.

