### PR TITLE
EqStrUntilNul trait to compare Rust strings (str, String) against CStr16 and CString16

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -119,7 +119,7 @@ mod enums;
 
 mod strs;
 pub use self::strs::{
-    CStr16, CStr8, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16,
+    CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16,
     UnalignedCStr16Error,
 };
 

--- a/src/data_types/owned_strs.rs
+++ b/src/data_types/owned_strs.rs
@@ -1,6 +1,7 @@
 use super::chars::{Char16, NUL_16};
 use super::strs::{CStr16, FromSliceWithNulError};
 use crate::alloc_api::vec::Vec;
+use crate::data_types::strs::EqStrUntilNul;
 use core::fmt;
 use core::ops;
 
@@ -14,6 +15,9 @@ pub enum FromStrError {
 }
 
 /// An owned UCS-2 null-terminated string.
+///
+/// For convenience, a [CString16] is comparable with `&str` and `String` from the standard library
+/// through the trait [EqStrUntilNul].
 ///
 /// # Examples
 ///
@@ -107,9 +111,17 @@ impl PartialEq<&CStr16> for CString16 {
     }
 }
 
+impl<StrType: AsRef<str>> EqStrUntilNul<StrType> for CString16 {
+    fn eq_str_until_nul(&self, other: &StrType) -> bool {
+        let this = self.as_ref();
+        this.eq_str_until_nul(other)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc_api::string::String;
     use crate::alloc_api::vec;
 
     #[test]
@@ -159,5 +171,19 @@ mod tests {
             CString16::try_from("abc").unwrap(),
             crate::prelude::cstr16!("abc")
         );
+    }
+
+    /// Tests the trait implementation of trait [EqStrUntilNul].
+    #[test]
+    fn test_cstring16_eq_std_str() {
+        let input = CString16::try_from("test").unwrap();
+
+        // test various comparisons with different order (left, right)
+        assert!(input.eq_str_until_nul(&"test"));
+        assert!(input.eq_str_until_nul(&String::from("test")));
+
+        // now other direction
+        assert!(String::from("test").eq_str_until_nul(&input));
+        assert!("test".eq_str_until_nul(&input));
     }
 }

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -120,6 +120,9 @@ impl CStr8 {
 ///
 /// This type is largely inspired by `std::ffi::CStr`, see the documentation of
 /// `CStr` for more details on its semantics.
+///
+/// For convenience, a [CStr16] is comparable with `&str` and `String` from the standard library
+/// through the trait [EqStrUntilNul].
 #[derive(Eq, PartialEq)]
 #[repr(transparent)]
 pub struct CStr16([Char16]);
@@ -278,6 +281,22 @@ impl CStr16 {
     }
 }
 
+impl<StrType: AsRef<str>> EqStrUntilNul<StrType> for CStr16 {
+    fn eq_str_until_nul(&self, other: &StrType) -> bool {
+        let other = other.as_ref();
+
+        let any_not_equal = self
+            .iter()
+            .copied()
+            .map(char::from)
+            .zip(other.chars())
+            .take_while(|(l, r)| *l != '\0' && *r != '\0')
+            .any(|(l, r)| l != r);
+
+        !any_not_equal
+    }
+}
+
 /// An iterator over `CStr16`.
 #[derive(Debug)]
 pub struct CStr16Iter<'a> {
@@ -427,9 +446,39 @@ impl<'a> UnalignedCStr16<'a> {
     }
 }
 
+/// Trait that helps to compare Rust strings against CStr16 types.
+/// A generic implementation of this trait enables us that we only have to
+/// implement one direction (`left.eq_str_until_nul(&right)`) and we get
+/// the other direction (`right.eq_str_until_nul(&left)`) for free.
+pub trait EqStrUntilNul<StrType: ?Sized> {
+    /// Checks if the provided Rust string `StrType` is equal to [Self] until the first null-byte
+    /// is found. An exception is the terminating null-byte of [Self] which is ignored.
+    ///
+    /// As soon as the first null byte in either `&self` or `other` is found, this method returns.
+    /// Note that Rust strings are allowed to contain null-bytes that do not terminate the string.
+    /// Although this is rather unusual, you can compare `"foo\0bar"` with an instance of [Self].
+    /// In that case, only `foo"` is compared against [Self] (if [Self] is long enough).
+    fn eq_str_until_nul(&self, other: &StrType) -> bool;
+}
+
+// magic implementation which transforms an existing `left.eq_str_until_nul(&right)` implementation
+// into an additional working `right.eq_str_until_nul(&left)` implementation.
+impl<StrType, C16StrType> EqStrUntilNul<C16StrType> for StrType
+where
+    StrType: AsRef<str>,
+    C16StrType: EqStrUntilNul<StrType> + ?Sized,
+{
+    fn eq_str_until_nul(&self, other: &C16StrType) -> bool {
+        // reuse the existing implementation
+        other.eq_str_until_nul(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc_api::string::String;
+    use uefi_macros::cstr16;
 
     #[test]
     fn test_cstr16_num_bytes() {
@@ -514,5 +563,25 @@ mod tests {
             us.to_cstring16().unwrap(),
             CString16::try_from("test").unwrap()
         );
+    }
+
+    #[test]
+    fn test_compare() {
+        let input: &CStr16 = cstr16!("test");
+
+        // test various comparisons with different order (left, right)
+        assert!(input.eq_str_until_nul(&"test"));
+        assert!(input.eq_str_until_nul(&String::from("test")));
+
+        // now other direction
+        assert!(String::from("test").eq_str_until_nul(input));
+        assert!("test".eq_str_until_nul(input));
+
+        // some more tests
+        // this is fine: compare until the first null
+        assert!(input.eq_str_until_nul(&"te\0st"));
+        // this is fine
+        assert!(input.eq_str_until_nul(&"test\0"));
+        assert!(!input.eq_str_until_nul(&"hello"));
     }
 }


### PR DESCRIPTION
~I cleaned up and improved the code of `.eq()`-implementations for `CStr16` and `CString16`. Now it is easy to compare `&str` and `String` from the standard library with UEFI strings.~

~Let me know what you think.~

According to the discussion, I changed the PR. Now there is a common trait which allows to compare Rust strings (str, String) against CStr16 and CString16.


PS: If it's okay for you, I'd be happy to support you as a maintainer/developer in `uefi-rs` as I'm submitting stuff to uefi-rs anyway from time to time. Just let me know if you need support