### PR TITLE
Don't run doctests with invalid pointers

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -16,7 +16,7 @@ impl Handle {
     /// come from the Multiboot2 information structure or something similar.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// use core::ffi::c_void;
     /// use uefi::Handle;
     ///

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -78,7 +78,7 @@ impl<View: SystemTableView> SystemTable<View> {
     /// come from the Multiboot2 information structure or something similar.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// use core::ffi::c_void;
     /// use uefi::prelude::{Boot, SystemTable};
     ///


### PR DESCRIPTION
The `Handle::from_ptr` and `SystemTable<View>::from_ptr` doctests use a
`0xdeadbeef` pointer, which of course is not valid. Change the tests to
compile but not actually run so that they don't trigger UB.

Noticed this when running the unit tests with Miri, which caught the
undefined behavior the in the SystemTable case.