### PR TITLE
Fix alignment issues in file info types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   underlying slice.
 - Added `LoadedImage::load_options_as_bytes` and
   `LoadedImage::load_options_as_cstr16`.
+- Added `Align::offset_up_to_alignment`, `Align::round_up_to_alignment`,
+  and `Align::align_buf`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@
   avoiding an implicit string conversion.
 - `FileInfo::new`, `FileSystemInfo::new`, and
   `FileSystemVolumeLabel::new` now take their `name` parameter as
-  `&CStr16` instead of `&str`, avoiding an implicit string conversion.
+  `&CStr16` instead of `&str`, avoiding an implicit string
+  conversion. Additionally, an unaligned storage buffer is now allowed
+  as long as it is big enough to provide an aligned subslice.
 - `LoadImage::set_load_options` now takes a `u8` pointer instead of
   `Char16`.
 
@@ -38,6 +40,9 @@
 - Removed `LoadedImage::load_options`, use
   `LoadedImage::load_options_as_bytes` or
   `LoadedImage::load_options_as_cstr16` instead.
+- Removed `NamedFileProtocolInfo`, `FileInfoHeader`,
+  `FileSystemInfoHeader`, and `FileSystemVolumeLabelHeader`. Use
+  `FileInfo`, `FileSystemInfo`, and `FileSystemVolumeLabel` instead.
 
 ### Fixed
 
@@ -45,3 +50,8 @@
   `vec_spare_capacity` feature, which has been stabilized.
 - Fixed the header size calculated by `FileInfo::new` and
   `FileSystemInfo::new`.
+- Fixed incorrect alignment of the volume label field in
+  `FileSystemInfo`. This caused the beginning of the string to be
+  truncated and could result in out-of-bounds reads.
+- Fixed size check for file info types so that alignment padding is
+  taken into account. This fixes potential out-of-bounds writes.

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -68,6 +68,33 @@ pub trait Align {
     /// Required memory alignment for this type
     fn alignment() -> usize;
 
+    /// Calculate the offset from `val` necessary to make it aligned,
+    /// rounding up. For example, if `val` is 1 and the alignment is 8,
+    /// this will return 7. Returns 0 if `val == 0`.
+    fn offset_up_to_alignment(val: usize) -> usize {
+        assert!(Self::alignment() != 0);
+        let r = val % Self::alignment();
+        if r == 0 {
+            0
+        } else {
+            Self::alignment() - r
+        }
+    }
+
+    /// Round `val` up so that it is aligned.
+    fn round_up_to_alignment(val: usize) -> usize {
+        val + Self::offset_up_to_alignment(val)
+    }
+
+    /// Get a subslice of `buf` where the address of the first element
+    /// is aligned. Returns `None` if no element of the buffer is
+    /// aligned.
+    fn align_buf(buf: &mut [u8]) -> Option<&mut [u8]> {
+        let addr = buf.as_ptr() as usize;
+        let offset = Self::offset_up_to_alignment(addr);
+        buf.get_mut(offset..)
+    }
+
     /// Assert that some storage is correctly aligned for this type
     fn assert_aligned(storage: &mut [u8]) {
         if !storage.is_empty() {
@@ -97,3 +124,49 @@ pub use self::strs::{CStr16, CStr8, FromSliceWithNulError, FromStrWithBufError};
 mod owned_strs;
 #[cfg(feature = "exts")]
 pub use self::owned_strs::{CString16, FromStrError};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alignment() {
+        struct X {}
+
+        impl Align for X {
+            fn alignment() -> usize {
+                4
+            }
+        }
+
+        assert_eq!(X::offset_up_to_alignment(0), 0);
+        assert_eq!(X::offset_up_to_alignment(1), 3);
+        assert_eq!(X::offset_up_to_alignment(2), 2);
+        assert_eq!(X::offset_up_to_alignment(3), 1);
+        assert_eq!(X::offset_up_to_alignment(4), 0);
+        assert_eq!(X::offset_up_to_alignment(5), 3);
+        assert_eq!(X::offset_up_to_alignment(6), 2);
+        assert_eq!(X::offset_up_to_alignment(7), 1);
+        assert_eq!(X::offset_up_to_alignment(8), 0);
+
+        assert_eq!(X::round_up_to_alignment(0), 0);
+        assert_eq!(X::round_up_to_alignment(1), 4);
+        assert_eq!(X::round_up_to_alignment(2), 4);
+        assert_eq!(X::round_up_to_alignment(3), 4);
+        assert_eq!(X::round_up_to_alignment(4), 4);
+        assert_eq!(X::round_up_to_alignment(5), 8);
+        assert_eq!(X::round_up_to_alignment(6), 8);
+        assert_eq!(X::round_up_to_alignment(7), 8);
+        assert_eq!(X::round_up_to_alignment(8), 8);
+
+        // Get an intentionally mis-aligned buffer.
+        let mut buffer = [0u8; 16];
+        let mut buffer = &mut buffer[..];
+        if (buffer.as_ptr() as usize) % X::alignment() == 0 {
+            buffer = &mut buffer[1..];
+        }
+
+        let buffer = X::align_buf(buffer).unwrap();
+        X::assert_aligned(buffer);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(try_trait_v2)]
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
+#![feature(ptr_metadata)]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(missing_docs, unused)]

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -19,10 +19,7 @@ use core::ffi::c_void;
 use core::mem;
 use core::ptr;
 
-pub use self::info::{
-    FileInfo, FileInfoHeader, FileProtocolInfo, FileSystemInfo, FileSystemInfoHeader,
-    FileSystemVolumeLabel, FileSystemVolumeLabelHeader, FromUefi, NamedFileProtocolInfo,
-};
+pub use self::info::{FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi};
 pub use self::{dir::Directory, regular::RegularFile};
 
 /// Common interface to `FileHandle`, `RegularFile`, and `Directory`.


### PR DESCRIPTION
This fixes a couple alignment bugs with the info types:

The `FileSystemInfo` was accidentally different from the intended C representation of the type due to extra alignment padding as described in https://github.com/rust-osdev/uefi-rs/issues/80. Fixing that required fairly invasive changes to the file info types, but I think everything is now aligned correctly and has no UB.

Additionally the storage size check didn't take trailing alignment padding into account, now it does.

One more alignment improvement: if the storage buffer is not aligned, an aligned sub-slice is used (if possible). With that fix in place it's possible run the tests under Miri for some added confidence in the correctness of all the unsafe code.

More details in the commit messages.