### PR TITLE
chore(deps): update the version of `qemu-exit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,6 @@ members = [
 ]
 
 [patch.crates-io]
-# TODO: workaround for https://github.com/rust-osdev/uefi-rs/issues/329
-qemu-exit = { git = "https://github.com/toku-sa-n/qemu-exit.git", rev = "7279783c309423168398394682faa93ff81cdd31" }
 uefi-macros = { path = "uefi-macros" }
 uefi = { path = "." }
 

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -18,7 +18,7 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 uefi = { version = "0.13.0", features = ["alloc", "logger"] }
 log = { version = "0.4.14", default-features = false }
 cfg-if = "1.0.0"
-qemu-exit = { version = "2.0.1", optional = true }
+qemu-exit = { version = "3.0.0", optional = true }
 
 [features]
 # Enable QEMU-specific functionality

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -11,7 +11,7 @@ uefi-services = { path = "../uefi-services" }
 
 log = { version = "0.4.11", default-features = false }
 
-qemu-exit = "2.0.0"
+qemu-exit = "3.0.0"
 
 [features]
 # This feature should only be enabled in our CI, it disables some tests


### PR DESCRIPTION
Fixes: https://github.com/rust-osdev/uefi-rs/issues/329