### PR TITLE
Improve Time struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 
 - Added `FileHandle::into_directory` and `FileHandle::into_regular_file`.
+- Added `TimeParams`, `Time::invalid`, and `Time::is_invalid`.
+
+### Changed
+
+- `Time::new` now takes a single `TimeParams` argument so that date and
+  time fields can be explicitly named at the call site.
 
 ## uefi-macros - [Unreleased]
 

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -375,6 +375,7 @@ impl FileProtocolInfo for FileSystemVolumeLabel {}
 mod tests {
     use super::*;
     use crate::alloc_api::vec;
+    use crate::table::runtime::TimeParams;
     use crate::table::runtime::{Daylight, Time};
     use crate::CString16;
 
@@ -394,9 +395,20 @@ mod tests {
 
         let file_size = 123;
         let physical_size = 456;
-        let create_time = Time::new(1970, 1, 1, 0, 0, 0, 0, 0, Daylight::IN_DAYLIGHT);
-        let last_access_time = Time::new(1971, 1, 1, 0, 0, 0, 0, 0, Daylight::IN_DAYLIGHT);
-        let modification_time = Time::new(1972, 1, 1, 0, 0, 0, 0, 0, Daylight::IN_DAYLIGHT);
+        let tp = TimeParams {
+            year: 1970,
+            month: 1,
+            day: 1,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            nanosecond: 0,
+            time_zone: None,
+            daylight: Daylight::IN_DAYLIGHT,
+        };
+        let create_time = Time::new(tp).unwrap();
+        let last_access_time = Time::new(TimeParams { year: 1971, ..tp }).unwrap();
+        let modification_time = Time::new(TimeParams { year: 1972, ..tp }).unwrap();
         let attribute = FileAttribute::READ_ONLY;
         let name = CString16::try_from("test_name").unwrap();
         let info = FileInfo::new(

--- a/uefi-test-runner/src/proto/media/known_disk.rs
+++ b/uefi-test-runner/src/proto/media/known_disk.rs
@@ -5,7 +5,7 @@ use uefi::proto::media::file::{
 };
 use uefi::proto::media::fs::SimpleFileSystem;
 use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
-use uefi::table::runtime::{Daylight, Time};
+use uefi::table::runtime::{Daylight, Time, TimeParams};
 use uefi::CString16;
 
 /// Test directory entry iteration.
@@ -78,17 +78,37 @@ fn test_existing_file(directory: &mut Directory) {
     let info = file.get_info::<FileInfo>(&mut info_buffer).unwrap();
     assert_eq!(info.file_size(), 15);
     assert_eq!(info.physical_size(), 512);
-    assert_eq!(
-        *info.create_time(),
-        Time::new(2000, 1, 24, 0, 0, 0, 0, 2047, Daylight::empty())
-    );
+    let tp = TimeParams {
+        year: 2000,
+        month: 1,
+        day: 24,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        nanosecond: 0,
+        time_zone: None,
+        daylight: Daylight::empty(),
+    };
+    assert_eq!(*info.create_time(), Time::new(tp).unwrap());
     assert_eq!(
         *info.last_access_time(),
-        Time::new(2001, 2, 25, 0, 0, 0, 0, 2047, Daylight::empty())
+        Time::new(TimeParams {
+            year: 2001,
+            month: 2,
+            day: 25,
+            ..tp
+        })
+        .unwrap()
     );
     assert_eq!(
         *info.modification_time(),
-        Time::new(2002, 3, 26, 0, 0, 0, 0, 2047, Daylight::empty())
+        Time::new(TimeParams {
+            year: 2002,
+            month: 3,
+            day: 26,
+            ..tp
+        })
+        .unwrap()
     );
     assert_eq!(info.attribute(), FileAttribute::empty());
     assert_eq!(


### PR DESCRIPTION
* Add a `TimeParams` struct with public fields corresponding to all the
  non-padding fields of `Time`, and change `Time::new` to take that as
  input. That improves callsites of `Time::new` so that you can see what
  the numeric values correspond to. See `known_disk.rs` for an example.

* Add `Time::invalid` for use with `File::set_info`. When setting file
  info, a fully-zero-time indicates the attribute should not be
  updated. I think ideally we'd have `Time` always represent a valid
  value, and use `Option<Time>::None` to represent an invalid time
  similar to what we do with `Handle`s, but I don't think Rust currently
  allows us to indicate that all-zero-Time can be used for the
  Option::None niche.

* Add `Time::is_invalid` to check that all fields are in the valid range.

* Update Time's docstring to be more general. Although `EFI_TIME` in the
  spec says it's for the current time, it's used elsewhere too (like
  `EFI_FILE_INFO`).

* Fix the docstring for `Daylight`, which was accidentally copied from
  `MemoryAttribute`.