### PR TITLE
implement BootServices::locate_handle_buffer function

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -157,7 +157,7 @@ pub struct BootServices {
     locate_handle_buffer: unsafe extern "efiapi" fn(
         search_ty: i32,
         proto: *const Guid,
-        key: *mut c_void,
+        key: *const c_void,
         no_handles: &mut usize,
         buf: &mut *mut Handle,
     ) -> Status,

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -20,7 +20,7 @@ fn test_locate_handle_buffer(bt: &BootServices) {
         let handles = bt
             .locate_handle_buffer(SearchType::AllHandles)
             .expect_success("Failed to locate handle buffer");
-        assert!(handles.handles().len() > 0, "Could not find any handles");
+        assert!(!handles.handles().is_empty(), "Could not find any handles");
     }
 
     {
@@ -29,7 +29,7 @@ fn test_locate_handle_buffer(bt: &BootServices) {
             .locate_handle_buffer(SearchType::ByProtocol(&Output::GUID))
             .expect_success("Failed to locate handle buffer");
         assert!(
-            handles.handles().len() > 0,
+            !handles.handles().is_empty(),
             "Could not find any OUTPUT protocol handles"
         );
     }

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -1,10 +1,36 @@
-use uefi::table::boot::BootServices;
+use uefi::proto::console::text::Output;
+use uefi::table::boot::{BootServices, SearchType};
+use uefi::{prelude::*, Identify};
 
 pub fn test(bt: &BootServices) {
     info!("Testing boot services");
     memory::test(bt);
     misc::test(bt);
+    test_locate_handle_buffer(bt);
 }
 
 mod memory;
 mod misc;
+
+fn test_locate_handle_buffer(bt: &BootServices) {
+    info!("Testing the `locate_handle_buffer` function");
+
+    {
+        // search all handles
+        let handles = bt
+            .locate_handle_buffer(SearchType::AllHandles)
+            .expect_success("Failed to locate handle buffer");
+        assert!(handles.handles().len() > 0, "Could not find any handles");
+    }
+
+    {
+        // search by protocol
+        let handles = bt
+            .locate_handle_buffer(SearchType::ByProtocol(&Output::GUID))
+            .expect_success("Failed to locate handle buffer");
+        assert!(
+            handles.handles().len() > 0,
+            "Could not find any OUTPUT protocol handles"
+        );
+    }
+}


### PR DESCRIPTION
This is an implementation of https://github.com/rust-osdev/uefi-rs/issues/372.

I would like to ask something.

1. How should I use `*const` and `*mut` each? I couldn't get which should I use.
2. Should I remove `unsafe` keyword from `locate_handle_buffer` property? I believe I should not but it confuses me that some FFI function pointers ( such as `locate_protocol` ) do not mark self as `unsafe`.
3. How do I test this function?

Thanks! :)