### PR TITLE
Add documentation links for `BootServices` and `RuntimeServices`.

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -18,6 +18,12 @@ use core::{ptr, slice};
 
 /// Contains pointers to all of the boot services.
 ///
+/// # Accessing `BootServices`
+///
+/// A reference to `BootServices` can only be accessed by calling [`boot_services`].
+///
+/// [`boot_services`]: crate::table::SystemTable::boot_services
+///
 /// # Accessing protocols
 ///
 /// Protocols can be opened using several methods of `BootServices`. Most

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -18,6 +18,12 @@ use core::{fmt, ptr};
 ///
 /// This table, and the function pointers it contains are valid
 /// even after the UEFI OS loader and OS have taken control of the platform.
+///
+/// # Accessing `RuntimeServices`
+///
+/// A reference to `RuntimeServices` can only be accessed by calling [`runtime_services`].
+///
+/// [`runtime_services`]: crate::table::SystemTable::runtime_services
 #[repr(C)]
 pub struct RuntimeServices {
     header: Header,


### PR DESCRIPTION
The added links show which methods in `SystemTable` can be called to get
a reference of each struct.

rust-osdev#416