### PR TITLE
fix: build error on the latest nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ members = [
 ]
 
 [patch.crates-io]
+# TODO: workaround for https://github.com/rust-osdev/uefi-rs/issues/329
+qemu-exit = { git = "https://github.com/toku-sa-n/qemu-exit.git", rev = "7279783c309423168398394682faa93ff81cdd31" }
 uefi-macros = { path = "uefi-macros" }
 uefi = { path = "." }
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -18,7 +18,6 @@
 
 #![no_std]
 #![feature(alloc_error_handler)]
-#![feature(asm)]
 #![feature(lang_items)]
 #![feature(panic_info_message)]
 #![feature(abi_efiapi)]
@@ -28,6 +27,7 @@ extern crate log;
 // Core types.
 extern crate uefi;
 
+use core::arch::asm;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
@@ -187,14 +187,14 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
                     loop {
                         unsafe {
                             // Try to at least keep CPU from running at 100%
-                            core::arch::asm!("hlt", options(nomem, nostack));
+                            asm!("hlt", options(nomem, nostack));
                         }
                     }
                 } else if #[cfg(target_arch = "aarch64")] {
                     loop {
                         unsafe {
                             // Try to at least keep CPU from running at 100%
-                            core::arch::asm!("hlt 420", options(nomem, nostack));
+                            asm!("hlt 420", options(nomem, nostack));
                         }
                     }
                 } else {

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -187,14 +187,14 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
                     loop {
                         unsafe {
                             // Try to at least keep CPU from running at 100%
-                            asm!("hlt", options(nomem, nostack));
+                            core::arch::asm!("hlt", options(nomem, nostack));
                         }
                     }
                 } else if #[cfg(target_arch = "aarch64")] {
                     loop {
                         unsafe {
                             // Try to at least keep CPU from running at 100%
-                            asm!("hlt 420", options(nomem, nostack));
+                            core::arch::asm!("hlt 420", options(nomem, nostack));
                         }
                     }
                 } else {

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
 #![feature(abi_efiapi)]
 
 #[macro_use]


### PR DESCRIPTION
`qemu-exit` crate also must be updated. I sent a PR: https://github.com/andre-richter/qemu-exit/pull/20
