### PR TITLE
Drop maintenance badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 ![Stars](https://img.shields.io/github/stars/rust-osdev/uefi-rs)
 ![License](https://img.shields.io/github/license/rust-osdev/uefi-rs)
 ![Build status](https://github.com/rust-osdev/uefi-rs/workflows/Rust/badge.svg)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/rust-osdev/uefi-rs.svg)](http://isitmaintained.com/project/rust-osdev/uefi-rs "Average time to resolve an issue")
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/rust-osdev/uefi-rs.svg)](http://isitmaintained.com/project/rust-osdev/uefi-rs "Percentage of issues still open")
 
 ## Description
 


### PR DESCRIPTION
It seems like these badges aren't getting dynamically updated the way they're supposed to.