### PR TITLE
Add BootServices::load_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   and `Align::align_buf`.
 - Added `BootServices::connect_controller` and
   `BootServices::disconnect_controller`.
+- Added `BootServices::load_image` and `LoadImageSource`. Together these
+  replace `BootServices::load_image_from_buffer` and also allow an image
+  to be loaded via the `SimpleFileSystem` protocol.
 
 ### Changed
 
@@ -46,6 +49,8 @@
 - Removed `NamedFileProtocolInfo`, `FileInfoHeader`,
   `FileSystemInfoHeader`, and `FileSystemVolumeLabelHeader`. Use
   `FileInfo`, `FileSystemInfo`, and `FileSystemVolumeLabel` instead.
+- Removed `BootServices::load_image_from_buffer`. Use
+  `BootServices::load_image` instead.
 
 ### Fixed
 


### PR DESCRIPTION
This replaces `BootServices::load_image_from_buffer` with a single
method that can load from either a `[u8]` buffer or a file path via
`SimpleFileSystem`.

The source is modeled with the `LoadImageSource` enum. That helps make
it clear that the buffer input isn't needed when specifying a file path,
but the reverse isn't necessarily true since the file path can be added
as metadata when loading from a buffer. Additionally, the `boot_policy`
flag (called `from_boot_manager` in `LoadImageSource`) is only used when
loading from a file path.