### PR TITLE
Change logger max level to be set by feature

### DIFF
--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -110,9 +110,6 @@ unsafe fn init_logger(st: &mut SystemTable<Boot>) {
 
     // Set the logger.
     log::set_logger(logger).unwrap(); // Can only fail if already initialized.
-
-    // Log everything.
-    log::set_max_level(log::LevelFilter::Info);
 }
 
 /// Notify the utility library that boot services are not safe to call anymore

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -110,6 +110,9 @@ unsafe fn init_logger(st: &mut SystemTable<Boot>) {
 
     // Set the logger.
     log::set_logger(logger).unwrap(); // Can only fail if already initialized.
+
+    // Set logger max level to level specified by log features
+    log::set_max_level(log::STATIC_MAX_LEVEL);
 }
 
 /// Notify the utility library that boot services are not safe to call anymore


### PR DESCRIPTION
Resolves #428 

By changing `log::set_max_level(log::LevelFilter::Info);` to `log::set_max_level(log::STATIC_MAX_LEVEL);`, the max log level can be set by specifying features.

For example, to use info for release and trace for debugging, set `features = ["release_max_level_info", "max_level_trace"]`.

Tested this to work, thought I could just remove that line, but it seems you need to explicitly set it to STATIC_MAX_LEVEL, which is set depending on the features and whether it is a release build.