### PR TITLE
Change memory_map_size return

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,10 +102,7 @@ jobs:
           args: --all -- --check
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target x86_64-unknown-uefi --all-features -- -Dwarnings
+        run: uefi-test-runner/build.py clippy
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,5 +135,5 @@ impl NewProtocol {
 
 ## Publishing new versions of the crates
 
-Maintainers of this repository might also be interested in [the guidelines](CONTRIBUTING.md)
+Maintainers of this repository might also be interested in [the guidelines](PUBLISHING.md)
 for publishing new versions of the uefi-rs crates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,3 +132,8 @@ impl NewProtocol {
 ```
 
 [fork]: https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo
+
+## Publishing new versions of the crates
+
+Maintainers of this repository might also be interested in [the guidelines](CONTRIBUTING.md)
+for publishing new versions of the uefi-rs crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>"]
 readme = "README.md"
 edition = "2018"
@@ -34,8 +34,8 @@ ignore-logger-errors = []
 [dependencies]
 bitflags = "1.3.2"
 log = { version = "0.4.14", default-features = false }
-ucs2 = "0.3.1"
-uefi-macros = "0.4.0"
+ucs2 = "0.3.2"
+uefi-macros = "0.5.0"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ members = [
 [patch.crates-io]
 uefi-macros = { path = "uefi-macros" }
 uefi = { path = "." }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -31,13 +31,11 @@ can be combined in a single pull request).
 
 The dependency graph of the published crates in this repo is:
 
-```
-uefi-macros <-- uefi (root project) <-- uefi-services
-```
+- `uefi-services` depends on `uefi` (the root project)
+- `uefi` depends on `uefi-macros`
 
-which suggests that, if there are breaking changes happening in the project,
-we should first process/publish a new version of `uefi-macros`, then of `uefi`,
-then of `uefi-services` and so on.
+If there are breaking changes happening in the project, we should first publish
+a new version of `uefi-macros`, then of `uefi`, then of `uefi-services` and so on.
 
 For example, if the signature of a widely-used macro from `uefi-macros` is changed,
 a new major version of that crate will have to be published, then a new version of

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,78 @@
+# Publishing new versions of uefi-rs to Crates.io
+
+This guide documents the best practices for publishing new versions of
+the crates in this repository to [crates.io](https://crates.io/).
+
+**It is mostly intended for maintainers of the uefi-rs project.**
+
+## Before bumping the crate versions
+
+It is a good idea to occasionally update/refresh the dependencies of the uefi-rs crates,
+even if we don't necessarily need a bugfix included in one of them.
+
+This can be done easily by using the [`cargo upgrade`][cargo-upgrade] tool.
+
+[cargo-upgrade]: https://crates.io/crates/cargo-edit#cargo-upgrade
+
+## Bumping the crate versions
+
+For ensuring compatibility within the crates ecosystem,
+Cargo [recommends][cargo-semver] maintainers to follow the [semantic versioning][semver] guidelines.
+
+This means that before publishing the changes, we need to decide
+which crates were modified and how should their version numbers be incremented.
+
+Incrementing the version number of a crate is as simple as editing
+the corresponding `Cargo.toml` file and updating the `version = ...` line,
+then commiting the change (preferrably on a new branch, so that all of the version bumps
+can be combined in a single pull request).
+
+### Crate dependencies
+
+The dependency graph of the published crates in this repo is:
+
+```
+uefi-macros <-- uefi (root project) <-- uefi-services
+```
+
+which suggests that, if there are breaking changes happening in the project,
+we should first process/publish a new version of `uefi-macros`, then of `uefi`,
+then of `uefi-services` and so on.
+
+For example, if the signature of a widely-used macro from `uefi-macros` is changed,
+a new major version of that crate will have to be published, then a new version of
+`uefi` (major if the previous bump caused changes in the public API of this crate as well),
+then possibly a new version of `uefi-services`.
+
+Furthermore, `uefi-macros` has the `uefi` crate as a `dev-dependency`,
+and that will have to be updated in tandem with the major versions of the core crate.
+
+### Updating the dependent crates
+
+Remember that if a new major version of a crate gets released, when bumping the version
+of it's dependents you will have to also change the dependency line for it.
+
+For example, if `uefi-macros` gets bumped from `1.1.0` to `2.0.0`,
+you will also have to update the corresponding `Cargo.toml` of `uefi` to be:
+
+```toml
+uefi-macros = "2.0.0"
+```
+
+[cargo-semver]: https://doc.rust-lang.org/cargo/reference/semver.html
+[semver]: https://semver.org/
+
+## Publishing new versions of the crates
+
+This section is mostly a summary of the official [guide to publishing on crates.io][cargo-publishing-reference],
+with a few remarks regarding the specific of this project.
+
+Start by following the steps in the guide. When running `cargo publish`,
+you will have to use a custom `--target` flag to be able to build/verify the crates:
+
+```
+cargo publish --target x86_64-unknown-uefi
+```
+
+[cargo-publishing-reference]: https://doc.rust-lang.org/cargo/reference/publishing.html
+

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -218,12 +218,13 @@ impl BootServices {
         (self.free_pages)(addr, count).into()
     }
 
-    /// Retrieves the size, in bytes, of the current memory map.
+    /// Returns struct which contains the size of a single memory descriptor
+    /// as well as the size of the current memory map.
     ///
-    /// A buffer of this size will be capable of holding the whole current memory map,
-    /// including padding. Note, however, that allocations will increase the size of the
-    /// memory map, therefore it is better to allocate some extra space.
-    pub fn memory_map_size(&self) -> usize {
+    /// Note that the size of the memory map can increase any time an allocation happens,
+    /// so when creating a buffer to put the memory map into, it's recommended to allocate a few extra
+    /// elements worth of space above the size of the current memory map.
+    pub fn memory_map_size(&self) -> MemoryMapSize {
         let mut map_size = 0;
         let mut map_key = MemoryMapKey(0);
         let mut entry_size = 0;
@@ -240,7 +241,10 @@ impl BootServices {
         };
         assert_eq!(status, Status::BUFFER_TOO_SMALL);
 
-        map_size
+        MemoryMapSize {
+            entry_size,
+            map_size,
+        }
     }
 
     /// Retrieves the current memory map.
@@ -1296,6 +1300,14 @@ bitflags! {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub struct MemoryMapKey(usize);
+
+/// A structure containing the size of a memory descriptor and the size of the memory map
+pub struct MemoryMapSize {
+    /// Size of a single memory descriptor in bytes
+    pub entry_size: usize,
+    /// Size of the entire memory map in bytes
+    pub map_size: usize,
+}
 
 /// An iterator of memory descriptors
 #[derive(Debug, Clone)]

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -123,8 +123,20 @@ pub struct BootServices {
     disconnect_controller: usize,
 
     // Protocol open / close services
-    open_protocol: usize,
-    close_protocol: usize,
+    open_protocol: extern "efiapi" fn(
+        handle: Handle,
+        protocol: &Guid,
+        interface: &mut *mut c_void,
+        agent_handle: Handle,
+        controller_handle: Option<Handle>,
+        attributes: u32,
+    ) -> Status,
+    close_protocol: extern "efiapi" fn(
+        handle: Handle,
+        protocol: &Guid,
+        agent_handle: Handle,
+        controller_handle: Option<Handle>,
+    ) -> Status,
     open_protocol_information: usize,
 
     // Library services
@@ -481,10 +493,16 @@ impl BootServices {
     /// This function attempts to get the protocol implementation of a handle,
     /// based on the protocol GUID.
     ///
+    /// It is recommended that all new drivers and applications use
+    /// [`open_protocol`] instead of `handle_protocol`.
+    ///
     /// UEFI protocols are neither thread-safe nor reentrant, but the firmware
     /// provides no mechanism to protect against concurrent usage. Such
     /// protections must be implemented by user-level code, for example via a
     /// global `HashSet`.
+    ///
+    /// [`open_protocol`]: BootServices::open_protocol
+    #[deprecated(note = "it is recommended to use `open_protocol` instead")]
     pub fn handle_protocol<P: Protocol>(&self, handle: Handle) -> Result<&UnsafeCell<P>> {
         let mut ptr = ptr::null_mut();
         (self.handle_protocol)(handle, &P::GUID, &mut ptr).into_with_val(|| {
@@ -672,6 +690,67 @@ impl BootServices {
         unsafe { (self.set_watchdog_timer)(timeout, watchdog_code, data_len, data) }.into()
     }
 
+    /// Open a protocol interface for a handle.
+    ///
+    /// This function attempts to get the protocol implementation of a
+    /// handle, based on the protocol GUID. It is an extended version of
+    /// [`handle_protocol`]. It is recommended that all
+    /// new drivers and applications use `open_protocol` instead of
+    /// `handle_protocol`.
+    ///
+    /// See [`OpenProtocolParams`] and [`OpenProtocolAttributes`] for
+    /// details of the input parameters.
+    ///
+    /// If successful, a [`ScopedProtocol`] is returned that will
+    /// automatically close the protocol interface when dropped.
+    ///
+    /// UEFI protocols are neither thread-safe nor reentrant, but the firmware
+    /// provides no mechanism to protect against concurrent usage. Such
+    /// protections must be implemented by user-level code, for example via a
+    /// global `HashSet`.
+    ///
+    /// [`handle_protocol`]: BootServices::handle_protocol
+    pub fn open_protocol<P: Protocol>(
+        &self,
+        params: OpenProtocolParams,
+        attributes: OpenProtocolAttributes,
+    ) -> Result<ScopedProtocol<P>> {
+        let mut interface = ptr::null_mut();
+        (self.open_protocol)(
+            params.handle,
+            &P::GUID,
+            &mut interface,
+            params.agent,
+            params.controller,
+            attributes as u32,
+        )
+        .into_with_val(|| {
+            let interface = interface as *mut P as *mut UnsafeCell<P>;
+            unsafe {
+                ScopedProtocol {
+                    interface: &*interface,
+                    open_params: params,
+                    boot_services: self,
+                }
+            }
+        })
+    }
+
+    /// Test whether a handle supports a protocol.
+    pub fn test_protocol<P: Protocol>(&self, params: OpenProtocolParams) -> Result<()> {
+        const TEST_PROTOCOL: u32 = 0x04;
+        let mut interface = ptr::null_mut();
+        (self.open_protocol)(
+            params.handle,
+            &P::GUID,
+            &mut interface,
+            params.agent,
+            params.controller,
+            TEST_PROTOCOL,
+        )
+        .into_with_val(|| ())
+    }
+
     /// Get the list of protocol interface [`Guids`][Guid] that are installed
     /// on a [`Handle`].
     pub fn protocols_per_handle(&self, handle: Handle) -> Result<ProtocolsPerHandle> {
@@ -770,24 +849,45 @@ impl BootServices {
     pub fn get_image_file_system(
         &self,
         image_handle: Handle,
-    ) -> Result<&UnsafeCell<SimpleFileSystem>> {
+    ) -> Result<ScopedProtocol<SimpleFileSystem>> {
         let loaded_image = self
-            .handle_protocol::<LoadedImage>(image_handle)?
+            .open_protocol::<LoadedImage>(
+                OpenProtocolParams {
+                    handle: image_handle,
+                    agent: image_handle,
+                    controller: None,
+                },
+                OpenProtocolAttributes::Exclusive,
+            )?
             .expect("Failed to retrieve `LoadedImage` protocol from handle");
-        let loaded_image = unsafe { &*loaded_image.get() };
+        let loaded_image = unsafe { &*loaded_image.interface.get() };
 
         let device_handle = loaded_image.device();
 
         let device_path = self
-            .handle_protocol::<DevicePath>(device_handle)?
+            .open_protocol::<DevicePath>(
+                OpenProtocolParams {
+                    handle: device_handle,
+                    agent: image_handle,
+                    controller: None,
+                },
+                OpenProtocolAttributes::Exclusive,
+            )?
             .expect("Failed to retrieve `DevicePath` protocol from image's device handle");
-        let mut device_path = unsafe { &*device_path.get() };
+        let mut device_path = unsafe { &*device_path.interface.get() };
 
         let device_handle = self
             .locate_device_path::<SimpleFileSystem>(&mut device_path)?
             .expect("Failed to locate `SimpleFileSystem` protocol on device path");
 
-        self.handle_protocol::<SimpleFileSystem>(device_handle)
+        self.open_protocol::<SimpleFileSystem>(
+            OpenProtocolParams {
+                handle: device_handle,
+                agent: image_handle,
+                controller: None,
+            },
+            OpenProtocolAttributes::Exclusive,
+        )
     }
 }
 
@@ -959,6 +1059,97 @@ impl Drop for TplGuard<'_> {
         unsafe {
             (self.boot_services.restore_tpl)(self.old_tpl);
         }
+    }
+}
+
+// OpenProtocolAttributes is safe to model as a regular enum because it
+// is only used as an input. The attributes are bitflags, but all valid
+// combinations are listed in the spec and only ByDriver and Exclusive
+// can actually be combined.
+//
+// Some values intentionally excluded:
+//
+// ByHandleProtocol (0x01) excluded because it is only intended to be
+// used in an implementation of `HandleProtocol`.
+//
+// TestProtocol (0x04) excluded because it doesn't actually open the
+// protocol, just tests if it's present on the handle. Since that
+// changes the interface significantly, that's exposed as a separate
+// method: `BootServices::test_protocol`.
+
+/// Attributes for [`BootServices::open_protocol`].
+#[repr(u32)]
+pub enum OpenProtocolAttributes {
+    /// Used by drivers to get a protocol interface for a handle. The
+    /// driver will not be informed if the interface is uninstalled or
+    /// reinstalled.
+    GetProtocol = 0x02,
+
+    /// Used by bus drivers to show that a protocol is being used by one
+    /// of the child controllers of the bus.
+    ByChildController = 0x08,
+
+    /// Used by a driver to gain access to a protocol interface. When
+    /// this mode is used, the driver's `Stop` function will be called
+    /// if the protocol interface is reinstalled or uninstalled. Once a
+    /// protocol interface is opened with this attribute, no other
+    /// drivers will be allowed to open the same protocol interface with
+    /// the `ByDriver` attribute.
+    ByDriver = 0x10,
+
+    /// Used by a driver to gain exclusive access to a protocol
+    /// interface. If any other drivers have the protocol interface
+    /// opened with an attribute of `ByDriver`, then an attempt will be
+    /// made to remove them with `DisconnectController`.
+    ByDriverExclusive = 0x30,
+
+    /// Used by applications to gain exclusive access to a protocol
+    /// interface. If any drivers have the protocol opened with an
+    /// attribute of `ByDriver`, then an attempt will be made to remove
+    /// them by calling the driver's `Stop` function.
+    Exclusive = 0x20,
+}
+
+/// Parameters passed to [`BootServices::open_protocol`].
+pub struct OpenProtocolParams {
+    /// The handle for the protocol to open.
+    pub handle: Handle,
+
+    /// The handle of the calling agent. For drivers, this is the handle
+    /// containing the `EFI_DRIVER_BINDING_PROTOCOL` instance. For
+    /// applications, this is the image handle.
+    pub agent: Handle,
+
+    /// For drivers, this is the controller handle that requires the
+    /// protocol interface. For applications this should be set to
+    /// `None`.
+    pub controller: Option<Handle>,
+}
+
+/// An open protocol interface. Automatically closes the protocol
+/// interface on drop.
+pub struct ScopedProtocol<'a, P: Protocol> {
+    /// The protocol interface.
+    pub interface: &'a UnsafeCell<P>,
+
+    open_params: OpenProtocolParams,
+    boot_services: &'a BootServices,
+}
+
+impl<'a, P: Protocol> Drop for ScopedProtocol<'a, P> {
+    fn drop(&mut self) {
+        let status = (self.boot_services.close_protocol)(
+            self.open_params.handle,
+            &P::GUID,
+            self.open_params.agent,
+            self.open_params.controller,
+        );
+        // All of the error cases for close_protocol boil down to
+        // calling it with a different set of parameters than what was
+        // passed to open_protocol. The public API prevents such errors,
+        // and the error can't be propagated out of drop anyway, so just
+        // assert success.
+        assert_eq!(status, Status::SUCCESS);
     }
 }
 

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -111,6 +111,13 @@ impl SystemTable<Boot> {
     /// `SystemTable<Boot>` view of the System Table and returning a more
     /// restricted `SystemTable<Runtime>` view as an output.
     ///
+    /// Once boot services are exited, the logger and allocator provided by
+    /// this crate can no longer be used. The logger should be disabled using
+    /// the [`Logger::disable`] method, and the allocator should be disabled by
+    /// calling [`alloc::exit_boot_services`]. Note that if the logger and
+    /// allocator were initialized with [`uefi_services::init`], they will be
+    /// disabled automatically when `exit_boot_services` is called.
+    ///
     /// The handle passed must be the one of the currently executing image,
     /// which is received by the entry point of the UEFI application. In
     /// addition, the application must provide storage for a memory map, which
@@ -132,6 +139,10 @@ impl SystemTable<Boot> {
     /// system table which more accurately reflects the state of the UEFI
     /// firmware following exit from boot services, along with a high-level
     /// iterator to the UEFI memory map.
+    ///
+    /// [`alloc::exit_boot_services`]: crate::alloc::exit_boot_services
+    /// [`Logger::disable`]: crate::logger::Logger::disable
+    /// [`uefi_services::init`]: https://docs.rs/uefi-services/latest/uefi_services/fn.init.html
     pub fn exit_boot_services(
         self,
         image: Handle,

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-macros"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Hadrien G. <knights_of_ni@gmx.com>"]
 readme = "README.md"
 edition = "2018"
@@ -19,10 +19,10 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.28"
-quote = "1.0.9"
-syn = { version = "1.0.75", features = ["full"] }
+proc-macro2 = "1.0.33"
+quote = "1.0.10"
+syn = { version = "1.0.82", features = ["full"] }
 
 [dev-dependencies]
-trybuild = "1.0.45"
-uefi = { version = "0.12.0", default-features = false }
+trybuild = "1.0.53"
+uefi = { version = "0.13.0", default-features = false }

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>"]
 edition = "2018"
 description = "Higher-level utilities for uefi-rs"
@@ -15,7 +15,7 @@ is-it-maintained-issue-resolution = { repository = "rust-osdev/uefi-rs" }
 is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 
 [dependencies]
-uefi = { version = "0.12.0", features = ["alloc", "logger"] }
+uefi = { version = "0.13.0", features = ["alloc", "logger"] }
 log = { version = "0.4.14", default-features = false }
 cfg-if = "1.0.0"
 qemu-exit = { version = "2.0.1", optional = true }

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -3,11 +3,18 @@
 //! It initializes the memory allocation and logging crates,
 //! allowing code to use Rust's data structures and to log errors.
 //!
+//! Logging and allocation are only allowed while boot services are
+//! active. Once runtime services are activated by calling
+//! [`exit_boot_services`], the logger will be disabled and the
+//! allocator will always return null.
+//!
 //! It also stores a global reference to the UEFI system table,
 //! in order to reduce the redundant passing of references to it.
 //!
 //! Library code can simply use global UEFI functions
 //! through the reference provided by `system_table`.
+//!
+//! [`exit_boot_services`]: uefi::table::SystemTable::exit_boot_services
 
 #![no_std]
 #![feature(alloc_error_handler)]

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -68,6 +68,10 @@ def esp_dir():
     'Returns the directory where we will build the emulated UEFI system partition'
     return build_dir() / 'esp'
 
+def repo_dir():
+    'Returns the root directory of the git repo.'
+    return Path(__file__).resolve().parent.parent
+
 def run_tool(tool, *flags):
     'Runs cargo-<tool> with certain arguments.'
 
@@ -120,7 +124,15 @@ def build(*test_flags):
 def clippy():
     'Runs Clippy on all projects'
 
-    run_clippy('--all')
+    run_clippy(
+        # Specifying the manifest path allows this command to
+        # run successfully regardless of the CWD.
+        '--manifest-path', repo_dir() / 'Cargo.toml',
+        # Lint all packages in the workspace.
+        '--workspace',
+        # Enable all the features in the uefi package that enable more
+        # code.
+        '--features=alloc,exts,logger')
 
 def doc():
     'Generates documentation for the library crates.'
@@ -158,12 +170,11 @@ def get_host_target():
 
 def test():
     'Run tests and doctests using the host target.'
-    repo_dir = Path(__file__).resolve().parent.parent
     sp.run([
         'cargo', 'test',
         # Specifying the manifest path allows this command to
         # run successfully regardless of the CWD.
-        '--manifest-path', repo_dir / 'Cargo.toml',
+        '--manifest-path', repo_dir() / 'Cargo.toml',
         '-Zbuild-std=std',
         '--target', get_host_target(),
         '--features', 'exts',

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -79,7 +79,7 @@ def run_tool(tool, *flags):
     cmd = ['cargo', tool, '--target', target, *flags]
 
     if SETTINGS['verbose']:
-        print(' '.join(cmd))
+        print(' '.join(str(arg) for arg in cmd))
 
     sp.run(cmd, check=True)
 

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -132,7 +132,9 @@ def clippy():
         '--workspace',
         # Enable all the features in the uefi package that enable more
         # code.
-        '--features=alloc,exts,logger')
+        '--features=alloc,exts,logger',
+        # Treat all warnings as errors.
+        '--', '-D', 'warnings')
 
 def doc():
     'Generates documentation for the library crates.'

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -1,8 +1,7 @@
 use uefi::prelude::*;
-use uefi::table::boot::{AllocateType, BootServices, MemoryDescriptor, MemoryType};
+use uefi::table::boot::{AllocateType, BootServices, MemoryType};
 
 use crate::alloc::vec::Vec;
-use core::mem;
 
 pub fn test(bt: &BootServices) {
     info!("Testing memory functions");
@@ -84,13 +83,13 @@ fn memmove(bt: &BootServices) {
 fn memory_map(bt: &BootServices) {
     info!("Testing memory map functions");
 
-    // Get an estimate of the memory map size.
-    let map_sz = bt.memory_map_size();
+    // Get the memory descriptor size and an estimate of the memory map size
+    let sizes = bt.memory_map_size();
 
-    // 8 extra descriptors should be enough.
-    let buf_sz = map_sz + 8 * mem::size_of::<MemoryDescriptor>();
+    // 2 extra descriptors should be enough.
+    let buf_sz = sizes.map_size + 2 * sizes.entry_size;
 
-    // We will use vectors for convencience.
+    // We will use vectors for convenience.
     let mut buffer = vec![0_u8; buf_sz];
 
     let (_key, desc_iter) = bt

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -9,10 +9,9 @@ extern crate log;
 extern crate alloc;
 
 use alloc::string::String;
-use core::mem;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
-use uefi::table::boot::{MemoryDescriptor, OpenProtocolAttributes, OpenProtocolParams};
+use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
 
 mod boot;
 mod proto;
@@ -142,8 +141,8 @@ fn shutdown(image: uefi::Handle, mut st: SystemTable<Boot>) -> ! {
     }
 
     // Exit boot services as a proof that it works :)
-    let max_mmap_size =
-        st.boot_services().memory_map_size() + 8 * mem::size_of::<MemoryDescriptor>();
+    let sizes = st.boot_services().memory_map_size();
+    let max_mmap_size = sizes.map_size + 2 * sizes.entry_size;
     let mut mmap_storage = vec![0; max_mmap_size].into_boxed_slice();
     let (st, _iter) = st
         .exit_boot_services(image, &mut mmap_storage[..])

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -2,7 +2,7 @@ use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::BootServices;
 
-pub fn test(bt: &BootServices) {
+pub fn test(image: Handle, bt: &BootServices) {
     info!("Running graphics output protocol test");
     if let Ok(gop) = bt.locate_protocol::<GraphicsOutput>() {
         let gop = gop.expect("Warnings encountered while opening GOP");
@@ -12,7 +12,7 @@ pub fn test(bt: &BootServices) {
         fill_color(gop);
         draw_fb(gop);
 
-        crate::check_screenshot(bt, "gop_test");
+        crate::check_screenshot(image, bt, "gop_test");
     } else {
         // No tests can be run.
         warn!("UEFI Graphics Output Protocol is not supported");

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,13 +1,13 @@
 use uefi::prelude::*;
 
-pub fn test(st: &mut SystemTable<Boot>) {
+pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());
 
     let bt = st.boot_services();
     serial::test(bt);
-    gop::test(bt);
+    gop::test(image, bt);
     pointer::test(bt);
 }
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -6,15 +6,15 @@ use uefi::{proto, Identify};
 pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     info!("Testing various protocols");
 
-    console::test(st);
+    console::test(image, st);
 
     let bt = st.boot_services();
     find_protocol(bt);
     test_protocols_per_handle(image, bt);
 
-    debug::test(bt);
+    debug::test(image, bt);
     device_path::test(image, bt);
-    media::test(bt);
+    media::test(image, bt);
     pi::test(bt);
 
     #[cfg(any(

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -19,19 +19,19 @@ fn test_variables(rt: &RuntimeServices) {
     ));
 
     info!("Testing set_variable");
-    rt.set_variable(&name, &vendor, test_attrs, test_value)
+    rt.set_variable(name, &vendor, test_attrs, test_value)
         .expect_success("failed to set variable");
 
     info!("Testing get_variable_size");
     let size = rt
-        .get_variable_size(&name, &vendor)
+        .get_variable_size(name, &vendor)
         .expect_success("failed to get variable size");
     assert_eq!(size, test_value.len());
 
     info!("Testing get_variable");
     let mut buf = [0u8; 9];
     let (data, attrs) = rt
-        .get_variable(&name, &vendor, &mut buf)
+        .get_variable(name, &vendor, &mut buf)
         .expect_success("failed to get variable");
     assert_eq!(data, test_value);
     assert_eq!(attrs, test_attrs);


### PR DESCRIPTION
Modify memory_map_size to return the size of a memory descriptor as well as the current memory map size. Fixes #317.  

Note that this is a breaking change to the current API. 
