### PR TITLE
Add FilePathMediaDevicePath (and a bunch of supporting code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `DevicePathToText` and `DevicePathFromText`.
 - Added `LoadedImage::file_path`
 - Implemented `TryFrom<Vec<u16>> for CString16`.
+- Added `UnalignedCStr16`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Added `LoadedImage::file_path`
 - Implemented `TryFrom<Vec<u16>> for CString16`.
 - Added `UnalignedCStr16`.
+- Added `FilePathMediaDevicePath`.
+- Added `DevicePath::as_acpi_device_path` and
+  `DevicePath::as_file_path_media_device_path`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `RuntimeServices::query_variable_info` and `VariableStorageInfo`.
 - Added `DevicePathToText` and `DevicePathFromText`.
 - Added `LoadedImage::file_path`
+- Implemented `TryFrom<Vec<u16>> for CString16`.
 
 ### Changed
 

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -118,7 +118,10 @@ pub use self::chars::{Char16, Char8};
 mod enums;
 
 mod strs;
-pub use self::strs::{CStr16, CStr8, FromSliceWithNulError, FromStrWithBufError};
+pub use self::strs::{
+    CStr16, CStr8, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16,
+    UnalignedCStr16Error,
+};
 
 #[cfg(feature = "exts")]
 mod owned_strs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(abi_efiapi)]
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
+#![cfg_attr(feature = "exts", feature(vec_into_raw_parts))]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(missing_docs, unused)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 
 #![feature(try_trait_v2)]
 #![feature(abi_efiapi)]
+#![feature(maybe_uninit_slice)]
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
 #![cfg_attr(feature = "exts", feature(vec_into_raw_parts))]


### PR DESCRIPTION
This is a start for https://github.com/rust-osdev/uefi-rs/issues/401

It turned out to be a bit complicated to add useful support for file path media device path nodes, because the data is in a packed struct so the path string may be unaligned. (The spec says "All code references to device path nodes must assume all fields are unaligned".) That means we can't use `&CStr16` to provide access to the path, since reference in Rust must always be aligned.

To solve this I added a new type, `UnalignedCStr16`, with methods to convert to a `&CStr16` using a separate aligned buffer, or `CString16` if `exts` is enabled. There are other places in the UEFI spec with unaligned strings, so this type will be useful elsewhere in the future.

There's a fair amount of unsafe code here, but there are unit tests and Miri seems OK with it :)