### PR TITLE
data_types: add string equality impls

### DIFF
--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -78,6 +78,12 @@ impl fmt::Display for CString16 {
     }
 }
 
+impl PartialEq<&CStr16> for CString16 {
+    fn eq(&self, other: &&CStr16) -> bool {
+        PartialEq::eq(self.as_ref(), other)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,5 +99,21 @@ mod tests {
         assert_eq!(CString16::try_from("😀"), Err(FromStrError::InvalidChar));
 
         assert_eq!(CString16::try_from("x\0"), Err(FromStrError::InteriorNul));
+    }
+
+    /// Test `CString16 == &CStr16` and `&CStr16 == CString16`.
+    #[test]
+    fn test_cstring16_cstr16_eq() {
+        let mut buf = [0; 4];
+
+        assert_eq!(
+            CStr16::from_str_with_buf("abc", &mut buf).unwrap(),
+            CString16::try_from("abc").unwrap()
+        );
+
+        assert_eq!(
+            CString16::try_from("abc").unwrap(),
+            CStr16::from_str_with_buf("abc", &mut buf).unwrap(),
+        );
     }
 }

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -1,4 +1,6 @@
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
+#[cfg(feature = "exts")]
+use super::CString16;
 use core::convert::TryInto;
 use core::fmt;
 use core::iter::Iterator;
@@ -100,6 +102,7 @@ impl CStr8 {
 ///
 /// This type is largely inspired by `std::ffi::CStr`, see the documentation of
 /// `CStr` for more details on its semantics.
+#[derive(Eq, PartialEq)]
 #[repr(transparent)]
 pub struct CStr16([Char16]);
 
@@ -284,6 +287,13 @@ impl fmt::Display for CStr16 {
             <Char16 as fmt::Display>::fmt(c, f)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(feature = "exts")]
+impl PartialEq<CString16> for &CStr16 {
+    fn eq(&self, other: &CString16) -> bool {
+        PartialEq::eq(*self, other.as_ref())
     }
 }
 


### PR DESCRIPTION
Add support for `CStr16 == CStr16`, `&CStr16 == CString`, and `CString == &CStr16`.