### PR TITLE
Fix test_get_boxed_info with -Zmiri-tag-raw-pointers

### DIFF
--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -117,7 +117,7 @@ pub trait File: Sized {
             )
         }
         .into_with(
-            || unsafe { Info::from_uefi(buffer.as_ptr() as *mut c_void) },
+            || unsafe { Info::from_uefi(buffer.as_mut_ptr().cast::<c_void>()) },
             |s| {
                 if s == Status::BUFFER_TOO_SMALL {
                     Some(buffer_size)


### PR DESCRIPTION
Very simple fix, we're making a `&mut Info` so need to pass in a mutable
pointer.

Partial fix for https://github.com/rust-osdev/uefi-rs/issues/414