### PR TITLE
DOC: Fixed link

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -8,10 +8,10 @@ how to build and run a UEFI application developed using `uefi-rs`.
 
 ## File structure
 
-- [`template/.cargo/config`](template/.cargo/config) file sets some `build-std` options.
-- [`template/Cargo.toml`](template/Cargo.toml) shows the necessary
+- [`template/.cargo/config`](./.cargo/config) file sets some `build-std` options.
+- [`template/Cargo.toml`](./Cargo.toml) shows the necessary
   dependencies.
-- [`template/src/main.rs`](template/src/main.rs) has a minimal entry point that
+- [`template/src/main.rs`](./src/main.rs) has a minimal entry point that
   initializes the `uefi-services` crate and exits successfully.
 
 ## Building kernels which use UEFI


### PR DESCRIPTION
Clicking from the file alone is correct, but there is a problem if it is read automatically by github at the folder level.

Maybe it would be better to provide the full path?