### PR TITLE
Add MemoryProtection protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   This eliminates the need to explicitly access the `interface` field,
   which is now marked as deprecated.
 - Implemented `core::fmt::Write` for the `Serial` protocol.
+- Added the `MemoryProtection` protocol.
 
 ### Fixed
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -72,4 +72,5 @@ pub mod media;
 pub mod network;
 pub mod pi;
 pub mod rng;
+pub mod security;
 pub mod shim;

--- a/src/proto/security/memory_protection.rs
+++ b/src/proto/security/memory_protection.rs
@@ -1,0 +1,106 @@
+use crate::proto::Protocol;
+use crate::table::boot::MemoryAttribute;
+use crate::{unsafe_guid, Result, Status};
+use core::ops::Range;
+
+/// Protocol for getting and setting memory protection attributes.
+///
+/// This corresponds to the `EFI_MEMORY_ATTRIBUTE_PROTOCOL` [proposal].
+///
+/// [proposal]: https://bugzilla.tianocore.org/show_bug.cgi?id=3519
+#[repr(C)]
+#[unsafe_guid("f4560cf6-40ec-4b4a-a192-bf1d57d0b189")]
+#[derive(Protocol)]
+pub struct MemoryProtection {
+    get_memory_attributes: unsafe extern "efiapi" fn(
+        this: *const Self,
+        base_address: u64,
+        length: u64,
+        attributes: *mut MemoryAttribute,
+    ) -> Status,
+
+    set_memory_attributes: unsafe extern "efiapi" fn(
+        this: *const Self,
+        base_address: u64,
+        length: u64,
+        attributes: MemoryAttribute,
+    ) -> Status,
+
+    clear_memory_attributes: unsafe extern "efiapi" fn(
+        this: *const Self,
+        base_address: u64,
+        length: u64,
+        attributes: MemoryAttribute,
+    ) -> Status,
+}
+
+impl MemoryProtection {
+    /// Get the attributes of a memory region.
+    ///
+    /// The attribute mask this returns will only contain bits in the
+    /// set of [`READ_PROTECT`], [`EXECUTE_PROTECT`], and [`READ_ONLY`].
+    ///
+    /// If the attributes are not consistent within the region,
+    /// [`Status::NO_MAPPING`] is returned.
+    ///
+    /// [`READ_PROTECT`]: MemoryAttribute::READ_PROTECT
+    /// [`EXECUTE_PROTECT`]: MemoryAttribute::EXECUTE_PROTECT
+    /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
+    pub fn get_memory_attributes(&self, byte_region: Range<u64>) -> Result<MemoryAttribute> {
+        let mut attributes = MemoryAttribute::empty();
+        let (base_address, length) = range_to_base_and_len(byte_region);
+        unsafe {
+            (self.get_memory_attributes)(self, base_address, length, &mut attributes)
+                .into_with_val(|| attributes)
+        }
+    }
+
+    /// Set the attributes of a memory region.
+    ///
+    /// The valid attributes to set are [`READ_PROTECT`],
+    /// [`EXECUTE_PROTECT`], and [`READ_ONLY`].
+    ///
+    /// [`READ_PROTECT`]: MemoryAttribute::READ_PROTECT
+    /// [`EXECUTE_PROTECT`]: MemoryAttribute::EXECUTE_PROTECT
+    /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
+    pub fn set_memory_attributes(
+        &self,
+        byte_region: Range<u64>,
+        attributes: MemoryAttribute,
+    ) -> Result {
+        let (base_address, length) = range_to_base_and_len(byte_region);
+        unsafe { (self.set_memory_attributes)(self, base_address, length, attributes).into() }
+    }
+
+    /// Clear the attributes of a memory region.
+    ///
+    /// The valid attributes to clear are [`READ_PROTECT`],
+    /// [`EXECUTE_PROTECT`], and [`READ_ONLY`].
+    ///
+    /// [`READ_PROTECT`]: MemoryAttribute::READ_PROTECT
+    /// [`EXECUTE_PROTECT`]: MemoryAttribute::EXECUTE_PROTECT
+    /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
+    pub fn clear_memory_attributes(
+        &self,
+        byte_region: Range<u64>,
+        attributes: MemoryAttribute,
+    ) -> Result {
+        let (base_address, length) = range_to_base_and_len(byte_region);
+        unsafe { (self.clear_memory_attributes)(self, base_address, length, attributes).into() }
+    }
+}
+
+/// Convert a byte `Range` to `(base_address, length)`.
+fn range_to_base_and_len(r: Range<u64>) -> (u64, u64) {
+    (r.start, r.end.checked_sub(r.start).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_range_conversion() {
+        assert_eq!(range_to_base_and_len(2..5), (2, 3));
+    }
+}

--- a/src/proto/security/mod.rs
+++ b/src/proto/security/mod.rs
@@ -1,0 +1,4 @@
+//! Protocols related to secure technologies.
+
+mod memory_protection;
+pub use memory_protection::MemoryProtection;


### PR DESCRIPTION
This corresponds to the `EFI_MEMORY_ATTRIBUTE_PROTOCOL` proposal:
https://bugzilla.tianocore.org/show_bug.cgi?id=3519

The protocol is part of a push to add better memory protection to UEFI:
https://github.com/MicrosoftDocs/windows-driver-docs/blob/abb7dfa01467a300eefe589a4a8f9353199c0ade/windows-driver-docs-pr/bringup/uefi-ca-memory-mitigation-requirements.md

This is not yet part of a released UEFI Specification, but support for
using the protocol has already been added to shim and Fedora's fork of grub
* https://github.com/rhboot/shim/pull/459/commits/825d99361b4aaa16144392dc6cea43e24c8472ae
* https://github.com/rhboot/grub2/commit/aa3c4f62715c81de280de8403d0de1ff52a7440c

By our usual naming conventions, `EFI_MEMORY_ATTRIBUTE_PROTOCOL` would
translate to a struct named `MemoryAttribute`. I went with
`MemoryProtection` instead because:

1. We don't typically include `Protocol` in the name of our `Protocol`
   structs, but there's already a `MemoryAttribute` type in the crate,
   which is the bitflag enum that describes the actual attributes. Since
   the two types are used together, the naming conflict would be
   confusing.
2. This protocol only gets and sets the RO/RP/XP memory attribute flags,
   so the generic `EFI_MEMORY_ATTRIBUTE_PROTOCOL` name is a bit
   misleading; there are many other memory attributes that it does not
   cover.

I put the new protocol under `proto::security` since the proposal would
place the new protocol in the UEFI Specification under section 37
"Secure Technologies"; `proto::secure_technologies` is a bit verbose so
went with `proto::security` instead.