### PR TITLE
Fix potential UB in file info

### DIFF
--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -88,12 +88,13 @@ trait InfoInternal: Align + ptr::Pointee<Metadata = usize> {
         // Initialize the struct header.
         init(info_ptr, info_size as u64);
 
+        // Create a pointer to the part of info where the name is
+        // stored. Note that `info_ptr` is used rather than `storage` to
+        // comply with Stacked Borrows.
+        let info_name_ptr = Self::name_ptr(info_ptr as *mut u8);
+
         // Initialize the name slice.
-        ptr::copy(
-            name.as_ptr(),
-            Self::name_ptr(storage.as_mut_ptr()),
-            name_length_ucs2,
-        );
+        ptr::copy(name.as_ptr(), info_name_ptr, name_length_ucs2);
 
         // The struct is now valid and safe to dereference.
         let info = &mut *info_ptr;


### PR DESCRIPTION
When running the file info tests under Miri with
`-Zmiri-tag-raw-pointers` enabled, `new_impl` triggered a Stacked
Borrows error. This occurred because after a mutable info pointer to the
raw `u8` buffer was created, we went back and created another mutable
pointer within the `u8` buffer to copy the name string into.

Fix by creating the name destination pointer from the info pointer
rather than the `u8` buffer pointer.