### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = ["nightly"]
+components = ["rust-src"]


### PR DESCRIPTION
Just to make it easier to run the repo, I added a toolchain file to setup using nightly and rust-src, so people don't have to worry about doing it manually.