### PR TITLE
System Table and Handle: From-implementation to create objects from raw pointers

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -15,6 +15,18 @@ impl Handle {
     /// Creates a new [`Handle`] from a raw address. The address might
     /// come from the Multiboot2 information structure or something similar.
     ///
+    /// # Example
+    /// ```rust
+    /// use core::ffi::c_void;
+    /// use uefi::Handle;
+    ///
+    /// let image_handle_addr = 0xdeadbeef as *mut c_void;
+    ///
+    /// let uefi_image_handle = unsafe {
+    ///     Handle::from_ptr(image_handle_addr).expect("Pointer must not be null!")
+    /// };
+    /// ```
+    ///
     /// # Safety
     /// This function is unsafe because the caller must be sure that the pointer
     /// is valid. Otherwise, further operations on the object might result in

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -11,6 +11,20 @@ use core::{ffi::c_void, ptr::NonNull};
 #[repr(transparent)]
 pub struct Handle(NonNull<c_void>);
 
+impl Handle {
+    /// Creates a new [`Handle`] from a raw address. The address might
+    /// come from the Multiboot2 information structure or something similar.
+    ///
+    /// # Safety
+    /// This function is unsafe because the caller must be sure that the pointer
+    /// is valid. Otherwise, further operations on the object might result in
+    /// undefined behaviour, even if the methods aren't marked as unsafe.
+    pub unsafe fn from_ptr(ptr: *mut c_void) -> Option<Self> {
+        // shorthand for "|ptr| Self(ptr)"
+        NonNull::new(ptr).map(Self)
+    }
+}
+
 /// Handle to an event structure
 #[repr(transparent)]
 pub struct Event(*mut c_void);

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -77,6 +77,18 @@ impl<View: SystemTableView> SystemTable<View> {
     /// Creates a new `SystemTable<View>` from a raw address. The address might
     /// come from the Multiboot2 information structure or something similar.
     ///
+    /// # Example
+    /// ```rust
+    /// use core::ffi::c_void;
+    /// use uefi::prelude::{Boot, SystemTable};
+    ///
+    /// let system_table_addr = 0xdeadbeef as *mut c_void;
+    ///
+    /// let mut uefi_system_table = unsafe {
+    ///     SystemTable::<Boot>::from_ptr(system_table_addr).expect("Pointer must not be null!")
+    /// };
+    /// ```
+    ///
     /// # Safety
     /// This function is unsafe because the caller must be sure that the pointer
     /// is valid. Otherwise, further operations on the object might result in


### PR DESCRIPTION
Enables to create Handle and System Table from raw pointers.

# Use Case
```rust
        let uefi_system_table_addr = mb2_boot_info.efi_sdt_64_tag().unwrap().sdt_address();
        let uefi_image_handle_addr = mb2_boot_info.efi_64_ih().unwrap().image_handle();
        
        // nice "from"-creation
        let mut uefi_system_table = SystemTable::<Boot>::from(uefi_system_table_addr);
        let uefi_image_handle = Handle::from(uefi_image_handle_addr);
        // ...
        let rt_table = uefi_system_table.exit_boot_services(uefi_image_handle, mmap);
```