### PR TITLE
Fix undefined behavior in `File::get_boxed_info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - `Time::new` now takes a single `TimeParams` argument so that date and
   time fields can be explicitly named at the call site.
+  
+### Fixed
+
+- Fixed undefined behavior in `proto::media::file::File::get_boxed_info`.
 
 ## uefi-macros - [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `Time::new` now takes a single `TimeParams` argument so that date and
   time fields can be explicitly named at the call site.
+- The file info types now derive `PartialEq` and `Eq`.
   
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 - `Time::new` now takes a single `TimeParams` argument so that date and
   time fields can be explicitly named at the call site.
 - The file info types now derive `PartialEq` and `Eq`.
-  
+- The `FileAttributes` type is now `repr(transparent)`.
+
 ### Fixed
 
 - Fixed undefined behavior in `proto::media::file::File::get_boxed_info`.

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -219,7 +219,7 @@ impl FileInfo {
 
     /// Name of the file
     pub fn file_name(&self) -> &CStr16 {
-        unsafe { CStr16::from_ptr(&self.file_name[0]) }
+        unsafe { CStr16::from_ptr(self.file_name.as_ptr()) }
     }
 }
 
@@ -306,7 +306,7 @@ impl FileSystemInfo {
 
     /// Volume label
     pub fn volume_label(&self) -> &CStr16 {
-        unsafe { CStr16::from_ptr(&self.volume_label[0]) }
+        unsafe { CStr16::from_ptr(self.volume_label.as_ptr()) }
     }
 }
 
@@ -353,7 +353,7 @@ impl FileSystemVolumeLabel {
 
     /// Volume label
     pub fn volume_label(&self) -> &CStr16 {
-        unsafe { CStr16::from_ptr(&self.volume_label[0]) }
+        unsafe { CStr16::from_ptr(self.volume_label.as_ptr()) }
     }
 }
 

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -139,7 +139,7 @@ pub enum FileInfoCreationError {
 ///   existing file in the same directory.
 /// - If a file is read-only, the only allowed change is to remove the read-only
 ///   attribute. Other changes must be carried out in a separate transaction.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[repr(C)]
 #[unsafe_guid("09576e92-6d3f-11d2-8e39-00a0c969723b")]
 pub struct FileInfo {
@@ -243,7 +243,7 @@ impl FileProtocolInfo for FileInfo {}
 ///
 /// Please note that only the system volume's volume label may be set using
 /// this information structure. Consider using `FileSystemVolumeLabel` instead.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[repr(C)]
 #[unsafe_guid("09576e93-6d3f-11d2-8e39-00a0c969723b")]
 pub struct FileSystemInfo {
@@ -327,7 +327,7 @@ impl FileProtocolInfo for FileSystemInfo {}
 /// System volume label
 ///
 /// May only be obtained on the root directory's file handle.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[repr(C)]
 #[unsafe_guid("db47d7d3-fe81-11d3-9a35-0090273fc14d")]
 pub struct FileSystemVolumeLabel {

--- a/uefi-test-runner/src/proto/media/known_disk.rs
+++ b/uefi-test-runner/src/proto/media/known_disk.rs
@@ -116,6 +116,10 @@ fn test_existing_file(directory: &mut Directory) {
         CString16::try_from("test_input.txt").unwrap()
     );
 
+    // Check that `get_boxed_info` returns the same info.
+    let boxed_info = file.get_boxed_info::<FileInfo>().unwrap();
+    assert_eq!(*info, *boxed_info);
+
     // Delete the file.
     file.delete().unwrap();
 
@@ -187,6 +191,10 @@ pub fn test_known_disk(image: Handle, bt: &BootServices) {
         assert_eq!(fs_info.volume_size(), 512 * 1192);
         assert_eq!(fs_info.free_space(), 512 * 1190);
         assert_eq!(fs_info.block_size(), 512);
+
+        // Check that `get_boxed_info` returns the same info.
+        let boxed_fs_info = directory.get_boxed_info::<FileSystemInfo>().unwrap();
+        assert_eq!(*fs_info, *boxed_fs_info);
 
         test_existing_dir(&mut directory);
         test_delete_warning(&mut directory);


### PR DESCRIPTION
This is a partial fix for https://github.com/rust-osdev/uefi-rs/issues/406 in that it removes the only internal use of `exts::allocate_buffer`.

Also added a call to `get_boxed_info` in uefi-test-runner to check that it works there, and a new unit test so that Miri can validate all the unsafe code in `get_boxed_info`.