### PR TITLE
`build.py`: fix `clippy --verbose`

### DIFF
--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -79,7 +79,7 @@ def run_tool(tool, *flags):
     cmd = ['cargo', tool, '--target', target, *flags]
 
     if SETTINGS['verbose']:
-        print(' '.join(cmd))
+        print(' '.join(str(arg) for arg in cmd))
 
     sp.run(cmd, check=True)
 


### PR DESCRIPTION
This was failing because the manifest path is passed in as a path object
rather than a string.