### PR TITLE
Improve clippy linting in `build.py` and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,10 +102,7 @@ jobs:
           args: --all -- --check
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target x86_64-unknown-uefi --all-features -- -Dwarnings
+        run: uefi-test-runner/build.py clippy
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -68,6 +68,10 @@ def esp_dir():
     'Returns the directory where we will build the emulated UEFI system partition'
     return build_dir() / 'esp'
 
+def repo_dir():
+    'Returns the root directory of the git repo.'
+    return Path(__file__).resolve().parent.parent
+
 def run_tool(tool, *flags):
     'Runs cargo-<tool> with certain arguments.'
 
@@ -120,7 +124,15 @@ def build(*test_flags):
 def clippy():
     'Runs Clippy on all projects'
 
-    run_clippy('--all')
+    run_clippy(
+        # Specifying the manifest path allows this command to
+        # run successfully regardless of the CWD.
+        '--manifest-path', repo_dir() / 'Cargo.toml',
+        # Lint all packages in the workspace.
+        '--workspace',
+        # Enable all the features in the uefi package that enable more
+        # code.
+        '--features=alloc,exts,logger')
 
 def doc():
     'Generates documentation for the library crates.'
@@ -158,12 +170,11 @@ def get_host_target():
 
 def test():
     'Run tests and doctests using the host target.'
-    repo_dir = Path(__file__).resolve().parent.parent
     sp.run([
         'cargo', 'test',
         # Specifying the manifest path allows this command to
         # run successfully regardless of the CWD.
-        '--manifest-path', repo_dir / 'Cargo.toml',
+        '--manifest-path', repo_dir() / 'Cargo.toml',
         '-Zbuild-std=std',
         '--target', get_host_target(),
         '--features', 'exts',

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -19,19 +19,19 @@ fn test_variables(rt: &RuntimeServices) {
     ));
 
     info!("Testing set_variable");
-    rt.set_variable(&name, &vendor, test_attrs, test_value)
+    rt.set_variable(name, &vendor, test_attrs, test_value)
         .expect_success("failed to set variable");
 
     info!("Testing get_variable_size");
     let size = rt
-        .get_variable_size(&name, &vendor)
+        .get_variable_size(name, &vendor)
         .expect_success("failed to get variable size");
     assert_eq!(size, test_value.len());
 
     info!("Testing get_variable");
     let mut buf = [0u8; 9];
     let (data, attrs) = rt
-        .get_variable(&name, &vendor, &mut buf)
+        .get_variable(name, &vendor, &mut buf)
         .expect_success("failed to get variable");
     assert_eq!(data, test_value);
     assert_eq!(attrs, test_attrs);


### PR DESCRIPTION
The CI only lints the uefi package but with all features enabled, while build.py lints all packages but with no features enabled. Change build.py to lint all packages with a subset of features enabled (all the uefi features that enable more code), and change the CI to just run the build.py clippy command so that the two stay in sync.

Also fixed a few clippy lints in the test runner.