### PR TITLE
Add documentation links

### DIFF
--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -7,6 +7,19 @@ use core::fmt::{Debug, Formatter};
 ///
 /// It implements the fmt::Write trait, so you can use it to print text with
 /// standard Rust constructs like the `write!()` and `writeln!()` macros.
+///
+/// # Accessing `Output` protocol
+///
+/// The standard output and standard error output protocols can be accessed
+/// using [`SystemTable::stdout`] and [`SystemTable::stderr`], respectively.
+///
+/// An `Output` protocol can also be accessed like any other UEFI protocol.
+/// See the [`BootServices`] documentation for more details of how to open a
+/// protocol.
+///
+/// [`SystemTable::stdout`]: crate::table::SystemTable::stdout
+/// [`SystemTable::stderr`]: crate::table::SystemTable::stderr
+/// [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
 #[repr(C)]
 #[unsafe_guid("387477c2-69c7-11d2-8e39-00a0c969723b")]
 #[derive(Protocol)]

--- a/src/proto/media/fs.rs
+++ b/src/proto/media/fs.rs
@@ -9,6 +9,16 @@ use core::ptr;
 ///
 /// This interface is implemented by some storage devices
 /// to allow file access to the contained file systems.
+///
+/// # Accessing `SimpleFileSystem` protocol
+///
+/// Use [`BootServices::get_image_file_system`] to retrieve the `SimpleFileSystem`
+/// protocol associated with a given image handle.
+///
+/// See the [`BootServices`] documentation for more details of how to open a protocol.
+///
+/// [`BootServices::get_image_file_system`]: crate::table::boot::BootServices::get_image_file_system
+/// [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
 #[repr(C)]
 #[unsafe_guid("964e5b22-6459-11d2-8e39-00a0c969723b")]
 #[derive(Protocol)]

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -21,9 +21,9 @@ use core::{ptr, slice};
 ///
 /// # Accessing `BootServices`
 ///
-/// A reference to `BootServices` can only be accessed by calling [`boot_services`].
+/// A reference to `BootServices` can only be accessed by calling [`SystemTable::boot_services`].
 ///
-/// [`boot_services`]: crate::table::SystemTable::boot_services
+/// [`SystemTable::boot_services`]: crate::table::SystemTable::boot_services
 ///
 /// # Accessing protocols
 ///

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -21,9 +21,9 @@ use core::{fmt, ptr};
 ///
 /// # Accessing `RuntimeServices`
 ///
-/// A reference to `RuntimeServices` can only be accessed by calling [`runtime_services`].
+/// A reference to `RuntimeServices` can only be accessed by calling [`SystemTable::runtime_services`].
 ///
-/// [`runtime_services`]: crate::table::SystemTable::runtime_services
+/// [`SystemTable::runtime_services`]: crate::table::SystemTable::runtime_services
 #[repr(C)]
 pub struct RuntimeServices {
     header: Header,


### PR DESCRIPTION
Documentation links have been added to the following structs:
* `SimpleFileSystem`
* `Output`

Documentation links have been updated in the following structs:
* `BootServices`
* `RuntimeServices`

Adds documentation for https://github.com/rust-osdev/uefi-rs/issues/416