### PR TITLE
Remove more implicit string conversions

### DIFF
--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -207,6 +207,11 @@ impl CStr16 {
         self.0.as_ptr()
     }
 
+    /// Get the underlying [`Char16`] slice, including the trailing null.
+    pub fn as_slice_with_nul(&self) -> &[Char16] {
+        &self.0
+    }
+
     /// Converts this C string to a u16 slice
     pub fn to_u16_slice(&self) -> &[u16] {
         let chars = self.to_u16_slice_with_nul();


### PR DESCRIPTION
The file info types are now constructed directly from a `&CStr16`
instead of internally converting from a `&str`. This also removes
`FileInfoCreationError::InvalidChar`, since that error is no longer
possible.

Also added `CStr16::as_slice_with_nul`.

https://github.com/rust-osdev/uefi-rs/issues/73
