### PR TITLE
Add flag to `build.py` for disabling KVM

### DIFF
--- a/uefi-test-runner/README.md
+++ b/uefi-test-runner/README.md
@@ -38,3 +38,7 @@ Available options:
 - `--verbose`: enables verbose mode, prints commands before running them
 - `--headless`: enables headless mode, which runs QEMU without a GUI
 - `--release`: builds the code with optimizations enabled
+- `--disable-kvm`: disable [KVM](https://www.linux-kvm.org/page/Main_Page) hardware acceleration
+  when running the tests in QEMU
+
+  This is especially useful if you want to run the tests under [WSL](https://docs.microsoft.com/en-us/windows/wsl/) on Windows.

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -28,6 +28,9 @@ SETTINGS = {
     'config': 'debug',
     # Disables some tests which don't work in our CI setup
     'ci': False,
+    # KVM is a Linux kernel module which allows QEMU to use
+    # hardware-accelerated virtualization.
+    'disable_kvm': False,
     # QEMU executable to use
     # Indexed by the `arch` setting
     'qemu_binary': {
@@ -247,8 +250,9 @@ def run_qemu():
             '-m', '256M',
         ])
         if not SETTINGS['ci']:
-            # Enable acceleration if possible.
-            qemu_flags.append('--enable-kvm')
+            # Enable hardware-accelerated virtualization if possible.
+            if not SETTINGS['disable_kvm']:
+                qemu_flags.append('--enable-kvm')
         else:
             # Exit instead of rebooting
             qemu_flags.append('-no-reboot')
@@ -407,6 +411,9 @@ def main():
     parser.add_argument('--ci', help='disables some tests which currently break CI',
                         action='store_true')
 
+    parser.add_argument('--disable-kvm', help='disables hardware accelerated virtualization support in QEMU',
+                        action='store_true')
+
     opts = parser.parse_args()
 
     SETTINGS['arch'] = opts.target
@@ -415,6 +422,7 @@ def main():
     SETTINGS['headless'] = opts.headless
     SETTINGS['config'] = 'release' if opts.release else 'debug'
     SETTINGS['ci'] = opts.ci
+    SETTINGS['disable_kvm'] = opts.disable_kvm
 
     verb = opts.verb
 


### PR DESCRIPTION
I've recently had the need to build and run the project on Windows using the Windows Subsystem for Linux, and I didn't encounter many blockers. The only problem is that QEMU would try to use KVM, which is currently broken in WSL. This PR adds a new flag to the test runner to allow selectively disabling hardware acceleration.

With this change,  `./build.py run --disable-kvm --ci --headless` runs all the tests successfully under WSL2 on Windows 10. Unfortunately, trying to run the tests excluded from CI results in failures, suggesting that QEMU on WSL has some similar bugs.