### PR TITLE
Fix incorrect pointer cast in get_rng

### DIFF
--- a/src/proto/rng.rs
+++ b/src/proto/rng.rs
@@ -122,9 +122,9 @@ impl Rng {
     pub fn get_rng(&mut self, algorithm: Option<RngAlgorithmType>, buffer: &mut [u8]) -> Result {
         let buffer_length = buffer.len();
 
-        let algo = match algorithm {
+        let algo = match algorithm.as_ref() {
             None => ptr::null(),
-            Some(algo) => &algo as *const RngAlgorithmType,
+            Some(algo) => algo as *const RngAlgorithmType,
         };
 
         unsafe { (self.get_rng)(self, algo, buffer_length, buffer.as_mut_ptr()).into() }


### PR DESCRIPTION
When passing in a specific algorithm type to the get_rng function, a
pointer to the `Option`-wrapped value was incorrectly being passed
in. The pointer should be to the `RngAlgorithmType` inside the `Option`
instead.

Fixes https://github.com/rust-osdev/uefi-rs/issues/446