### PR TITLE
Simplify uefi-services panic handler

### DIFF
--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -18,7 +18,6 @@
 
 #![no_std]
 #![feature(alloc_error_handler)]
-#![feature(panic_info_message)]
 #![feature(abi_efiapi)]
 
 #[macro_use]
@@ -134,17 +133,7 @@ unsafe extern "efiapi" fn exit_boot_services(_e: Event, _ctx: Option<NonNull<c_v
 #[cfg(not(feature = "no_panic_handler"))]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    if let Some(location) = info.location() {
-        error!(
-            "Panic in {} at ({}, {}):",
-            location.file(),
-            location.line(),
-            location.column()
-        );
-        if let Some(message) = info.message() {
-            error!("{}", message);
-        }
-    }
+    error!("{}", info);
 
     // Give the user some time to read the message
     if let Some(st) = unsafe { SYSTEM_TABLE.as_ref() } {


### PR DESCRIPTION
The `PanicInfo` type implements `Display`, so it can be printed out in a
standard format without manually accessing the location and message data.

This changes the format of the panic output a bit, and now matches the
"normal" panic output of an std Rust target.

Old output:

```
[ERROR]: uefi-services/src/lib.rs@144: Panic in uefi-test-runner/src/main.rs at (44, 5):
[ERROR]: uefi-services/src/lib.rs@151: test panic
```

New output:

```
[ERROR]: uefi-services/src/lib.rs@141: panicked at 'test panic', uefi-test-runner/src/main.rs:44:5
```

This also allows the `panic_info_message` unstable feature to be removed.