### PR TITLE
Remove unused From<ucs2::Error> impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   cause undefined behavior when called with a `Layout` with an alignment
   other than 1. A safe alternative is to use
   [`Vec::into_boxed_slice`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_boxed_slice).
+- Removed `From` conversions from `ucs2::Error` to `Status` and `Error`.
 
 ## uefi-macros - [Unreleased]
 

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -38,11 +38,3 @@ impl From<Status> for Error<()> {
         Self { status, data: () }
     }
 }
-
-// FIXME: This conversion will go away along with usage of the ucs2 crate
-
-impl From<ucs2::Error> for Error<()> {
-    fn from(other: ucs2::Error) -> Self {
-        Status::from(other).into()
-    }
-}

--- a/src/result/status.rs
+++ b/src/result/status.rs
@@ -211,18 +211,6 @@ impl FromResidual<core::result::Result<Infallible, Error>> for Status {
     }
 }
 
-// FIXME: This conversion will go away along with usage of the ucs2 crate
-
-impl From<ucs2::Error> for Status {
-    fn from(other: ucs2::Error) -> Self {
-        use ucs2::Error;
-        match other {
-            Error::BufferOverflow => Status::BUFFER_TOO_SMALL,
-            Error::MultiByte => Status::UNSUPPORTED,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The ucs2 crate is still used for `Output`'s `fmt::Write` impl, but that returns a `fmt::Result` so it doesn't need `uefi::Status` or `uefi::Error` conversions.