### PR TITLE
Implement `Deref` and `DerefMut` for `ScopedProtocol`

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1031,21 +1031,17 @@ impl BootServices {
             },
             OpenProtocolAttributes::Exclusive,
         )?;
-        let loaded_image = unsafe { &*loaded_image.interface.get() };
-
-        let device_handle = loaded_image.device();
 
         let device_path = self.open_protocol::<DevicePath>(
             OpenProtocolParams {
-                handle: device_handle,
+                handle: loaded_image.device(),
                 agent: image_handle,
                 controller: None,
             },
             OpenProtocolAttributes::Exclusive,
         )?;
-        let mut device_path = unsafe { &*device_path.interface.get() };
 
-        let device_handle = self.locate_device_path::<SimpleFileSystem>(&mut device_path)?;
+        let device_handle = self.locate_device_path::<SimpleFileSystem>(&mut &*device_path)?;
 
         self.open_protocol::<SimpleFileSystem>(
             OpenProtocolParams {

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -14,6 +14,7 @@ use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
 use core::mem::{self, MaybeUninit};
+use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::{ptr, slice};
 
@@ -1350,6 +1351,20 @@ impl<'a, P: Protocol + ?Sized> Drop for ScopedProtocol<'a, P> {
         // and the error can't be propagated out of drop anyway, so just
         // assert success.
         assert_eq!(status, Status::SUCCESS);
+    }
+}
+
+impl<'a, P: Protocol + ?Sized> Deref for ScopedProtocol<'a, P> {
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.interface.get() }
+    }
+}
+
+impl<'a, P: Protocol + ?Sized> DerefMut for ScopedProtocol<'a, P> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.interface.get() }
     }
 }
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -885,6 +885,8 @@ impl BootServices {
         )
         .into_with_val(|| unsafe {
             let interface = P::mut_ptr_from_ffi(interface) as *const UnsafeCell<P>;
+
+            #[allow(deprecated)]
             ScopedProtocol {
                 interface: &*interface,
                 open_params: params,
@@ -1327,6 +1329,7 @@ pub struct OpenProtocolParams {
 /// protocol and why [`UnsafeCell`] is used.
 pub struct ScopedProtocol<'a, P: Protocol + ?Sized> {
     /// The protocol interface.
+    #[deprecated(since = "0.16.0", note = "use Deref and DerefMut instead")]
     pub interface: &'a UnsafeCell<P>,
 
     open_params: OpenProtocolParams,
@@ -1354,13 +1357,19 @@ impl<'a, P: Protocol + ?Sized> Deref for ScopedProtocol<'a, P> {
     type Target = P;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &*self.interface.get() }
+        #[allow(deprecated)]
+        unsafe {
+            &*self.interface.get()
+        }
     }
 }
 
 impl<'a, P: Protocol + ?Sized> DerefMut for ScopedProtocol<'a, P> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.interface.get() }
+        #[allow(deprecated)]
+        unsafe {
+            &mut *self.interface.get()
+        }
     }
 }
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -86,7 +86,7 @@ fn check_screenshot(image: Handle, bt: &BootServices, name: &str) {
             .get(1)
             .expect("Second serial device is missing");
 
-        let serial = bt
+        let mut serial = bt
             .open_protocol::<Serial>(
                 OpenProtocolParams {
                     handle: serial_handle,
@@ -96,7 +96,6 @@ fn check_screenshot(image: Handle, bt: &BootServices, name: &str) {
                 OpenProtocolAttributes::Exclusive,
             )
             .expect("Could not open serial protocol");
-        let serial = unsafe { &mut *serial.interface.get() };
 
         // Set a large timeout to avoid problems with Travis
         let mut io_mode = *serial.io_mode();

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -7,7 +7,7 @@ pub fn test(image: Handle, bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
     if let Ok(handles) = bt.find_handles::<DebugSupport>() {
         for handle in handles {
-            if let Ok(debug_support) = bt.open_protocol::<DebugSupport>(
+            if let Ok(mut debug_support) = bt.open_protocol::<DebugSupport>(
                 OpenProtocolParams {
                     handle,
                     agent: image,
@@ -15,8 +15,6 @@ pub fn test(image: Handle, bt: &BootServices) {
                 },
                 OpenProtocolAttributes::Exclusive,
             ) {
-                let debug_support = unsafe { &mut *debug_support.interface.get() };
-
                 // make sure that the max processor index is a sane value, i.e. it works
                 let maximum_processor_index = debug_support.get_maximum_processor_index();
                 assert_ne!(
@@ -94,7 +92,7 @@ pub fn test(image: Handle, bt: &BootServices) {
                     _ => unreachable!(),
                 }
 
-                test_invalidate_instruction_cache(debug_support);
+                test_invalidate_instruction_cache(&mut *debug_support);
             }
         }
     } else {

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -16,7 +16,6 @@ pub fn test(image: Handle, bt: &BootServices) {
             OpenProtocolAttributes::Exclusive,
         )
         .expect("Failed to open LoadedImage protocol");
-    let loaded_image = unsafe { &*loaded_image.interface.get() };
 
     let device_path = bt
         .open_protocol::<DevicePath>(
@@ -28,7 +27,6 @@ pub fn test(image: Handle, bt: &BootServices) {
             OpenProtocolAttributes::Exclusive,
         )
         .expect("Failed to open DevicePath protocol");
-    let device_path = unsafe { &*device_path.interface.get() };
 
     let device_path_to_text = bt
         .locate_protocol::<DevicePathToText>()

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -15,7 +15,6 @@ pub fn test(image: Handle, bt: &BootServices) {
             OpenProtocolAttributes::Exclusive,
         )
         .expect("Failed to open LoadedImage protocol");
-    let loaded_image = unsafe { &*loaded_image.interface.get() };
 
     let load_options = loaded_image.load_options_as_bytes();
     info!("LoadedImage options: {:?}", load_options);

--- a/uefi-test-runner/src/proto/media/known_disk.rs
+++ b/uefi-test-runner/src/proto/media/known_disk.rs
@@ -154,7 +154,7 @@ pub fn test_known_disk(image: Handle, bt: &BootServices) {
 
     let mut found_test_disk = false;
     for handle in handles {
-        let sfs = bt
+        let mut sfs = bt
             .open_protocol::<SimpleFileSystem>(
                 OpenProtocolParams {
                     handle,
@@ -164,7 +164,6 @@ pub fn test_known_disk(image: Handle, bt: &BootServices) {
                 OpenProtocolAttributes::Exclusive,
             )
             .expect("Failed to get simple file system");
-        let sfs = unsafe { &mut *sfs.interface.get() };
         let mut directory = sfs.open_volume().unwrap();
 
         let mut fs_info_buf = vec![0; 128];

--- a/uefi-test-runner/src/proto/media/mod.rs
+++ b/uefi-test-runner/src/proto/media/mod.rs
@@ -72,7 +72,6 @@ pub fn test(image: Handle, bt: &BootServices) {
                 OpenProtocolAttributes::Exclusive,
             )
             .expect("Failed to get partition info");
-        let pi = unsafe { &*pi.interface.get() };
 
         if let Some(mbr) = pi.mbr_partition_record() {
             info!("MBR partition: {:?}", mbr);

--- a/uefi-test-runner/src/proto/network.rs
+++ b/uefi-test-runner/src/proto/network.rs
@@ -13,7 +13,7 @@ pub fn test(image: Handle, bt: &BootServices) {
 
     if let Ok(handles) = bt.find_handles::<BaseCode>() {
         for handle in handles {
-            let base_code = bt
+            let mut base_code = bt
                 .open_protocol::<BaseCode>(
                     OpenProtocolParams {
                         handle,
@@ -23,8 +23,6 @@ pub fn test(image: Handle, bt: &BootServices) {
                     OpenProtocolAttributes::Exclusive,
                 )
                 .unwrap();
-
-            let base_code = unsafe { &mut *base_code.interface.get() };
 
             info!("Starting PXE Base Code");
             base_code

--- a/uefi-test-runner/src/proto/rng.rs
+++ b/uefi-test-runner/src/proto/rng.rs
@@ -11,7 +11,7 @@ pub fn test(image: Handle, bt: &BootServices) {
         .first()
         .expect("No Rng handles");
 
-    let rng = bt
+    let mut rng = bt
         .open_protocol::<Rng>(
             OpenProtocolParams {
                 handle,
@@ -21,7 +21,6 @@ pub fn test(image: Handle, bt: &BootServices) {
             OpenProtocolAttributes::Exclusive,
         )
         .expect("Failed to open Rng protocol");
-    let rng = unsafe { &mut *rng.interface.get() };
 
     let mut list = [RngAlgorithmType::EMPTY_ALGORITHM; 4];
 


### PR DESCRIPTION
Since `ScopedProtocol`'s only use is to be dereferenced, it makes sense to add a `Deref` impl so users don't have to do it manually. This also improves safety, since with this change it's harder to accidentally keep a reference to a protocol alive after exiting boot services.