### PR TITLE
(cargo-release) uefi-services version 0.11.0

### DIFF
--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Gabriel Majeri <gabriel.majeri6@gmail.com>"]
 edition = "2018"
 description = "Higher-level utilities for uefi-rs"


### PR DESCRIPTION
https://github.com/rust-osdev/uefi-rs/issues/340