### PR TITLE
Remove implicit string conversion from File::open

### DIFF
--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -2,6 +2,7 @@ use super::chars::{Char16, NUL_16};
 use super::strs::CStr16;
 use crate::alloc_api::vec::Vec;
 use core::convert::TryFrom;
+use core::fmt;
 use core::ops;
 
 /// Error returned by [`CString16::try_from::<&str>`].
@@ -68,6 +69,12 @@ impl ops::Deref for CString16 {
 impl AsRef<CStr16> for CString16 {
     fn as_ref(&self) -> &CStr16 {
         self
+    }
+}
+
+impl fmt::Display for CString16 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.as_ref().fmt(f)
     }
 }
 

--- a/uefi-test-runner/src/proto/media/mod.rs
+++ b/uefi-test-runner/src/proto/media/mod.rs
@@ -1,7 +1,41 @@
+use core::convert::TryFrom;
 use uefi::prelude::*;
+use uefi::proto::media::file::{Directory, File, FileAttribute, FileMode, FileType};
 use uefi::proto::media::fs::SimpleFileSystem;
 use uefi::proto::media::partition::PartitionInfo;
 use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
+use uefi::CString16;
+
+/// Open and read a test file in the boot directory.
+pub fn test_open_and_read(directory: &mut Directory) {
+    let test_input_path = CString16::try_from("EFI\\BOOT\\test_input.txt").unwrap();
+    match directory.open(&test_input_path, FileMode::Read, FileAttribute::empty()) {
+        Ok(file) => {
+            let file = file.unwrap().into_type().unwrap_success();
+            if let FileType::Regular(mut file) = file {
+                let mut buffer = vec![0; 128];
+                let size = file
+                    .read(&mut buffer)
+                    .expect_success(&format!("failed to read {}", test_input_path));
+                let buffer = &buffer[..size];
+                info!("Successfully read {}", test_input_path);
+                assert_eq!(buffer, b"test input data");
+            } else {
+                panic!("{} is not a regular file", test_input_path);
+            }
+        }
+        Err(err) => {
+            let msg = format!("Failed to open {}: {:?}", test_input_path, err);
+            // The file might reasonably not be present when running on real
+            // hardware, so only panic on failure under qemu.
+            if cfg!(feature = "qemu") {
+                panic!("{}", msg);
+            } else {
+                warn!("{}", msg);
+            }
+        }
+    }
+}
 
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Testing Media Access protocols");
@@ -31,6 +65,8 @@ pub fn test(image: Handle, bt: &BootServices) {
             info!("Root directory entry: {:?}", file_info);
         }
         directory.reset_entry_readout().unwrap().unwrap();
+
+        test_open_and_read(&mut directory);
     } else {
         warn!("`SimpleFileSystem` protocol is not available");
     }

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -256,6 +256,10 @@ fn build_esp_dir(opt: &QemuOpt) -> Result<PathBuf> {
         fs_err::create_dir_all(&boot_dir)?;
     }
     fs_err::copy(built_file, boot_dir.join(output_file))?;
+
+    // Add a test file that is used in the media protocol tests.
+    fs_err::write(boot_dir.join("test_input.txt"), "test input data")?;
+
     Ok(esp_dir)
 }
 


### PR DESCRIPTION
As suggested in https://github.com/rust-osdev/uefi-rs/issues/73, avoid an implicit `&str` -> `&CStr16` conversion in `File::open`, and just take a `&CStr16` directly.

Also added a test for opening and reading a file so we can see this code works as expected. And to make logging easier in the test, add a `Display` impl for `CString16`.