### PR TITLE
Fix errors due to deprecations in the `clap` API

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.51"
 cfg-if = "1.0.0"
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "3.2.1", features = ["derive"] }
 # The latest fatfs release (0.3.5) is old, use git instead to pick up some fixes.
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }
 fs-err = "2.6.0"

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 pub struct TargetOpt {
     /// UEFI target to build for.
-    #[clap(long, default_value_t)]
+    #[clap(long, action, default_value_t)]
     pub target: UefiArch,
 }
 
@@ -24,7 +24,7 @@ impl Deref for TargetOpt {
 #[derive(Debug, Parser)]
 pub struct ToolchainOpt {
     /// Rust toolchain to use, e.g. "nightly-2022-02-24".
-    #[clap(long)]
+    #[clap(long, action)]
     toolchain: Option<String>,
 }
 
@@ -40,14 +40,14 @@ impl ToolchainOpt {
 #[derive(Debug, Parser)]
 pub struct BuildModeOpt {
     /// Build in release mode.
-    #[clap(long)]
+    #[clap(long, action)]
     pub release: bool,
 }
 
 #[derive(Debug, Parser)]
 pub struct WarningOpt {
     /// Treat warnings as errors.
-    #[clap(long)]
+    #[clap(long, action)]
     pub warnings_as_errors: bool,
 }
 
@@ -102,7 +102,7 @@ pub struct DocOpt {
     pub toolchain: ToolchainOpt,
 
     /// Open the docs in a browser.
-    #[clap(long)]
+    #[clap(long, action)]
     pub open: bool,
 
     #[clap(flatten)]
@@ -129,19 +129,19 @@ pub struct QemuOpt {
     pub build_mode: BuildModeOpt,
 
     /// Disable hardware accelerated virtualization support in QEMU.
-    #[clap(long)]
+    #[clap(long, action)]
     pub disable_kvm: bool,
 
     /// Disable some tests that don't work in the CI.
-    #[clap(long)]
+    #[clap(long, action)]
     pub ci: bool,
 
     /// Run QEMU without a GUI.
-    #[clap(long)]
+    #[clap(long, action)]
     pub headless: bool,
 
     /// Directory in which to look for OVMF files.
-    #[clap(long)]
+    #[clap(long, action)]
     pub ovmf_dir: Option<PathBuf>,
 }
 


### PR DESCRIPTION
Similar in scope to 57e61fb5d074294b1856c0f59852b491b2f5faa1, but attempts to cleanly update to clap 3.2 and fix the deprecations. The changes are based on the example set in https://github.com/EmbarkStudios/cargo-deny/pull/431.