### PR TITLE
Fix query_variable_info test

### DIFF
--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -47,14 +47,18 @@ fn test_variables(rt: &RuntimeServices) {
 
 fn test_variable_info(rt: &RuntimeServices) {
     info!(
-        "Storage for non-volatile variabls: {:?}",
-        rt.query_variable_info(VariableAttributes::NON_VOLATILE),
+        "Storage for non-volatile boot-services variables: {:?}",
+        rt.query_variable_info(
+            VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::NON_VOLATILE
+        )
+        .unwrap(),
     );
     info!(
         "Storage for volatile runtime variables: {:?}",
         rt.query_variable_info(
             VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS
-        ),
+        )
+        .unwrap(),
     );
 }
 


### PR DESCRIPTION
The behavior of OVMF changed recently so that calling
query_variable_info with just the `NON_VOLATILE` attribute is treated as
an error:
https://github.com/tianocore/edk2/commit/21320ef66989f8af5a9e9b57df73d20a70bea85f

Fix by OR'ing it with `BOOTSERVICE_ACCESS`.

Also fix a typo in the output, and `unwrap` the result of calling
`query_variable_info` since these calls should always succeed.