### PR TITLE
Add documentation on why UnsafeCell is used for protocols

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,12 +1,13 @@
 //! Protocol definitions.
 //!
-//! Protocols are sets of related functionality.
+//! Protocols are sets of related functionality identified by a unique
+//! ID. They can be implemented by a UEFI driver or occasionally by a
+//! UEFI application.
 //!
-//! Protocols are identified by a unique ID.
+//! See the [`BootServices`] documentation for details of how to open a
+//! protocol.
 //!
-//! Protocols can be implemented by a UEFI driver,
-//! and are usually retrieved from a standard UEFI table or
-//! by querying a handle.
+//! [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
 
 use crate::Identify;
 


### PR DESCRIPTION
I periodically get confused about why we use `UnsafeCell` to return protocol references. I _think_ this new documentation accurately describes why, but definitely open to corrections if I have it wrong :)

I think it's possible that in the future we could improve the API to avoid needing `UnsafeCell`. For example, if we make `open_protocol` always use `Exclusive` access then we can provide stronger guarantees (and then maybe have some `unsafe` escape-hatch methods for opening protocols in other modes, with appropriate documentation around how to use them without triggering UB). For now though, I figure it would be helpful to document the current state of things.