### PR TITLE
Fix ProtocolsPerHandle internal slice property.

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -776,12 +776,10 @@ impl BootServices {
             }
         }
 
-        status.into_with_val(|| {
-            ProtocolsPerHandle {
-                boot_services: self,
-                protocols: protocols as *mut &Guid,
-                count,
-            }
+        status.into_with_val(|| ProtocolsPerHandle {
+            boot_services: self,
+            protocols: protocols as *mut &Guid,
+            count,
         })
     }
 
@@ -1428,9 +1426,7 @@ pub struct ProtocolsPerHandle<'a> {
 impl<'a> Drop for ProtocolsPerHandle<'a> {
     fn drop(&mut self) {
         // Ignore the result, we can't do anything about an error here.
-        let _ = self
-            .boot_services
-            .free_pool(self.protocols as *mut u8);
+        let _ = self.boot_services.free_pool(self.protocols as *mut u8);
     }
 }
 


### PR DESCRIPTION
The old implementation contains a `protocols` slice with a lifetime `a`.

```rust
pub struct ProtocolsPerHandle<'a> {
    boot_services: &'a BootServices,
    protocols: &'a mut [&'a Guid],
}
```

But `protocols` slice does not live long enough for `'a`. It will be freed when the `ProtocolsPerHandle` struct is dropped.


From std doc, ( https://doc.rust-lang.org/nightly/core/slice/fn.from_raw_parts.html )

```rust
pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
```

> The memory referenced by the returned slice must not be mutated for the duration of lifetime `'a`.

The current codebase does not use this internal property except the `protocols` getter method. So having an invalid lifetime does not immediately cause undefined behavior but it is safer to fix.

Since I'm not a native English speaker, it is very appreciated to fix my English document :)

Thanks!