### PR TITLE
Add `DiskIo` and `DiskIo2` protocols

### DIFF
--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -10,7 +10,7 @@ use crate::{unsafe_guid, Event, Result, Status};
 /// reponsible for adding this protocol to any block I/O interface that
 /// appears in the system that does not already have a disk I/O protocol.
 #[repr(C)]
-#[unsafe_guid("ce345171-ba0b-11d2-4f8e-00a0c969723b")]
+#[unsafe_guid("ce345171-ba0b-11d2-8e4f-00a0c969723b")]
 #[derive(Protocol)]
 pub struct DiskIo {
     revision: u64,
@@ -83,7 +83,7 @@ pub struct DiskIo2Token {
 /// This protocol provides an extension to the disk I/O protocol to enable
 /// non-blocking / asynchronous byte-oriented disk operation.
 #[repr(C)]
-#[unsafe_guid("151c8eae-7f2c-472c-549e-9828194f6a88")]
+#[unsafe_guid("151c8eae-7f2c-472c-9e54-9828194f6a88")]
 #[derive(Protocol)]
 pub struct DiskIo2 {
     revision: u64,

--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -126,7 +126,7 @@ impl DiskIo2 {
     /// * `len` - Buffer size.
     /// * `buffer` - Buffer to read into.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// Because of the asynchronous nature of the disk transaction, manual lifetime
     /// tracking is required.
@@ -160,7 +160,7 @@ impl DiskIo2 {
     /// * `len` - Buffer size.
     /// * `buffer` - Buffer to write from.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// Because of the asynchronous nature of the disk transaction, manual lifetime
     /// tracking is required.

--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -1,0 +1,200 @@
+//! Disk I/O protocols.
+
+use crate::proto::Protocol;
+use crate::{unsafe_guid, Event, Result, Status};
+
+/// The disk I/O protocol.
+///
+/// This protocol is used to abstract the block accesses of the block I/O
+/// protocol to a more general offset-length protocol. Firmware is
+/// reponsible for adding this protocol to any block I/O interface that
+/// appears in the system that does not already have a disk I/O protocol.
+#[repr(C)]
+#[unsafe_guid("ce345171-ba0b-11d2-4f8e-00a0c969723b")]
+#[derive(Protocol)]
+pub struct DiskIo {
+    revision: u64,
+    read_disk: extern "efiapi" fn(
+        this: &DiskIo,
+        media_id: u32,
+        offset: u64,
+        len: usize,
+        buffer: *mut u8,
+    ) -> Status,
+    write_disk: extern "efiapi" fn(
+        this: &mut DiskIo,
+        media_id: u32,
+        offset: u64,
+        len: usize,
+        buffer: *const u8,
+    ) -> Status,
+}
+
+impl DiskIo {
+    /// Reads bytes from the disk device.
+    ///
+    /// # Arguments:
+    /// * `media_id` - ID of the medium to be read.
+    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
+    /// * `buffer` - Pointer to a buffer to read into.
+    ///
+    /// # Errors:
+    /// * `uefi::status::INVALID_PARAMETER` The read request contains device addresses that
+    ///                                     are not valid for the device.
+    /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
+    ///                                     the read operation.
+    /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
+    /// * `uefi::status::MEDIA_CHANGED`     `media_id` is not for the current medium.
+    pub fn read_disk(&self, media_id: u32, offset: u64, buffer: &mut [u8]) -> Result {
+        (self.read_disk)(self, media_id, offset, buffer.len(), buffer.as_mut_ptr()).into()
+    }
+
+    /// Writes bytes to the disk device.
+    ///
+    /// # Arguments:
+    /// * `media_id` - ID of the medium to be written.
+    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
+    /// * `buffer` - Pointer to a buffer to write from.
+    ///
+    /// # Errors:
+    /// * `uefi::status::INVALID_PARAMETER` The write request contains device addresses that
+    ///                                     are not valid for the device.
+    /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
+    ///                                     the write operation.
+    /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
+    /// * `uefi::status::MEDIA_CHANGED`     `media_id` is not for the current medium.
+    /// * `uefi::status::WRITE_PROTECTED`   The device cannot be written to.
+    pub fn write_disk(&mut self, media_id: u32, offset: u64, buffer: &[u8]) -> Result {
+        (self.write_disk)(self, media_id, offset, buffer.len(), buffer.as_ptr()).into()
+    }
+}
+
+/// Asynchronous transaction token for disk I/O 2 operations.
+#[repr(C)]
+pub struct DiskIo2Token {
+    /// Event to be signalled when an asynchronous disk I/O operation completes.
+    event: Option<Event>,
+    /// Transaction status code.
+    transaction_status: Status,
+}
+
+/// The disk I/O 2 protocol.
+///
+/// This protocol provides an extension to the disk I/O protocol to enable
+/// non-blocking / asynchronous byte-oriented disk operation.
+#[repr(C)]
+#[unsafe_guid("151c8eae-7f2c-472c-549e-9828194f6a88")]
+#[derive(Protocol)]
+pub struct DiskIo2 {
+    revision: u64,
+    cancel: extern "efiapi" fn(this: &mut DiskIo2) -> Status,
+    read_disk_ex: extern "efiapi" fn(
+        this: &DiskIo2,
+        media_id: u32,
+        offset: u64,
+        token: &mut DiskIo2Token,
+        len: usize,
+        buffer: *mut u8,
+    ) -> Status,
+    write_disk_ex: extern "efiapi" fn(
+        this: &mut DiskIo2,
+        media_id: u32,
+        offset: u64,
+        token: &mut DiskIo2Token,
+        len: usize,
+        buffer: *const u8,
+    ) -> Status,
+    flush_disk_ex: extern "efiapi" fn(this: &mut DiskIo2, token: &mut DiskIo2Token) -> Status,
+}
+
+impl DiskIo2 {
+    /// Terminates outstanding asynchronous requests to the device.
+    ///
+    /// # Errors:
+    /// * `uefi::status::DEVICE_ERROR`  The device reported an error while performing
+    ///                                 the cancel operation.
+    pub fn cancel(&mut self) -> Result {
+        (self.cancel)(self).into()
+    }
+
+    /// Reads bytes from the disk device.
+    ///
+    /// # Arguments:
+    /// * `media_id` - ID of the medium to be read from.
+    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
+    /// * `token` - Transaction token for asynchronous read.
+    /// * `buffer` - Buffer to read into.
+    ///
+    /// # Errors:
+    /// * `uefi::status::INVALID_PARAMETER` The read request contains device addresses
+    ///                                     that are not valid for the device.
+    /// * `uefi::status::OUT_OF_RESOURCES`  The request could not be completed due to
+    ///                                     a lack of resources.
+    /// * `uefi::status::MEDIA_CHANGED`     `media_id` is not for the current medium.
+    /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
+    /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
+    ///                                     the read operation.
+    pub fn read_disk(
+        &self,
+        media_id: u32,
+        offset: u64,
+        token: &mut DiskIo2Token,
+        buffer: &mut [u8],
+    ) -> Result {
+        (self.read_disk_ex)(
+            self,
+            media_id,
+            offset,
+            token,
+            buffer.len(),
+            buffer.as_mut_ptr(),
+        )
+        .into()
+    }
+
+    /// Writes bytes to the disk device.
+    ///
+    /// # Arguments:
+    /// * `media_id` - ID of the medium to write to.
+    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
+    /// * `token` - Transaction token for asynchronous write.
+    /// * `buffer` - Buffer to write from.
+    ///
+    /// # Errors:
+    /// * `uefi::status::INVALID_PARAMETER` The write request contains device addresses
+    ///                                     that are not valid for the device.
+    /// * `uefi::status::OUT_OF_RESOURCES`  The request could not be completed due to
+    ///                                     a lack of resources.
+    /// * `uefi::status::MEDIA_CHANGED`     `media_id` is not for the current medium.
+    /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
+    /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
+    ///                                     the write operation.
+    /// * `uefi::status::WRITE_PROTECTED`   The device cannot be written to.
+    pub fn write_disk(
+        &mut self,
+        media_id: u32,
+        offset: u64,
+        token: &mut DiskIo2Token,
+        buffer: &[u8],
+    ) -> Result {
+        (self.write_disk_ex)(self, media_id, offset, token, buffer.len(), buffer.as_ptr()).into()
+    }
+
+    /// Flushes all modified data to the physical device.
+    ///
+    /// # Arguments:
+    /// * `token` - Transaction token for the asynchronous flush.
+    ///
+    /// # Errors:
+    /// * `uefi::status::OUT_OF_RESOURCES`  The request could not be completed due to
+    ///                                     a lack of resources.
+    /// * `uefi::status::MEDIA_CHANGED`     The medium in the device has changed since
+    ///                                     the last access.
+    /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
+    /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
+    ///                                     the flush operation.
+    /// * `uefi::status::WRITE_PROTECTED`   The device cannot be written to.
+    pub fn flush_disk(&mut self, token: &mut DiskIo2Token) -> Result {
+        (self.flush_disk_ex)(self, token).into()
+    }
+}

--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -123,6 +123,7 @@ impl DiskIo2 {
     /// * `media_id` - ID of the medium to be read from.
     /// * `offset` - Starting byte offset on the logical block I/O device to read from.
     /// * `token` - Transaction token for asynchronous read.
+    /// * `len` - Buffer size.
     /// * `buffer` - Buffer to read into.
     ///
     /// # Errors:
@@ -134,22 +135,15 @@ impl DiskIo2 {
     /// * `uefi::status::NO_MEDIA`          There is no medium in the device.
     /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
     ///                                     the read operation.
-    pub fn read_disk(
+    pub unsafe fn read_disk_raw(
         &self,
         media_id: u32,
         offset: u64,
-        token: &mut DiskIo2Token,
-        buffer: &mut [u8],
+        token: *mut DiskIo2Token,
+        len: usize,
+        buffer: *mut u8,
     ) -> Result {
-        (self.read_disk_ex)(
-            self,
-            media_id,
-            offset,
-            token,
-            buffer.len(),
-            buffer.as_mut_ptr(),
-        )
-        .into()
+        (self.read_disk_ex)(self, media_id, offset, &mut *token, len, buffer).into()
     }
 
     /// Writes bytes to the disk device.
@@ -158,6 +152,7 @@ impl DiskIo2 {
     /// * `media_id` - ID of the medium to write to.
     /// * `offset` - Starting byte offset on the logical block I/O device to write to.
     /// * `token` - Transaction token for asynchronous write.
+    /// * `len` - Buffer size.
     /// * `buffer` - Buffer to write from.
     ///
     /// # Errors:
@@ -170,14 +165,15 @@ impl DiskIo2 {
     /// * `uefi::status::DEVICE_ERROR`      The device reported an error while performing
     ///                                     the write operation.
     /// * `uefi::status::WRITE_PROTECTED`   The device cannot be written to.
-    pub fn write_disk(
+    pub unsafe fn write_disk_raw(
         &mut self,
         media_id: u32,
         offset: u64,
-        token: &mut DiskIo2Token,
-        buffer: &[u8],
+        token: *mut DiskIo2Token,
+        len: usize,
+        buffer: *const u8,
     ) -> Result {
-        (self.write_disk_ex)(self, media_id, offset, token, buffer.len(), buffer.as_ptr()).into()
+        (self.write_disk_ex)(self, media_id, offset, &mut *token, len, buffer).into()
     }
 
     /// Flushes all modified data to the physical device.

--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -73,9 +73,9 @@ impl DiskIo {
 #[repr(C)]
 pub struct DiskIo2Token {
     /// Event to be signalled when an asynchronous disk I/O operation completes.
-    event: Option<Event>,
+    pub event: Option<Event>,
     /// Transaction status code.
-    transaction_status: Status,
+    pub transaction_status: Status,
 }
 
 /// The disk I/O 2 protocol.

--- a/src/proto/media/disk.rs
+++ b/src/proto/media/disk.rs
@@ -126,6 +126,11 @@ impl DiskIo2 {
     /// * `len` - Buffer size.
     /// * `buffer` - Buffer to read into.
     ///
+    /// # Safety:
+    ///
+    /// Because of the asynchronous nature of the disk transaction, manual lifetime
+    /// tracking is required.
+    ///
     /// # Errors:
     /// * `uefi::status::INVALID_PARAMETER` The read request contains device addresses
     ///                                     that are not valid for the device.
@@ -154,6 +159,11 @@ impl DiskIo2 {
     /// * `token` - Transaction token for asynchronous write.
     /// * `len` - Buffer size.
     /// * `buffer` - Buffer to write from.
+    ///
+    /// # Safety:
+    ///
+    /// Because of the asynchronous nature of the disk transaction, manual lifetime
+    /// tracking is required.
     ///
     /// # Errors:
     /// * `uefi::status::INVALID_PARAMETER` The write request contains device addresses

--- a/src/proto/media/mod.rs
+++ b/src/proto/media/mod.rs
@@ -7,5 +7,6 @@
 pub mod file;
 
 pub mod block;
+pub mod disk;
 pub mod fs;
 pub mod partition;


### PR DESCRIPTION
Adds the `EFI_DISK_IO_PROTOCOL` and `EFI_DISK_IO2_PROTOCOL` protocols from the UEFI specification that build on top of the block I/O protocol to provide byte-oriented disk I/O.