### PR TITLE
loaded_image: make load options API safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   `unsafe` methods for initializing from a raw pointer.
 - Added `CStr16::as_slice_with_nul` to provide immutable access to the
   underlying slice.
+- Added `LoadedImage::load_options_as_bytes` and
+  `LoadedImage::load_options_as_cstr16`.
 
 ### Changed
 
@@ -19,6 +21,8 @@
 - `FileInfo::new`, `FileSystemInfo::new`, and
   `FileSystemVolumeLabel::new` now take their `name` parameter as
   `&CStr16` instead of `&str`, avoiding an implicit string conversion.
+- `LoadImage::set_load_options` now takes a `u8` pointer instead of
+  `Char16`.
 
 ### Removed
 
@@ -28,6 +32,9 @@
 - Removed `FileInfoCreationError::InvalidChar`. This error type is no
   longer needed due to the removal of implicit string conversions in
   file info types.
+- Removed `LoadedImage::load_options`, use
+  `LoadedImage::load_options_as_bytes` or
+  `LoadedImage::load_options_as_cstr16` instead.
 
 ### Fixed
 

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -17,11 +17,8 @@ pub fn test(image: Handle, bt: &BootServices) {
         .expect_success("Failed to open LoadedImage protocol");
     let loaded_image = unsafe { &*loaded_image.interface.get() };
 
-    let mut buffer = vec![0; 128];
-    let load_options = loaded_image
-        .load_options(&mut buffer)
-        .expect("Failed to get load options");
-    info!("LoadedImage options: \"{}\"", load_options);
+    let load_options = loaded_image.load_options_as_bytes();
+    info!("LoadedImage options: {:?}", load_options);
 
     let (image_base, image_size) = loaded_image.info();
     info!(


### PR DESCRIPTION
The spec describes `LoadOptions` as "A pointer to the image’s binary
load options. See the OptionalData parameter in [section 3.1.3 Load
Options] of the Boot Manager chapter for information on the source of
the LoadOptions data." The `OptionalData` field is described as "The
remaining bytes in the load option descriptor are a binary data buffer
that is passed to the loaded image."

So there's no guarantee made about the contents of `LoadOptions`; it's
arbitrary binary data as far as the UEFI spec is concerned. So it's not
necessarily safe to treat the load_options as a `Char16` pointer, since
it might not be aligned and might not be null-terminated. That said, the
data is *usually* a null-terminated UCS-2 string. The UEFI Shell spec
specifies that command-line parameters are passed that way.

To safely support both cases, change the `load_options` field to a `u8`
pointer, drop the `load_options` method that converts the data to a
`&str`, and add two new methods: `load_options_as_bytes` and
`load_options_as_cstr16`. The `set_load_options` has also been changed
to take a `u8` pointer instead of a `Char16` pointer.

https://github.com/rust-osdev/uefi-rs/issues/73