### PR TITLE
Enable the clippy::ptr_as_ptr lint

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -72,7 +72,7 @@ unsafe impl GlobalAlloc for Allocator {
             }
             let return_ptr = ptr.add(offset);
             // store allocated pointer before the struct
-            (return_ptr as *mut *mut u8).sub(1).write(ptr);
+            (return_ptr.cast::<*mut u8>()).sub(1).write(ptr);
             return_ptr
         } else {
             boot_services()

--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -73,7 +73,7 @@ impl TryFrom<Vec<u16>> for CString16 {
         // example in the docs for `into_raw_parts`.
         let (ptr, len, cap) = input.into_raw_parts();
         let rebuilt = unsafe {
-            let ptr = ptr as *mut Char16;
+            let ptr = ptr.cast::<Char16>();
             Vec::from_raw_parts(ptr, len, cap)
         };
 

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -72,7 +72,7 @@ impl CStr8 {
         while *ptr.add(len) != NUL_8 {
             len += 1
         }
-        let ptr = ptr as *const u8;
+        let ptr = ptr.cast::<u8>();
         Self::from_bytes_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1))
     }
 
@@ -137,7 +137,7 @@ impl CStr16 {
         while *ptr.add(len) != NUL_16 {
             len += 1
         }
-        let ptr = ptr as *const u16;
+        let ptr = ptr.cast::<u16>();
         Self::from_u16_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 #![cfg_attr(feature = "exts", feature(vec_into_raw_parts))]
 #![no_std]
 // Enable some additional warnings and lints.
-#![warn(missing_docs, unused)]
+#![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
 
 // `uefi-exts` requires access to memory allocation APIs.

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -630,7 +630,8 @@ impl<'gop> FrameBuffer<'gop> {
             index.saturating_add(mem::size_of::<T>()) <= self.size,
             "Frame buffer accessed out of bounds"
         );
-        (self.base.add(index) as *mut T).write_volatile(value)
+        let ptr = self.base.add(index).cast::<T>();
+        ptr.write_volatile(value)
     }
 
     /// Read a value from the frame buffer, starting at the i-th byte

--- a/src/proto/device_path/mod.rs
+++ b/src/proto/device_path/mod.rs
@@ -114,11 +114,11 @@ impl PartialEq for DevicePath {
         // comparing the fields of the `DevicePath` struct.
         unsafe {
             let self_bytes = slice::from_raw_parts(
-                self as *const DevicePath as *const u8,
+                (self as *const DevicePath).cast::<u8>(),
                 self.length() as usize,
             );
             let other_bytes = slice::from_raw_parts(
-                other as *const DevicePath as *const u8,
+                (other as *const DevicePath).cast::<u8>(),
                 other.length() as usize,
             );
 
@@ -149,9 +149,9 @@ impl<'a> Iterator for DevicePathIterator<'a> {
 
         // Advance self.path to the next entry.
         let len = cur.header.length;
-        let byte_ptr = cur as *const DevicePath as *const u8;
+        let byte_ptr = (cur as *const DevicePath).cast::<u8>();
         unsafe {
-            let next_path_ptr = byte_ptr.add(len as usize) as *const DevicePath;
+            let next_path_ptr = byte_ptr.add(len as usize).cast::<DevicePath>();
             self.path = &*next_path_ptr;
         }
 
@@ -345,7 +345,7 @@ impl FilePathMediaDevicePath {
             // Use `addr_of` to avoid creating an unaligned reference.
             let ptr: *const [u16] = ptr::addr_of!(self.path_name);
             let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
-            UnalignedCStr16::new(self, ptr as *const u16, len)
+            UnalignedCStr16::new(self, ptr.cast::<u16>(), len)
         }
     }
 }

--- a/src/proto/loaded_image.rs
+++ b/src/proto/loaded_image.rs
@@ -83,7 +83,7 @@ impl LoadedImage {
         } else {
             let s = unsafe {
                 slice::from_raw_parts(
-                    self.load_options as *const u16,
+                    self.load_options.cast::<u16>(),
                     load_options_size / mem::size_of::<u16>(),
                 )
             };

--- a/src/proto/media/file/dir.rs
+++ b/src/proto/media/file/dir.rs
@@ -49,7 +49,7 @@ impl Directory {
         // Read the directory entry into the aligned storage
         self.0.read(buffer).map(|size| {
             if size != 0 {
-                unsafe { Some(FileInfo::from_uefi(buffer.as_mut_ptr() as *mut c_void)) }
+                unsafe { Some(FileInfo::from_uefi(buffer.as_mut_ptr().cast::<c_void>())) }
             } else {
                 None
             }

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -147,7 +147,7 @@ pub trait File: Sized {
     /// * `uefi::Status::ACCESS_DENIED`     Requested change is invalid for this information type
     /// * `uefi::Status::VOLUME_FULL`       Not enough space left on the volume to change the info
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
-        let info_ptr = info as *const Info as *const c_void;
+        let info_ptr = (info as *const Info).cast::<c_void>();
         let info_size = mem::size_of_val(&info);
         unsafe { (self.imp().set_info)(self.imp(), &Info::GUID, info_size, info_ptr).into() }
     }


### PR DESCRIPTION
`as` conversions are a bit of a blunt hammer, so where possible it's
nice to use a more restricted operation.

Lint is described here: https://rust-lang.github.io/rust-clippy/master/#ptr_as_ptr

It would be great to eventually get rid of most `as` conversions, but baby steps :)