### PR TITLE
Fix logs cut off after screenshot test

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -77,11 +77,17 @@ fn check_revision(rev: uefi::table::Revision) {
 /// inspection of the output.
 fn check_screenshot(image: Handle, bt: &BootServices, name: &str) {
     if cfg!(feature = "qemu") {
-        let serial_handle = *bt
+        let serial_handles = bt
             .find_handles::<Serial>()
-            .expect_success("Failed to get serial handles")
-            .first()
-            .expect("Could not find serial port");
+            .expect_success("Failed to get serial handles");
+
+        // Use the second serial device handle. Opening a serial device
+        // in exclusive mode breaks the connection between stdout and
+        // the serial device, and we don't want that to happen to the
+        // first serial device since it's used for log transport.
+        let serial_handle = *serial_handles
+            .get(1)
+            .expect("Second serial device is missing");
 
         let serial = bt
             .open_protocol::<Serial>(


### PR DESCRIPTION
OVMF sets up the stdout handle such that writes go to all serial devices
(as well as the visual console when not running headless). This is
convenient since the logger writes to stdout, so connecting a serial
device to QEMU's stdout writes logs from the test runner to the host.

However, once a serial device is opened in exclusive mode it is
disconnected from stdout. Since the test runner needs to open a serial
device in exclusive mode, a single serial device isn't sufficient --
once the device is opened in exclusive mode it will stop receiving logs.

So, open two serial devices for the QEMU test. The first one is
connected to the host's stdout, and serves just to transport logs. The
second one is connected to a pipe, and used to receive the SCREENSHOT
command and send the response. That second will also receive logs up
until the test runner opens the handle in exclusive mode, but we can
just read and ignore those lines.

Fixes https://github.com/rust-osdev/uefi-rs/issues/327