### PR TITLE
Revert "Temporarily allow clippy::return_self_not_must_use"

### DIFF
--- a/src/result/completion.rs
+++ b/src/result/completion.rs
@@ -1,7 +1,3 @@
-// TODO: workaround for
-// https://github.com/rust-lang/rust-clippy/issues/8140
-#![allow(clippy::return_self_not_must_use)]
-
 use super::Status;
 use log::warn;
 


### PR DESCRIPTION
This reverts commit bc21bb9cd63cf25f8d3c216fa3d935e980dde989.

Fixes https://github.com/rust-osdev/uefi-rs/issues/333