### PR TITLE
Add missing `#[must_use]` marker attributes

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -22,6 +22,7 @@ impl Event {
     /// When an event is closed by calling `BootServices::close_event`, that event and ALL references
     /// to it are invalidated and the underlying memory is freed by firmware. The caller must ensure
     /// that any clones of a closed `Event` are never used again.
+    #[must_use]
     pub unsafe fn unsafe_clone(&self) -> Self {
         Self(self.0)
     }

--- a/src/result/completion.rs
+++ b/src/result/completion.rs
@@ -1,3 +1,7 @@
+// TODO: workaround for
+// https://github.com/rust-lang/rust-clippy/issues/8140
+#![allow(clippy::return_self_not_must_use)]
+
 use super::Status;
 use log::warn;
 

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -191,6 +191,7 @@ impl SystemTable<Boot> {
     /// used after boot services are exited. However, the singleton-based
     /// designs that Rust uses for memory allocation, logging, and panic
     /// handling require taking this risk.
+    #[must_use]
     pub unsafe fn unsafe_clone(&self) -> Self {
         SystemTable {
             table: self.table,


### PR DESCRIPTION
Fixes CI getting broken by a new clippy lint.

Currently failing due to https://github.com/rust-lang/rust-clippy/issues/8140