### PR TITLE
Fix off-by-one test error

### DIFF
--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -36,7 +36,7 @@ fn find_protocol(bt: &BootServices) {
         .expect("Failed to retrieve list of handles");
 
     assert!(
-        handles.len() > 1,
+        !handles.is_empty(),
         "There should be at least one implementation of Simple Text Output (stdout)"
     );
 }


### PR DESCRIPTION
The check for "at least one implementation of Simple Text Output" was
accidentally checking for at least two implementations.