### PR TITLE
Remove eh_personality lang item

### DIFF
--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -18,7 +18,6 @@
 
 #![no_std]
 #![feature(alloc_error_handler)]
-#![feature(lang_items)]
 #![feature(panic_info_message)]
 #![feature(abi_efiapi)]
 
@@ -131,9 +130,6 @@ unsafe extern "efiapi" fn exit_boot_services(_e: Event, _ctx: Option<NonNull<c_v
 
     uefi::alloc::exit_boot_services();
 }
-
-#[lang = "eh_personality"]
-fn eh_personality() {}
 
 #[cfg(not(feature = "no_panic_handler"))]
 #[panic_handler]


### PR DESCRIPTION
This doesn't seem to be needed anymore. Tested by inserting an intentional panic into the test runner and verified it successfully panics.