### PR TITLE
Protocol safety improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Added the `MemoryProtection` protocol.
 - Added `BootServices::get_handle_for_protocol`.
 
+### Changed
+
+- Marked `BootServices::handle_protocol` as `unsafe`. (This method is
+  also deprecated -- use `open_protocol` instead.)
+
 ### Fixed
 
 - The `BootServices::create_event_ex` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   which is now marked as deprecated.
 - Implemented `core::fmt::Write` for the `Serial` protocol.
 - Added the `MemoryProtection` protocol.
+- Added `BootServices::get_handle_for_protocol`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 - Marked `BootServices::handle_protocol` as `unsafe`. (This method is
   also deprecated -- use `open_protocol` instead.)
+- Deprecated `BootServices::locate_protocol` and marked it `unsafe`. Use
+  `BootServices::get_handle_for_protocol` and
+  `BootServices::open_protocol` instead.
 
 ### Fixed
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -576,14 +576,21 @@ impl BootServices {
     /// protections must be implemented by user-level code, for example via a
     /// global `HashSet`.
     ///
+    /// # Safety
+    ///
+    /// This method is unsafe because the handle database is not
+    /// notified that the handle and protocol are in use; there is no
+    /// guarantee that they will remain valid for the duration of their
+    /// use. Use [`open_protocol`] instead.
+    ///
     /// [`open_protocol`]: BootServices::open_protocol
     #[deprecated(note = "it is recommended to use `open_protocol` instead")]
-    pub fn handle_protocol<P: ProtocolPointer + ?Sized>(
+    pub unsafe fn handle_protocol<P: ProtocolPointer + ?Sized>(
         &self,
         handle: Handle,
     ) -> Result<&UnsafeCell<P>> {
         let mut ptr = ptr::null_mut();
-        (self.handle_protocol)(handle, &P::GUID, &mut ptr).into_with_val(|| unsafe {
+        (self.handle_protocol)(handle, &P::GUID, &mut ptr).into_with_val(|| {
             let ptr = P::mut_ptr_from_ffi(ptr) as *const UnsafeCell<P>;
             &*ptr
         })

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1019,9 +1019,18 @@ impl BootServices {
     /// Returns a protocol implementation, if present on the system.
     ///
     /// The caveats of `BootServices::handle_protocol()` also apply here.
-    pub fn locate_protocol<P: ProtocolPointer + ?Sized>(&self) -> Result<&UnsafeCell<P>> {
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because the handle database is not
+    /// notified that the handle and protocol are in use; there is no
+    /// guarantee that they will remain valid for the duration of their
+    /// use. Use [`BootServices::get_handle_for_protocol`] and
+    /// [`BootServices::open_protocol`] instead.
+    #[deprecated(note = "it is recommended to use `open_protocol` instead")]
+    pub unsafe fn locate_protocol<P: ProtocolPointer + ?Sized>(&self) -> Result<&UnsafeCell<P>> {
         let mut ptr = ptr::null_mut();
-        (self.locate_protocol)(&P::GUID, ptr::null_mut(), &mut ptr).into_with_val(|| unsafe {
+        (self.locate_protocol)(&P::GUID, ptr::null_mut(), &mut ptr).into_with_val(|| {
             let ptr = P::mut_ptr_from_ffi(ptr) as *const UnsafeCell<P>;
             &*ptr
         })

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -8,7 +8,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     let bt = st.boot_services();
     serial::test(bt);
     gop::test(image, bt);
-    pointer::test(bt);
+    pointer::test(image, bt);
 }
 
 mod gop;

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -6,7 +6,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     stdout::test(st.stdout());
 
     let bt = st.boot_services();
-    serial::test(bt);
+    serial::test(image, bt);
     gop::test(image, bt);
     pointer::test(image, bt);
 }

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,10 +1,20 @@
 use uefi::proto::console::pointer::Pointer;
-use uefi::table::boot::BootServices;
+use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
+use uefi::Handle;
 
-pub fn test(bt: &BootServices) {
+pub fn test(image: Handle, bt: &BootServices) {
     info!("Running pointer protocol test");
-    if let Ok(pointer) = bt.locate_protocol::<Pointer>() {
-        let pointer = unsafe { &mut *pointer.get() };
+    if let Ok(handle) = bt.get_handle_for_protocol::<Pointer>() {
+        let mut pointer = bt
+            .open_protocol::<Pointer>(
+                OpenProtocolParams {
+                    handle,
+                    agent: image,
+                    controller: None,
+                },
+                OpenProtocolAttributes::Exclusive,
+            )
+            .expect("failed to open pointer protocol");
 
         pointer
             .reset(false)

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -29,14 +29,30 @@ pub fn test(image: Handle, bt: &BootServices) {
         .expect("Failed to open DevicePath protocol");
 
     let device_path_to_text = bt
-        .locate_protocol::<DevicePathToText>()
+        .open_protocol::<DevicePathToText>(
+            OpenProtocolParams {
+                handle: bt
+                    .get_handle_for_protocol::<DevicePathToText>()
+                    .expect("Failed to get DevicePathToText handle"),
+                agent: image,
+                controller: None,
+            },
+            OpenProtocolAttributes::Exclusive,
+        )
         .expect("Failed to open DevicePathToText protocol");
-    let device_path_to_text = unsafe { &*device_path_to_text.get() };
 
     let device_path_from_text = bt
-        .locate_protocol::<DevicePathFromText>()
+        .open_protocol::<DevicePathFromText>(
+            OpenProtocolParams {
+                handle: bt
+                    .get_handle_for_protocol::<DevicePathFromText>()
+                    .expect("Failed to get DevicePathFromText handle"),
+                agent: image,
+                controller: None,
+            },
+            OpenProtocolAttributes::Exclusive,
+        )
         .expect("Failed to open DevicePathFromText protocol");
-    let device_path_from_text = unsafe { &*device_path_from_text.get() };
 
     for path in device_path.node_iter() {
         info!(

--- a/uefi-test-runner/src/proto/media/mod.rs
+++ b/uefi-test-runner/src/proto/media/mod.rs
@@ -27,8 +27,18 @@ fn test_file_system_info(directory: &mut Directory) {
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Testing Media Access protocols");
 
-    if let Ok(sfs) = bt.locate_protocol::<SimpleFileSystem>() {
-        let sfs = unsafe { &mut *sfs.get() };
+    if let Ok(handle) = bt.get_handle_for_protocol::<SimpleFileSystem>() {
+        let mut sfs = bt
+            .open_protocol::<SimpleFileSystem>(
+                OpenProtocolParams {
+                    handle,
+                    agent: image,
+                    controller: None,
+                },
+                OpenProtocolAttributes::Exclusive,
+            )
+            .expect("failed to open SimpleFileSystem protocol");
+
         let mut directory = sfs.open_volume().unwrap();
         let mut buffer = vec![0; 128];
         loop {

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -26,7 +26,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
         target_arch = "arm",
         target_arch = "aarch64"
     ))]
-    shim::test(bt);
+    shim::test(image, bt);
 }
 
 fn find_protocol(bt: &BootServices) {

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -17,7 +17,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     loaded_image::test(image, bt);
     media::test(image, bt);
     network::test(image, bt);
-    pi::test(bt);
+    pi::test(image, bt);
     rng::test(image, bt);
 
     #[cfg(any(

--- a/uefi-test-runner/src/proto/pi/mod.rs
+++ b/uefi-test-runner/src/proto/pi/mod.rs
@@ -1,9 +1,9 @@
 use uefi::prelude::*;
 
-pub fn test(bt: &BootServices) {
+pub fn test(image: Handle, bt: &BootServices) {
     info!("Testing Platform Initialization protocols");
 
-    mp::test(bt);
+    mp::test(image, bt);
 }
 
 mod mp;

--- a/uefi-test-runner/src/proto/rng.rs
+++ b/uefi-test-runner/src/proto/rng.rs
@@ -5,11 +5,7 @@ use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Running rng protocol test");
 
-    let handle = *bt
-        .find_handles::<Rng>()
-        .expect("Failed to get Rng handles")
-        .first()
-        .expect("No Rng handles");
+    let handle = bt.get_handle_for_protocol::<Rng>().expect("No Rng handles");
 
     let mut rng = bt
         .open_protocol::<Rng>(


### PR DESCRIPTION
Overview:
* Add `BootServices::get_handle_for_protocol`. This is a convenience method for finding one arbitrary handle that supports a protocol.
* Mark `locate_protocol` as `unsafe` and deprecated, as it has the same safety problems as `handle_protocol`.
* Mark `handle_protocol` as `unsafe` (it's already deprecated).
* Update all the test code to use `open_protocol` instead of `locate_protocol`.

Using `open_protocol` is now the only undeprecated way of opening a protocol. There's still some more safety work to do here -- if the protocol isn't opened in exclusive mode, or if the `agent` parameter isn't set correctly, UB could result. But pushing all users towards `open_protocol` is a good first step.

This is a partial fix for https://github.com/rust-osdev/uefi-rs/issues/359
