### PR TITLE
Add miri action to xtask and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,6 +157,23 @@ jobs:
       - name: Run cargo doc
         run: cargo xtask doc --warnings-as-errors
 
+  miri:
+    name: Run unit tests and doctests under Miri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install latest nightly toolchain that includes Miri
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: miri
+
+      - name: Run miri
+        run: cargo xtask miri
+
   # This job tests that the template app builds successfully with the
   # released versions of the libraries on crates.io.
   #

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -82,6 +82,7 @@ pub enum CargoAction {
     Build,
     Clippy,
     Doc { open: bool },
+    Miri,
     Test,
 }
 
@@ -105,6 +106,7 @@ impl Cargo {
         }
 
         let action;
+        let mut sub_action = None;
         let mut extra_args: Vec<&str> = Vec::new();
         let mut tool_args: Vec<&str> = Vec::new();
         match self.action {
@@ -126,11 +128,18 @@ impl Cargo {
                     extra_args.push("--open");
                 }
             }
+            CargoAction::Miri => {
+                action = "miri";
+                sub_action = Some("test");
+            }
             CargoAction::Test => {
                 action = "test";
             }
         };
         cmd.arg(action);
+        if let Some(sub_action) = sub_action {
+            cmd.arg(sub_action);
+        }
 
         if self.release {
             cmd.arg("--release");

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -89,7 +89,7 @@ pub enum CargoAction {
 pub struct Cargo {
     pub action: CargoAction,
     pub features: Vec<Feature>,
-    pub nightly: bool,
+    pub toolchain: Option<String>,
     pub packages: Vec<Package>,
     pub release: bool,
     pub target: Option<UefiArch>,
@@ -99,8 +99,9 @@ pub struct Cargo {
 impl Cargo {
     pub fn command(&self) -> Result<Command> {
         let mut cmd = Command::new("cargo");
-        if self.nightly {
-            cmd.arg("+nightly");
+
+        if let Some(toolchain) = &self.toolchain {
+            cmd.arg(&format!("+{}", toolchain));
         }
 
         let action;
@@ -187,7 +188,7 @@ mod tests {
         let cargo = Cargo {
             action: CargoAction::Doc { open: true },
             features: vec![Feature::Alloc],
-            nightly: true,
+            toolchain: Some("nightly".into()),
             packages: vec![Package::Uefi, Package::Xtask],
             release: false,
             target: None,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,11 +12,13 @@ use std::process::Command;
 use tempfile::TempDir;
 use util::{command_to_string, run_cmd};
 
+const NIGHTLY: &str = "nightly";
+
 fn build(opt: &BuildOpt) -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Build,
         features: Feature::more_code(),
-        nightly: true,
+        toolchain: opt.toolchain.or(NIGHTLY),
         packages: Package::all_except_xtask(),
         release: opt.build_mode.release,
         target: Some(*opt.target),
@@ -30,7 +32,7 @@ fn clippy(opt: &ClippyOpt) -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Clippy,
         features: Feature::more_code(),
-        nightly: true,
+        toolchain: opt.toolchain.or(NIGHTLY),
         packages: Package::all_except_xtask(),
         release: false,
         target: Some(*opt.target),
@@ -42,7 +44,7 @@ fn clippy(opt: &ClippyOpt) -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Clippy,
         features: Vec::new(),
-        nightly: false,
+        toolchain: None,
         packages: vec![Package::Xtask],
         release: false,
         target: None,
@@ -56,7 +58,7 @@ fn doc(opt: &DocOpt) -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Doc { open: opt.open },
         features: Feature::more_code(),
-        nightly: true,
+        toolchain: opt.toolchain.or(NIGHTLY),
         packages: Package::published(),
         release: false,
         target: None,
@@ -76,7 +78,7 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Build,
         features,
-        nightly: true,
+        toolchain: opt.toolchain.or(NIGHTLY),
         packages: vec![Package::UefiTestRunner],
         release: opt.build_mode.release,
         target: Some(*opt.target),
@@ -94,7 +96,7 @@ fn run_host_tests() -> Result<()> {
     let cargo = Cargo {
         action: CargoAction::Test,
         features: vec![Feature::Exts],
-        nightly: true,
+        toolchain: Some(NIGHTLY.into()),
         // Don't test uefi-services (or the packages that depend on it)
         // as it has lang items that conflict with `std`.
         packages: vec![Package::Uefi, Package::UefiMacros, Package::Xtask],

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -63,6 +63,7 @@ pub enum Action {
     Build(BuildOpt),
     Clippy(ClippyOpt),
     Doc(DocOpt),
+    Miri(MiriOpt),
     Run(QemuOpt),
     Test(TestOpt),
     TestLatestRelease(TestLatestReleaseOpt),
@@ -106,6 +107,13 @@ pub struct DocOpt {
 
     #[clap(flatten)]
     pub warning: WarningOpt,
+}
+
+/// Run unit tests and doctests under Miri.
+#[derive(Debug, Parser)]
+pub struct MiriOpt {
+    #[clap(flatten)]
+    pub toolchain: ToolchainOpt,
 }
 
 /// Build uefi-test-runner and run it in QEMU.

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -22,6 +22,22 @@ impl Deref for TargetOpt {
 }
 
 #[derive(Debug, Parser)]
+pub struct ToolchainOpt {
+    /// Rust toolchain to use, e.g. "nightly-2022-02-24".
+    #[clap(long)]
+    toolchain: Option<String>,
+}
+
+impl ToolchainOpt {
+    /// Get the toolchain arg if set, otherwise use `default_toolchain`.
+    pub fn or(&self, default_toolchain: &str) -> Option<String> {
+        self.toolchain
+            .clone()
+            .or_else(|| Some(default_toolchain.to_string()))
+    }
+}
+
+#[derive(Debug, Parser)]
 pub struct BuildModeOpt {
     /// Build in release mode.
     #[clap(long)]
@@ -59,6 +75,9 @@ pub struct BuildOpt {
     pub target: TargetOpt,
 
     #[clap(flatten)]
+    pub toolchain: ToolchainOpt,
+
+    #[clap(flatten)]
     pub build_mode: BuildModeOpt,
 }
 
@@ -69,12 +88,18 @@ pub struct ClippyOpt {
     pub target: TargetOpt,
 
     #[clap(flatten)]
+    pub toolchain: ToolchainOpt,
+
+    #[clap(flatten)]
     pub warning: WarningOpt,
 }
 
 /// Build the docs for the uefi packages.
 #[derive(Debug, Parser)]
 pub struct DocOpt {
+    #[clap(flatten)]
+    pub toolchain: ToolchainOpt,
+
     /// Open the docs in a browser.
     #[clap(long)]
     pub open: bool,
@@ -88,6 +113,9 @@ pub struct DocOpt {
 pub struct QemuOpt {
     #[clap(flatten)]
     pub target: TargetOpt,
+
+    #[clap(flatten)]
+    pub toolchain: ToolchainOpt,
 
     #[clap(flatten)]
     pub build_mode: BuildModeOpt,


### PR DESCRIPTION
xtask: add option to override toolchain
xtask: add command for running unit tests under Miri
ci: add miri job

Fixes https://github.com/rust-osdev/uefi-rs/issues/379