### PR TITLE
Implement `open_protocol`, use it to fix flaky screenshot test

### DIFF
--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -2,7 +2,7 @@ use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::BootServices;
 
-pub fn test(bt: &BootServices) {
+pub fn test(image: Handle, bt: &BootServices) {
     info!("Running graphics output protocol test");
     if let Ok(gop) = bt.locate_protocol::<GraphicsOutput>() {
         let gop = gop.expect("Warnings encountered while opening GOP");
@@ -12,7 +12,7 @@ pub fn test(bt: &BootServices) {
         fill_color(gop);
         draw_fb(gop);
 
-        crate::check_screenshot(bt, "gop_test");
+        crate::check_screenshot(image, bt, "gop_test");
     } else {
         // No tests can be run.
         warn!("UEFI Graphics Output Protocol is not supported");

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,13 +1,13 @@
 use uefi::prelude::*;
 
-pub fn test(st: &mut SystemTable<Boot>) {
+pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());
 
     let bt = st.boot_services();
     serial::test(bt);
-    gop::test(bt);
+    gop::test(image, bt);
     pointer::test(bt);
 }
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -6,7 +6,7 @@ use uefi::{proto, Identify};
 pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     info!("Testing various protocols");
 
-    console::test(st);
+    console::test(image, st);
 
     let bt = st.boot_services();
     find_protocol(bt);

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -12,9 +12,9 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     find_protocol(bt);
     test_protocols_per_handle(image, bt);
 
-    debug::test(bt);
+    debug::test(image, bt);
     device_path::test(image, bt);
-    media::test(bt);
+    media::test(image, bt);
     pi::test(bt);
 
     #[cfg(any(


### PR DESCRIPTION
First commit implements open_protocol, test_protocol, and close_protocol. Second commit uses it in the test code for screenshots, which fixes occasional unexpected timeout errors.