### PR TITLE
Fix compilation of the xtask package under Windows and add to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,3 +226,25 @@ jobs:
 
     - name: Build
       run: cargo xtask test-latest-release
+
+  windows:
+    name: Check that the build works on a Windows target
+    runs-on: windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: nightly
+            components: rust-src
+
+      - name: Build
+        run: cargo xtask build

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.51"
+cfg-if = "1.0.0"
 clap = { version = "3.0.13", features = ["derive"] }
 # The latest fatfs release (0.3.5) is old, use git instead to pick up some fixes.
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use anyhow::Result;
 use fatfs::{Date, DateTime, FileSystem, FormatVolumeOptions, FsOptions, StdIoWrapper, Time};
 use mbrman::{MBRPartitionEntry, CHS, MBR};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ mod util;
 
 use anyhow::Result;
 use cargo::{Cargo, CargoAction, Feature, Package};
+use cfg_if::cfg_if;
 use clap::Parser;
 use opt::{Action, BuildOpt, ClippyOpt, DocOpt, MiriOpt, Opt, QemuOpt};
 use std::process::Command;
@@ -102,7 +103,13 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
     };
     run_cmd(cargo.command()?)?;
 
-    qemu::run_qemu(*opt.target, opt)
+    cfg_if! {
+        if #[cfg(unix)] {
+            qemu::run_qemu(*opt.target, opt)
+        } else {
+            panic!("vm tests are only supported on unix targets");
+        }
+    }
 }
 
 /// Run unit tests and doctests on the host. Most of uefi-rs is tested

--- a/xtask/src/net.rs
+++ b/xtask/src/net.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::net::UdpSocket;
 
 /// Start a thread that listens on UDP port 21572 and simulates a simple echo

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use crate::arch::UefiArch;
 use crate::disk::{check_mbr_test_disk, create_mbr_test_disk};
 use crate::net;


### PR DESCRIPTION
As reported in https://github.com/rust-osdev/uefi-rs/pull/433, the qemu code makes use of some APIs from the `nix` crate, which causes compilation to fail on Windows (native, not WSL). The qemu code can't be easily made to work on Windows, but the rest of xtask should still work fine building, running clippy, etc. Fix by adding `#![cfg(unix)]` to the `qemu` module, as well as the `disk` and `net` modules that are only used by the qemu code. Also changed the `run_vm_tests` action to panic on non-Unix targets.

Also add Windows compilation to CI. The new job builds the UEFI packages on a Windows runner instead of Ubuntu. This is a somewhat minimal test (just builds for a single target, doesn't run tests or clippy), but should be enough to ensure that development on Windows outside of WSL is in a working state.
