### PR TITLE
Fix file info sizes and add tests

### DIFF
--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -124,6 +124,7 @@ impl<Header> FromUefi for NamedFileProtocolInfo<Header> {
 }
 
 /// Errors that can occur when creating a `FileProtocolInfo`
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileInfoCreationError {
     /// The provided buffer was too small to hold the `FileInfo`. You need at
     /// least the indicated buffer size (in bytes). Please remember that using

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -199,7 +199,7 @@ impl FileInfo {
             attribute,
         };
         let info = Self::new_impl(storage, header, file_name)?;
-        info.header.size = mem::size_of_val(&info) as u64;
+        info.header.size = mem::size_of_val(info) as u64;
         Ok(info)
     }
 
@@ -288,7 +288,7 @@ impl FileSystemInfo {
             block_size,
         };
         let info = Self::new_impl(storage, header, volume_label)?;
-        info.header.size = mem::size_of_val(&info) as u64;
+        info.header.size = mem::size_of_val(info) as u64;
         Ok(info)
     }
 

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -421,6 +421,22 @@ impl fmt::Display for Time {
     }
 }
 
+impl PartialEq for Time {
+    fn eq(&self, other: &Time) -> bool {
+        self.year == other.year
+            && self.month == other.month
+            && self.day == other.day
+            && self.hour == other.hour
+            && self.minute == other.minute
+            && self.second == other.second
+            && self.nanosecond == other.nanosecond
+            && self.time_zone == other.time_zone
+            && self.daylight == other.daylight
+    }
+}
+
+impl Eq for Time {}
+
 /// Real time clock capabilities
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]


### PR DESCRIPTION
The bulk of this change is adding tests for `FileInfo`, `FileSystemInfo`, and `FileSystemVolumeLabel`.

In doing so I noticed that the `size` field in the header of the first two was calculated incorrectly in their `new` methods, so fixed that.

And some minor changes to implement Derive and PartialEq on additional types to make the tests easier to write.

(I have some more fixes to make in this area including removing the implicit string conversion, but that will be easier with the tests in place.)