### PR TITLE
ci/xtask: add test-latest-release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,3 +98,27 @@ jobs:
 
       - name: Run cargo doc
         run: cargo xtask doc --warnings-as-errors
+
+  # This job tests that the template app builds successfully with the
+  # released versions of the libraries on crates.io.
+  #
+  # Since a nightly toolchain is currently required to build uefi-rs,
+  # the released versions can suddenly stop building when a new nightly
+  # compiler with a breaking change is released. This job provides an
+  # alert when this situation occurs.
+  test_latest_release:
+    name: Build the template against the released version of uefi-rs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          components: rust-src
+
+    - name: Build
+      run: cargo xtask test-latest-release

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -49,6 +49,7 @@ pub enum Action {
     Doc(DocOpt),
     Run(QemuOpt),
     Test(TestOpt),
+    TestLatestRelease(TestLatestReleaseOpt),
 }
 
 /// Build all the uefi packages.
@@ -111,3 +112,7 @@ pub struct QemuOpt {
 /// Build uefi-test-runner and run it in QEMU.
 #[derive(Debug, Parser)]
 pub struct TestOpt;
+
+/// Build the template against the crates.io packages.
+#[derive(Debug, Parser)]
+pub struct TestLatestReleaseOpt;


### PR DESCRIPTION
Add an xtask action and corresponding CI job to test that the template
app builds against the released versions of the uefi-rs libraries. Since
nightly compiler changes can break the released versions at any time,
it's nice to have an automatic alert.

Fixes https://github.com/rust-osdev/uefi-rs/issues/343