### PR TITLE
strs: remove CStr16::as_string

### DIFF
--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -24,7 +24,7 @@ pub enum FromStrError {
 /// use uefi::CString16;
 ///
 /// let s = CString16::try_from("abc").unwrap();
-/// assert_eq!(s.as_string(), "abc");
+/// assert_eq!(s.to_string(), "abc");
 /// ```
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CString16(Vec<Char16>);

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -1,6 +1,4 @@
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
-#[cfg(feature = "exts")]
-use crate::alloc_api::string::String;
 use core::convert::TryInto;
 use core::fmt;
 use core::iter::Iterator;
@@ -251,19 +249,6 @@ impl CStr16 {
             buf.write_char(char::from(*c16))?;
         }
         Ok(())
-    }
-
-    /// Transforms the C16Str to a regular Rust String.
-    /// **WARNING** This will require **heap allocation**, i.e. you need an global allocator.
-    /// If the UEFI boot services are exited, your OS/Kernel needs to provide another allocation
-    /// mechanism!
-    #[cfg(feature = "exts")]
-    pub fn as_string(&self) -> String {
-        let mut buf = String::with_capacity(self.0.len() * 2);
-        for c16 in self.iter() {
-            buf.push(char::from(*c16));
-        }
-        buf
     }
 }
 


### PR DESCRIPTION
Since `CStr16` implements `Display`, the [`ToString`](https://doc.rust-lang.org/alloc/string/trait.ToString.html) trait is automatically implemented. That provides `to_string` as long as `alloc` is enabled, so `as_string` isn't needed.

https://github.com/rust-osdev/uefi-rs/issues/73