### PR TITLE
Add changelog entry for `ScopedProtocol` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - Added EFI revision constants to `Revision`.
+- Added `Deref` and `DerefMut` trait implementations to `ScopedProtocol`.
+  This eliminates the need to explicitly access the `interface` field,
+  which is now marked as deprecated.
 
 ### Fixed
 


### PR DESCRIPTION
Realized we didn't include one in #434.