### PR TITLE
Move badges from `Cargo.toml` to `README.md`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ keywords = ["uefi", "efi"]
 categories = ["embedded", "no-std", "api-bindings"]
 license = "MPL-2.0"
 
-[badges]
-travis-ci = { repository = "rust-osdev/uefi-rs" }
-is-it-maintained-issue-resolution = { repository = "rust-osdev/uefi-rs" }
-is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
-
 [features]
 default = []
 alloc = []

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ![Stars](https://img.shields.io/github/stars/rust-osdev/uefi-rs)
 ![License](https://img.shields.io/github/license/rust-osdev/uefi-rs)
 ![Build status](https://github.com/rust-osdev/uefi-rs/workflows/Rust/badge.svg)
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/rust-osdev/uefi-rs.svg)](http://isitmaintained.com/project/rust-osdev/uefi-rs "Average time to resolve an issue")
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/rust-osdev/uefi-rs.svg)](http://isitmaintained.com/project/rust-osdev/uefi-rs "Percentage of issues still open")
 
 ## Description
 


### PR DESCRIPTION
The badges section of Cargo.toml is mostly deprecated, and crates.io
doesn't display badges anymore. According to the [manifest
reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section),
badges should be placed in the readme instead.

Added maintenance badges from
https://isitmaintained.com/project/rust-osdev/uefi-rs, and dropped the
Travis CI badge entirely.