### PR TITLE
Remove no-longer-needed allows for clippy lints

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -51,7 +51,6 @@ pub fn exit_boot_services() {
 /// Only valid for as long as the UEFI boot services are available.
 pub struct Allocator;
 
-#[allow(clippy::cast_ptr_alignment)]
 unsafe impl GlobalAlloc for Allocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mem_ty = MemoryType::LOADER_DATA;

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -76,7 +76,6 @@ pub struct GraphicsOutput<'boot> {
     ) -> Status,
     set_mode: extern "efiapi" fn(&mut GraphicsOutput, mode: u32) -> Status,
     // Clippy correctly complains that this is too complicated, but we can't change the spec.
-    #[allow(clippy::type_complexity)]
     blt: unsafe extern "efiapi" fn(
         this: &mut GraphicsOutput,
         buffer: *mut BltPixel,

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -265,7 +265,6 @@ impl FileSystemInfo {
     /// The buffer must be correctly aligned. You can query the required
     /// alignment using the `alignment()` method of the `Align` trait that this
     /// struct implements.
-    #[allow(clippy::too_many_arguments)]
     pub fn new<'buf>(
         storage: &'buf mut [u8],
         read_only: bool,

--- a/src/result/status.rs
+++ b/src/result/status.rs
@@ -128,7 +128,6 @@ impl Status {
 
     /// Converts this status code into a result with a given value.
     #[inline]
-    #[allow(clippy::result_unit_err)]
     pub fn into_with_val<T>(self, val: impl FnOnce() -> T) -> Result<T, ()> {
         if self.is_success() {
             Ok(val())

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -283,7 +283,6 @@ impl BootServices {
     )> {
         let mut map_size = buffer.len();
         MemoryDescriptor::assert_aligned(buffer);
-        #[allow(clippy::cast_ptr_alignment)]
         let map_buffer = buffer.as_ptr() as *mut MemoryDescriptor;
         let mut map_key = MemoryMapKey(0);
         let mut entry_size = 0;

--- a/src/table/cfg.rs
+++ b/src/table/cfg.rs
@@ -7,8 +7,6 @@
 //! This module contains the actual entries of the configuration table,
 //! as well as GUIDs for many known vendor tables.
 
-#![allow(clippy::unreadable_literal)]
-
 use crate::Guid;
 use bitflags::bitflags;
 use core::ffi::c_void;

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -68,7 +68,6 @@ pub fn unsafe_guid(args: TokenStream, input: TokenStream) -> TokenStream {
     result.append_all(quote! {
         unsafe impl #impl_generics ::uefi::Identify for #ident #ty_generics #where_clause {
             #[doc(hidden)]
-            #[allow(clippy::unreadable_literal)]
             const GUID: ::uefi::Guid = ::uefi::Guid::from_values(
                 #time_low,
                 #time_mid,


### PR DESCRIPTION
Various clippy lints have either been made smarter such that they no
longer trigger, or have been moved to the pedantic group which is
allowed by default.