### PR TITLE
Check table version before calling UEFI 2.0+ functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## uefi - [Unreleased]
 
+### Added
+
+- Added EFI revision constants to `Revision`.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]
@@ -32,6 +36,7 @@
 - `DevicePath` is now a DST that represents an entire device path. The
   `DevicePathInstance` and `DevicePathNode` provide views of path
   instances and nodes, respectively.
+- The methods of `Revision` are now `const`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Added EFI revision constants to `Revision`.
 
+### Fixed
+
+- The `BootServices::create_event_ex` and
+  `RuntimeServices::query_variable_info` methods now check the table
+  version to make sure it's 2.0 or higher before calling the associated
+  function pointers. This prevents potential invalid pointer access.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/src/table/revision.rs
+++ b/src/table/revision.rs
@@ -9,21 +9,41 @@ use core::fmt;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Revision(u32);
 
+// Allow missing docs, there's nothing useful to document about these
+// constants.
+#[allow(missing_docs)]
+impl Revision {
+    pub const EFI_1_02: Self = Self::new(1, 2);
+    pub const EFI_1_10: Self = Self::new(1, 10);
+    pub const EFI_2_00: Self = Self::new(2, 00);
+    pub const EFI_2_10: Self = Self::new(2, 10);
+    pub const EFI_2_20: Self = Self::new(2, 20);
+    pub const EFI_2_30: Self = Self::new(2, 30);
+    pub const EFI_2_31: Self = Self::new(2, 31);
+    pub const EFI_2_40: Self = Self::new(2, 40);
+    pub const EFI_2_50: Self = Self::new(2, 50);
+    pub const EFI_2_60: Self = Self::new(2, 60);
+    pub const EFI_2_70: Self = Self::new(2, 70);
+    pub const EFI_2_80: Self = Self::new(2, 80);
+    pub const EFI_2_90: Self = Self::new(2, 90);
+}
+
 impl Revision {
     /// Creates a new revision.
-    pub fn new(major: u16, minor: u16) -> Self {
-        let (major, minor) = (u32::from(major), u32::from(minor));
+    pub const fn new(major: u16, minor: u16) -> Self {
+        let major = major as u32;
+        let minor = minor as u32;
         let value = (major << 16) | minor;
         Revision(value)
     }
 
     /// Returns the major revision.
-    pub fn major(self) -> u16 {
+    pub const fn major(self) -> u16 {
         (self.0 >> 16) as u16
     }
 
     /// Returns the minor revision.
-    pub fn minor(self) -> u16 {
+    pub const fn minor(self) -> u16 {
         self.0 as u16
     }
 }
@@ -33,5 +53,20 @@ impl fmt::Debug for Revision {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (major, minor) = (self.major(), self.minor());
         write!(f, "{}.{}.{}", major, minor / 10, minor % 10)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_revision() {
+        let rev = Revision::EFI_2_31;
+        assert_eq!(rev.major(), 2);
+        assert_eq!(rev.minor(), 31);
+        assert_eq!(rev.0, 0x0002_001f);
+
+        assert!(Revision::EFI_1_10 < Revision::EFI_2_00);
     }
 }


### PR DESCRIPTION
The create_event_ex function (in boot services) and query_variable_info (in runtime services) were added to their respective tables in UEFI 2.0. In earlier versions these functions can't be called, so check the table revision before using these function pointers.