### PR TITLE
ci: use stable toolchain for compiling xtask

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,11 +27,15 @@ jobs:
         cp /usr/share/AAVMF/AAVMF_CODE.fd uefi-test-runner/QEMU_EFI-pflash.raw
         cp /usr/share/AAVMF/AAVMF_VARS.fd uefi-test-runner/vars-template-pflash.raw
 
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
           toolchain: nightly
-          override: true
           components: rust-src
       # TODO: cache Rust binaries
 
@@ -54,11 +58,15 @@ jobs:
         sudo apt-get update
         sudo apt-get install qemu-system-x86 ovmf -y
 
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
           toolchain: nightly
-          override: true
           components: rust-src
       # TODO: cache Rust binaries
 
@@ -97,11 +105,15 @@ jobs:
         curl -o uefi-test-runner/OVMF32_CODE.fd https://raw.githubusercontent.com/retrage/edk2-nightly/${EDK2_NIGHTLY_COMMIT}/bin/RELEASEIa32_OVMF_CODE.fd
         curl -o uefi-test-runner/OVMF32_VARS.fd https://raw.githubusercontent.com/retrage/edk2-nightly/${EDK2_NIGHTLY_COMMIT}/bin/RELEASEIa32_OVMF_VARS.fd
 
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
           toolchain: nightly
-          override: true
           components: rust-src
       # TODO: cache Rust binaries
 
@@ -119,13 +131,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
             profile: minimal
             toolchain: nightly
             components: rust-src
-            override: true
 
       - name: Run cargo test
         run: cargo xtask test
@@ -137,13 +153,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
             profile: minimal
             toolchain: nightly
             components: rustfmt, clippy, rust-src
-            override: true
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -163,6 +183,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
 
       - name: Install latest nightly toolchain that includes Miri
         uses: actions-rs/toolchain@v1
@@ -188,11 +213,15 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
 
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
           toolchain: nightly
-          override: true
           components: rust-src
 
     - name: Build

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,13 +108,26 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
 /// with VM tests, but a few things like macros and data types can be
 /// tested with regular tests.
 fn run_host_tests() -> Result<()> {
+    // Run xtask tests.
+    let cargo = Cargo {
+        action: CargoAction::Test,
+        features: Vec::new(),
+        toolchain: None,
+        packages: vec![Package::Xtask],
+        release: false,
+        target: None,
+        warnings_as_errors: false,
+    };
+    run_cmd(cargo.command()?)?;
+
+    // Run uefi-rs and uefi-macros tests.
     let cargo = Cargo {
         action: CargoAction::Test,
         features: vec![Feature::Exts],
         toolchain: Some(NIGHTLY.into()),
         // Don't test uefi-services (or the packages that depend on it)
         // as it has lang items that conflict with `std`.
-        packages: vec![Package::Uefi, Package::UefiMacros, Package::Xtask],
+        packages: vec![Package::Uefi, Package::UefiMacros],
         release: false,
         // Use the host target so that tests can run without a VM.
         target: None,


### PR DESCRIPTION
The nightly rust compiler is currently unable to compile the version of
fatfs we are using in xtask. Rust bug:
https://github.com/rust-lang/rust/issues/95538. But we don't need to use
nightly to compile xtask. In the CI, install both stable and nightly
toolchains. The stable toolchain will be used by default, and xtask
already knows to insert `+nightly` when building uefi-rs, so there's no
need to set `override: true` for the nightly toolchain anymore.

Fixes https://github.com/rust-osdev/uefi-rs/issues/397