### PR TITLE
Remove `vec_spare_capacity` nightly feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,7 @@
 //! For example, a PC with no network card might not contain a network driver,
 //! therefore all the network protocols will be unavailable.
 
-#![cfg_attr(
-    feature = "exts",
-    feature(allocator_api, alloc_layout_extra, vec_spare_capacity)
-)]
+#![cfg_attr(feature = "exts", feature(allocator_api, alloc_layout_extra))]
 #![feature(auto_traits)]
 #![feature(control_flow_enum)]
 #![feature(try_trait_v2)]


### PR DESCRIPTION
Fixes clippy failures on latest `rustc` versions.