### PR TITLE
xtask: Pin to clap 3.1 to avoid deprecation errors

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.51"
 cfg-if = "1.0.0"
-clap = { version = "3.0.13", features = ["derive"] }
+clap = { version = "~3.1", features = ["derive"] }
 # The latest fatfs release (0.3.5) is old, use git instead to pick up some fixes.
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }
 fs-err = "2.6.0"


### PR DESCRIPTION
This is a minimal fix to get the CI passing again.

See https://github.com/clap-rs/clap/issues/3822 for more details.