### PR TITLE
Switch back to automatic Debug derive for Header struct

### DIFF
--- a/src/table/header.rs
+++ b/src/table/header.rs
@@ -1,7 +1,7 @@
 use super::Revision;
-use core::fmt::{Debug, Formatter};
 
 /// All standard UEFI tables begin with a common header.
+#[derive(Debug)]
 #[repr(C)]
 pub struct Header {
     /// Unique identifier for this table.
@@ -15,15 +15,4 @@ pub struct Header {
     pub crc: u32,
     /// Reserved field that must be set to 0.
     _reserved: u32,
-}
-
-impl Debug for Header {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Header")
-            .field("signature", &(self.size as *const u64))
-            .field("revision", &self.revision)
-            .field("size", &self.size)
-            .field("crc", &self.crc)
-            .finish()
-    }
 }


### PR DESCRIPTION
The `Header` `Debug` implementation was accidentally printing the `size`
field for the `signature`. Rather than just fix that field, switch the
whole thing back to using `derive(Debug)`. This adds in the `_reserved`
field, which probably doesn't matter much either way but might as well
show the whole struct when debug printing.