### PR TITLE
Introducing a high-level FS abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## uefi - [Unreleased]
 
+### Added
+
+- There is a new `fs` module that provides a high-level API for file-system
+  access. The API is close to the `std::fs` module.
+
 ### Changed
 
 - The `global_allocator` module has been renamed to `allocator`, and is now
@@ -9,6 +14,8 @@
   `global_allocator` feature now only controls whether `allocator::Allocator` is
   set as Rust's global allocator.
 - `Error::new` and `Error::from` now panic if the status is `SUCCESS`.
+- `Image::get_image_file_system` now returns a `fs::FileSystem` instead of the
+  protocol.
 
 ## uefi-macros - [Unreleased]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +410,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -537,6 +571,7 @@ name = "uefi"
 version = "0.20.0"
 dependencies = [
  "bitflags",
+ "derive_more",
  "log",
  "ptr_meta",
  "ucs2",

--- a/uefi-test-runner/src/fs/mod.rs
+++ b/uefi-test-runner/src/fs/mod.rs
@@ -1,0 +1,57 @@
+//! Tests functionality from the `uefi::fs` module. See function [`test`].
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use uefi::fs::{FileSystem, FileSystemError};
+use uefi::proto::media::fs::SimpleFileSystem;
+use uefi::table::boot::ScopedProtocol;
+
+/// Tests functionality from the `uefi::fs` module. This test relies on a
+/// working File System Protocol, which is tested at a dedicated place.
+pub fn test(sfs: ScopedProtocol<SimpleFileSystem>) -> Result<(), FileSystemError> {
+    let mut fs = FileSystem::new(sfs);
+
+    fs.create_dir("test_file_system_abs")?;
+
+    // slash is transparently transformed to backslash
+    fs.write("test_file_system_abs/foo", "hello")?;
+    // absolute or relative paths are supported; ./ is ignored
+    fs.copy("\\test_file_system_abs/foo", "\\test_file_system_abs/./bar")?;
+    let read = fs.read("\\test_file_system_abs\\bar")?;
+    let read = String::from_utf8(read).expect("Should be valid utf8");
+    assert_eq!(read, "hello");
+
+    assert_eq!(
+        fs.try_exists("test_file_system_abs\\barfoo"),
+        Err(FileSystemError::OpenError(
+            "\\test_file_system_abs\\barfoo".to_string()
+        ))
+    );
+    fs.rename("test_file_system_abs\\bar", "test_file_system_abs\\barfoo")?;
+    assert!(fs.try_exists("test_file_system_abs\\barfoo").is_ok());
+
+    let entries = fs
+        .read_dir("test_file_system_abs")?
+        .map(|e| {
+            e.expect("Should return boxed file info")
+                .file_name()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(&[".", "..", "foo", "barfoo"], entries.as_slice());
+
+    fs.create_dir("/deeply_nested_test")?;
+    fs.create_dir("/deeply_nested_test/1")?;
+    fs.create_dir("/deeply_nested_test/1/2")?;
+    fs.create_dir("/deeply_nested_test/1/2/3")?;
+    fs.create_dir("/deeply_nested_test/1/2/3/4")?;
+    fs.create_dir_all("/deeply_nested_test/1/2/3/4/5/6/7")?;
+    fs.try_exists("/deeply_nested_test/1/2/3/4/5/6/7")?;
+    // TODO
+    // fs.remove_dir_all("/deeply_nested_test/1/2/3/4/5/6/7")?;
+    fs.remove_dir("/deeply_nested_test/1/2/3/4/5/6/7")?;
+    let exists = matches!(fs.try_exists("/deeply_nested_test/1/2/3/4/5/6/7"), Ok(_));
+    assert!(!exists);
+
+    Ok(())
+}

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -13,6 +13,7 @@ use uefi::Result;
 use uefi_services::{print, println};
 
 mod boot;
+mod fs;
 mod proto;
 mod runtime;
 

--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -433,8 +433,12 @@ pub fn test(bt: &BootServices) {
         test_partition_info(bt, handle);
     }
 
-    // Close the `SimpleFileSystem` protocol so that the raw disk tests work.
-    drop(sfs);
+    // Invoke the fs test after the basic low-level file system protocol
+    // tests succeeded.
+
+    // This will also drop the `SimpleFileSystem` protocol so that the raw disk
+    // tests work.
+    crate::fs::test(sfs).unwrap();
 
     test_raw_disk_io(handle, bt);
     test_raw_disk_io2(handle, bt);

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -25,6 +25,7 @@ unstable = []
 
 [dependencies]
 bitflags = "1.3.1"
+derive_more = { version = "0.99.17", features = ["display"] }
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -1,0 +1,31 @@
+//! Module for directory iteration. See [`UefiDirectoryIter`].
+
+use super::*;
+use alloc::boxed::Box;
+use uefi::Result;
+
+/// Iterates over the entries of an UEFI directory. It returns boxed values of
+/// type [`UefiFileInfo`].
+#[derive(Debug)]
+pub struct UefiDirectoryIter(UefiDirectoryHandle);
+
+impl UefiDirectoryIter {
+    /// Constructor.
+    pub fn new(handle: UefiDirectoryHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl Iterator for UefiDirectoryIter {
+    type Item = Result<Box<UefiFileInfo>, ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let e = self.0.read_entry_boxed();
+        match e {
+            // no more entries
+            Ok(None) => None,
+            Ok(Some(e)) => Some(Ok(e)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}

--- a/uefi/src/fs/file_system.rs
+++ b/uefi/src/fs/file_system.rs
@@ -1,0 +1,303 @@
+//! Module for [`FileSystem`].
+
+use super::*;
+use alloc::boxed::Box;
+use alloc::string::{FromUtf8Error, String, ToString};
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::fmt;
+use core::fmt::{Debug, Formatter};
+use core::ops::Deref;
+use derive_more::Display;
+use log::info;
+use uefi::proto::media::file::{FileAttribute, FileInfo, FileType};
+use uefi::table::boot::ScopedProtocol;
+
+/// All errors that can happen when working with the [`FileSystem`].
+#[derive(Debug, Clone, Display, PartialEq, Eq)]
+pub enum FileSystemError {
+    /// Can't open the root directory of the underlying volume.
+    CantOpenVolume,
+    /// The path is invalid because of the underlying [`PathError`].
+    IllegalPath(PathError),
+    /// The file or directory was not found in the underlying volume.
+    FileNotFound(String),
+    /// The path is existent but does not correspond to a directory when a
+    /// directory was expected.
+    NotADirectory(String),
+    /// The path is existent but does not correspond to a file when a file was
+    /// expected.
+    NotAFile(String),
+    /// Can't delete the file.
+    CantDeleteFile(String),
+    /// Can't delete the directory.
+    CantDeleteDirectory(String),
+    /// Error writing bytes.
+    WriteFailure,
+    /// Error flushing file.
+    FlushFailure,
+    /// Error reading file.
+    ReadFailure,
+    /// Can't parse file content as UTF-8.
+    Utf8Error(FromUtf8Error),
+    /// Could not open the given path.
+    OpenError(String),
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for FileSystemError {}
+
+impl From<PathError> for FileSystemError {
+    fn from(err: PathError) -> Self {
+        Self::IllegalPath(err)
+    }
+}
+
+/// Return type for public [`FileSystem`] operations.
+pub type FileSystemResult<T> = Result<T, FileSystemError>;
+
+/// High-level file-system abstraction for UEFI volumes with an API that is
+/// close to `std::fs`. It acts as convenient accessor around the
+/// [`SimpleFileSystemProtocol`].
+pub struct FileSystem<'a>(ScopedProtocol<'a, SimpleFileSystemProtocol>);
+
+impl<'a> FileSystem<'a> {
+    /// Constructor.
+    #[must_use]
+    pub fn new(proto: ScopedProtocol<'a, SimpleFileSystemProtocol>) -> Self {
+        Self(proto)
+    }
+
+    /// Tests if the underlying file exists. If this returns `Ok`, the file
+    /// exists.
+    pub fn try_exists(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
+        self.metadata(path).map(|_| ())
+    }
+
+    /// Copies the contents of one file to another. Creates the destination file
+    /// if it doesn't exist and overwrites any content, if it exists.
+    pub fn copy(
+        &mut self,
+        src_path: impl AsRef<Path>,
+        dest_path: impl AsRef<Path>,
+    ) -> FileSystemResult<()> {
+        let read = self.read(src_path)?;
+        self.write(dest_path, read)
+    }
+
+    /// Creates a new, empty directory at the provided path
+    pub fn create_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
+        let path = path.as_ref();
+        self.open(path, UefiFileMode::CreateReadWrite, true)
+            .map(|_| ())
+            .map_err(|err| {
+                log::debug!("failed to fetch file info: {err:#?}");
+                FileSystemError::OpenError(path.to_string())
+            })
+    }
+
+    /// Recursively create a directory and all of its parent components if they
+    /// are missing.
+    pub fn create_dir_all(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
+        let path = path.as_ref();
+
+        let normalized_path = NormalizedPath::new("\\", path)?;
+        let normalized_path_string = normalized_path.to_string();
+        let normalized_path_pathref = Path::new(&normalized_path_string);
+
+        let iter = || normalized_path_pathref.components(SEPARATOR);
+        iter()
+            .scan(String::new(), |path_acc, component| {
+                if component != Component::RootDir {
+                    *path_acc += SEPARATOR_STR;
+                    *path_acc += format!("{component}").as_str();
+                }
+                info!("path_acc: {path_acc}, component: {component}");
+                Some((component, path_acc.clone()))
+            })
+            .try_for_each(|(_component, full_path)| self.create_dir(full_path.as_str()))
+    }
+
+    /// Given a path, query the file system to get information about a file,
+    /// directory, etc. Returns [`UefiFileInfo`].
+    pub fn metadata(&mut self, path: impl AsRef<Path>) -> FileSystemResult<Box<UefiFileInfo>> {
+        let path = path.as_ref();
+        let file = self.open(path, UefiFileMode::Read, false)?;
+        log::debug!("{:#?}", &file.into_type().unwrap());
+        let mut file = self.open(path, UefiFileMode::Read, false)?;
+        file.get_boxed_info().map_err(|err| {
+            log::debug!("failed to fetch file info: {err:#?}");
+            FileSystemError::OpenError(path.to_string())
+        })
+    }
+
+    /// Read the entire contents of a file into a bytes vector.
+    pub fn read(&mut self, path: impl AsRef<Path>) -> FileSystemResult<Vec<u8>> {
+        let path = path.as_ref();
+
+        let mut file = self
+            .open(path, UefiFileMode::Read, false)?
+            .into_regular_file()
+            .ok_or(FileSystemError::NotAFile(path.as_str().to_string()))?;
+        let info = file.get_boxed_info::<FileInfo>().map_err(|e| {
+            log::error!("get info failed: {e:?}");
+            FileSystemError::OpenError(path.as_str().to_string())
+        })?;
+
+        let mut vec = vec![0; info.file_size() as usize];
+        let read_bytes = file.read(vec.as_mut_slice()).map_err(|e| {
+            log::error!("reading failed: {e:?}");
+            FileSystemError::ReadFailure
+        })?;
+
+        // we read the whole file at once!
+        if read_bytes != info.file_size() as usize {
+            log::error!("Did only read {}/{} bytes", info.file_size(), read_bytes);
+        }
+
+        Ok(vec)
+    }
+
+    /// Returns an iterator over the entries within a directory.
+    pub fn read_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<UefiDirectoryIter> {
+        let path = path.as_ref();
+        let dir = self
+            .open(path, UefiFileMode::Read, false)?
+            .into_directory()
+            .ok_or(FileSystemError::NotADirectory(path.as_str().to_string()))?;
+        Ok(UefiDirectoryIter::new(dir))
+    }
+
+    /// Read the entire contents of a file into a string.
+    pub fn read_to_string(&mut self, path: impl AsRef<Path>) -> FileSystemResult<String> {
+        String::from_utf8(self.read(path)?).map_err(FileSystemError::Utf8Error)
+    }
+
+    /// Removes an empty directory.
+    pub fn remove_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
+        let path = path.as_ref();
+
+        let file = self
+            .open(path, UefiFileMode::ReadWrite, false)?
+            .into_type()
+            .unwrap();
+
+        match file {
+            FileType::Dir(dir) => dir.delete().map_err(|e| {
+                log::error!("error removing dir: {e:?}");
+                FileSystemError::CantDeleteDirectory(path.as_str().to_string())
+            }),
+            FileType::Regular(_) => Err(FileSystemError::NotADirectory(path.as_str().to_string())),
+        }
+    }
+
+    /*/// Removes a directory at this path, after removing all its contents. Use
+    /// carefully!
+    pub fn remove_dir_all(&mut self, _path: impl AsRef<Path>) -> FileSystemResult<()> {
+        todo!()
+    }*/
+
+    /// Removes a file from the filesystem.
+    pub fn remove_file(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
+        let path = path.as_ref();
+
+        let file = self
+            .open(path, UefiFileMode::ReadWrite, false)?
+            .into_type()
+            .unwrap();
+
+        match file {
+            FileType::Regular(file) => file.delete().map_err(|e| {
+                log::error!("error removing file: {e:?}");
+                FileSystemError::CantDeleteFile(path.as_str().to_string())
+            }),
+            FileType::Dir(_) => Err(FileSystemError::NotAFile(path.as_str().to_string())),
+        }
+    }
+
+    /// Rename a file or directory to a new name, replacing the original file if
+    /// it already exists.
+    pub fn rename(
+        &mut self,
+        src_path: impl AsRef<Path>,
+        dest_path: impl AsRef<Path>,
+    ) -> FileSystemResult<()> {
+        self.copy(&src_path, dest_path)?;
+        self.remove_file(src_path)
+    }
+
+    /// Write a slice as the entire contents of a file. This function will
+    /// create a file if it does not exist, and will entirely replace its
+    /// contents if it does.
+    pub fn write(
+        &mut self,
+        path: impl AsRef<Path>,
+        content: impl AsRef<[u8]>,
+    ) -> FileSystemResult<()> {
+        let path = path.as_ref();
+
+        // since there is no .truncate() in UEFI, we delete the file first it it
+        // exists.
+        if self.try_exists(path).is_ok() {
+            self.remove_file(path)?;
+        }
+
+        let mut handle = self
+            .open(path, UefiFileMode::CreateReadWrite, false)?
+            .into_regular_file()
+            .unwrap();
+
+        handle.write(content.as_ref()).map_err(|e| {
+            log::error!("only wrote {e:?} bytes");
+            FileSystemError::WriteFailure
+        })?;
+        handle.flush().map_err(|e| {
+            log::error!("flush failure: {e:?}");
+            FileSystemError::FlushFailure
+        })?;
+        Ok(())
+    }
+
+    /// Opens a fresh handle to the root directory of the volume.
+    fn open_root(&mut self) -> FileSystemResult<UefiDirectoryHandle> {
+        self.0.open_volume().map_err(|e| {
+            log::error!("Can't open root volume: {e:?}");
+            FileSystemError::CantOpenVolume
+        })
+    }
+
+    /// Wrapper around [`Self::open_root`] that opens the provided path as
+    /// absolute path.
+    ///
+    /// May create a file if [`UefiFileMode::CreateReadWrite`] is set. May
+    /// create a directory if [`UefiFileMode::CreateReadWrite`] and `is_dir`
+    /// is set.
+    fn open(
+        &mut self,
+        path: &Path,
+        mode: UefiFileMode,
+        is_dir: bool,
+    ) -> FileSystemResult<UefiFileHandle> {
+        let path = NormalizedPath::new("\\", path)?;
+        log::debug!("normalized path: {path}");
+
+        let attr = if mode == UefiFileMode::CreateReadWrite && is_dir {
+            FileAttribute::DIRECTORY
+        } else {
+            FileAttribute::empty()
+        };
+
+        self.open_root()?.open(&path, mode, attr).map_err(|x| {
+            log::trace!("Can't open file {path}: {x:?}");
+            FileSystemError::OpenError(path.to_string())
+        })
+    }
+}
+
+impl<'a> Debug for FileSystem<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("FileSystem(<>))")
+            .field(&(self.0.deref() as *const _))
+            .finish()
+    }
+}

--- a/uefi/src/fs/mod.rs
+++ b/uefi/src/fs/mod.rs
@@ -1,0 +1,48 @@
+//! A high-level file system API for UEFI applications close to the `fs` module
+//! from Rust's standard library.
+//!
+//! ## Difference to typical File System Abstractions
+//! Users perform actions on dedicated volumes: For example, the boot volume,
+//! such as a CD-rom, USB-stick, or any other storage device.
+//!
+//! ### UNIX
+//! Unlike in the API of typical UNIX file system abstractions, there is no
+//! virtual file system.
+//!
+//! ### Windows
+//! Unlike in Windows, there is no way to access volumes by a dedicated name.
+//!
+//! ## Paths
+//! All paths are absolute and follow the FAT-like file system conventions for
+//! paths. Thus, there is no current working directory and path components
+//! like `.` and `.."`are not supported. In other words, the current working
+//! directory is always `/`, i.e., the root, of the opened volume. This may
+//! change in the future but is currently sufficient.
+//!
+//! Symlinks or hard-links are not supported but only directories and regular
+//! files with plain linear paths to them.
+//!
+//! ## API Hints
+//! There are no `File` and `Path` abstractions similar to those from `std` that
+//! are publicly exported. Instead, paths to files are provided as `&str`, and
+//! will be validated and transformed internally to the correct type.
+//! Furthermore, there are no `File` objects that are exposed to users. Instead,
+//! it is intended to work with the file system as in `std::fs`.
+//!
+//! ### Synchronization
+//! There is no automatic synchronization of the file system for concurrent
+//! accesses. This is in the responsibility of the user.
+
+mod dir_entry_iter;
+mod file_system;
+mod normalized_path;
+mod path;
+mod uefi_types;
+
+pub use file_system::{FileSystem, FileSystemError, FileSystemResult};
+pub use normalized_path::{PathError, SEPARATOR, SEPARATOR_STR};
+
+use dir_entry_iter::*;
+use normalized_path::*;
+use path::*;
+use uefi_types::*;

--- a/uefi/src/fs/normalized_path.rs
+++ b/uefi/src/fs/normalized_path.rs
@@ -1,0 +1,239 @@
+//! Module for path normalization. See [`NormalizedPath`].
+
+use super::*;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::ops::Deref;
+use derive_more::Display;
+use uefi::data_types::FromStrError;
+use uefi::CString16;
+
+/// The default separator for paths.
+pub const SEPARATOR: char = '\\';
+
+/// Stringifyed version of [`SEPARATOR`].
+pub const SEPARATOR_STR: &str = "\\";
+
+/// Errors that may happen during path normalization..
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
+pub enum PathError {
+    /// The specified present working directory is not absolute.
+    PwdNotAbsolute,
+    /// The path is empty.
+    Empty,
+    /// There are illegal characters in the path.
+    IllegalCharacters(CharactersError),
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for PathError {}
+
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
+pub enum CharactersError {
+    ProhibitedSymbols,
+    NonUCS2Compatible(FromStrError),
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for CharactersError {}
+
+/// **Internal API (so far).**
+///
+/// Unlike a [`Path`], which is close to the implementation of the Rust
+/// standard library, this abstraction is an absolute path that is valid in
+/// FAT-like file systems (which are supported by UEFI and can be accessed via
+/// the file system protocol).
+///
+/// Hence, it is called normalized path. Another term might be canonicalized
+/// path.
+///
+/// For compatibility with the UEFI file-system protocol, this is a
+/// [`CString16`]. The separator is `\`. For convenience, all occurrences of `/`
+/// are transparently replaced by `\`.
+///
+/// A normalized path is always absolute, i.e., starts at the root directory.
+#[derive(Debug, Eq, PartialEq, Display)]
+pub struct NormalizedPath(CString16);
+
+impl NormalizedPath {
+    /// Deny list of characters for path components. UEFI supports FAT-like file
+    /// systems. According to <https://en.wikipedia.org/wiki/Comparison_of_file_systems>,
+    /// paths should not contain the following symbols.
+    pub const CHARACTER_DENY_LIST: [char; 10] =
+        ['\0', '"', '*', '/', ':', '<', '>', '?', '\\', '|'];
+
+    /// Constructor. Combines the path with the present working directory (pwd)
+    /// if the `path` is relative. The resulting path is technically valid so
+    /// that it can be passed to the underlying file-system protocol. The
+    /// resulting path doesn't contain `.` or `..`.
+    ///
+    /// `pwd` is expected to be valid.
+    pub fn new(pwd: impl AsRef<Path>, path: impl AsRef<Path>) -> Result<Self, PathError> {
+        let pwd = pwd.as_ref();
+        let path = path.as_ref();
+
+        let path = Self::normalize_separator(path);
+        let path = Path::new(path.as_str());
+
+        Self::check_pwd_absolute(pwd)?;
+        Self::check_prohibited_chars(path)?;
+
+        let path = Self::combine_path_with_pwd(pwd, path);
+
+        Self::build_normalized_path(path.as_str().as_ref())
+    }
+
+    /// Checks if the pwd is an absolute path.
+    fn check_pwd_absolute(pwd: &Path) -> Result<(), PathError> {
+        if !pwd.as_str().starts_with(SEPARATOR) {
+            return Err(PathError::PwdNotAbsolute);
+        }
+        Ok(())
+    }
+
+    /// Replaces all occurrences of `/` with [`SEPARATOR`].
+    fn normalize_separator(path: &Path) -> String {
+        path.as_str().replace('/', SEPARATOR_STR)
+    }
+
+    /// Checks that each component of type [`Component::Normal`] doesn't contain
+    /// any of the prohibited characters specified in
+    /// [`Self::CHARACTER_DENY_LIST`].
+    fn check_prohibited_chars(path: &Path) -> Result<(), PathError> {
+        let prohibited_character_found = path
+            .components(SEPARATOR)
+            .filter_map(|c| match c {
+                Component::Normal(n) => Some(n),
+                _ => None,
+            })
+            .flat_map(|c| c.chars())
+            .any(|c| Self::CHARACTER_DENY_LIST.contains(&c));
+
+        (!prohibited_character_found)
+            .then_some(())
+            .ok_or(PathError::IllegalCharacters(
+                CharactersError::ProhibitedSymbols,
+            ))
+    }
+
+    /// Merges `pwd` and `path`, if `path` is not absolute.
+    fn combine_path_with_pwd(pwd: &Path, path: &Path) -> String {
+        let path_is_absolute = path.as_str().starts_with(SEPARATOR);
+        if path_is_absolute {
+            path.as_str().to_string()
+        } else {
+            // This concatenation is fine as pwd is an absolute path.
+            if pwd.as_str() == SEPARATOR_STR {
+                format!("{separator}{path}", separator = SEPARATOR)
+            } else {
+                format!("{pwd}{separator}{path}", separator = SEPARATOR)
+            }
+        }
+    }
+
+    /// Consumes an absolute path and builds a `Self` from it. At this point,
+    /// the path is expected to have passed all sanity checks. The last step
+    /// is only relevant to resolve `.` and `..`.
+    fn build_normalized_path(path: &Path) -> Result<Self, PathError> {
+        let component_count = path.components(SEPARATOR).count();
+        let mut normalized_components = Vec::with_capacity(component_count);
+
+        for component in path.components(SEPARATOR) {
+            match component {
+                Component::RootDir => {
+                    normalized_components.push(SEPARATOR_STR);
+                }
+                Component::CurDir => continue,
+                Component::ParentDir => {
+                    normalized_components.remove(normalized_components.len() - 1);
+                }
+                Component::Normal(n) => {
+                    let prev_has_sep = normalized_components
+                        .last()
+                        .map(|x| x.eq(&SEPARATOR_STR))
+                        .unwrap_or(false);
+                    if !prev_has_sep {
+                        normalized_components.push(SEPARATOR_STR);
+                    }
+                    normalized_components.push(n);
+                }
+            }
+        }
+
+        let normalized_string: String = normalized_components.concat();
+        CString16::try_from(normalized_string.as_str())
+            .map(Self)
+            .map_err(|x| PathError::IllegalCharacters(CharactersError::NonUCS2Compatible(x)))
+    }
+}
+
+impl Deref for NormalizedPath {
+    type Target = CString16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pwd_must_be_absolute() {
+        let path = NormalizedPath::new("", "");
+        assert_eq!(Err(PathError::PwdNotAbsolute), path);
+
+        let path = NormalizedPath::new(".", "");
+        assert_eq!(Err(PathError::PwdNotAbsolute), path);
+
+        let path = NormalizedPath::new("/", "");
+        assert_eq!(Err(PathError::PwdNotAbsolute), path);
+    }
+
+    #[test]
+    fn normalized_path() {
+        let path = NormalizedPath::new("\\foo", "/bar/barfoo").map(|x| x.0);
+        assert_eq!(path, Ok(CString16::try_from("\\bar\\barfoo").unwrap()));
+
+        let path = NormalizedPath::new("\\foo", "bar/barfoo").map(|x| x.0);
+        assert_eq!(path, Ok(CString16::try_from("\\foo\\bar\\barfoo").unwrap()));
+
+        let path = NormalizedPath::new("\\foo", "./bar/barfoo").map(|x| x.0);
+        assert_eq!(path, Ok(CString16::try_from("\\foo\\bar\\barfoo").unwrap()));
+
+        let path = NormalizedPath::new("\\foo", "./bar/.././././barfoo").map(|x| x.0);
+        assert_eq!(path, Ok(CString16::try_from("\\foo\\barfoo").unwrap()));
+
+        let path = NormalizedPath::new("\\", "foo").map(|x| x.0);
+        assert_eq!(path, Ok(CString16::try_from("\\foo").unwrap()));
+    }
+
+    #[test]
+    fn check_components_for_allowed_chars() {
+        fn check_fail(path: impl AsRef<Path>) {
+            assert_eq!(
+                NormalizedPath::check_prohibited_chars(path.as_ref()),
+                Err(PathError::IllegalCharacters(
+                    CharactersError::ProhibitedSymbols
+                ))
+            );
+        }
+
+        assert_eq!(
+            NormalizedPath::check_prohibited_chars("\\foo".as_ref()),
+            Ok(())
+        );
+
+        check_fail("\\foo\0");
+        check_fail("\\foo:");
+        check_fail("\\foo*");
+        check_fail("\\foo/");
+        check_fail("\\foo<");
+        check_fail("\\foo>");
+        check_fail("\\foo?");
+        check_fail("\\foo|");
+        check_fail("\\foo\"");
+    }
+}

--- a/uefi/src/fs/path.rs
+++ b/uefi/src/fs/path.rs
@@ -1,0 +1,154 @@
+//! Module for handling file-system paths in [`super::FileSystem`].
+//! See [`Path`].
+
+use alloc::string::String;
+use core::fmt::{Display, Formatter};
+
+/// Path abstraction similar to `std::path::Path` but adapted to the platform-
+/// agnostic `no_std` use case. It is up to the file-system implementation to
+/// verify if a path is valid.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Path(str);
+
+impl Path {
+    /// Directly wraps a string slice as a `Path` slice.
+    pub fn new<S: AsRef<str> + ?Sized>(str: &S) -> &Self {
+        unsafe { &*(str.as_ref() as *const str as *const Path) }
+    }
+
+    /// Returns the underlying `str`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+
+    /// Returns an Iterator of type [`Components`].
+    pub fn components(&self, separator: char) -> Components<'_> {
+        let split = self.0.split(separator);
+        Components::new(self, split)
+    }
+}
+
+impl AsRef<Path> for str {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for Path {
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}
+
+impl AsRef<str> for Path {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for String {
+    fn as_ref(&self) -> &Path {
+        self.as_str().as_ref()
+    }
+}
+
+impl Display for Path {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+/// [`Iterator`] over the [`Component`]s of a [`Path`].
+#[derive(Debug)]
+pub struct Components<'a> {
+    path: &'a Path,
+    split: core::str::Split<'a, char>,
+    i: usize,
+}
+
+impl<'a> Components<'a> {
+    fn new(path: &'a Path, split: core::str::Split<'a, char>) -> Self {
+        Self { path, split, i: 0 }
+    }
+}
+
+impl<'a> Iterator for Components<'a> {
+    type Item = Component<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.path.0.is_empty() {
+            return None;
+        };
+
+        self.split.next().map(|str| match str {
+            "." => Component::CurDir,
+            ".." => Component::ParentDir,
+            "" if self.i == 0 => Component::RootDir,
+            normal => Component::Normal(normal),
+        })
+    }
+}
+
+/// Components of a [`Path`].
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub enum Component<'a> {
+    /// Current dir: `.`
+    CurDir,
+    /// Parent dir: `..`
+    ParentDir,
+    /// Root directory: `/`
+    RootDir,
+    /// Normal directory or filename.
+    Normal(&'a str),
+}
+
+impl<'a> Display for Component<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Component::CurDir => f.write_str(".\\"),
+            Component::ParentDir => f.write_str("..\\"),
+            Component::RootDir => f.write_str("\\"),
+            Component::Normal(normal) => f.write_str(normal),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn path_creation() {
+        let path_str = "/foo/bar/foobar";
+        let _path = Path::new(path_str);
+        let path: &Path = path_str.as_ref();
+        let _path: &Path = path.as_ref();
+    }
+
+    #[test]
+    fn path_components() {
+        let path_str = "/foo/./../bar/foobar";
+        let path = Path::new(path_str);
+        assert_eq!(path_str, path.as_str());
+        let components = path.components('/').collect::<Vec<_>>();
+        let expected = [
+            Component::RootDir,
+            Component::Normal("foo"),
+            Component::CurDir,
+            Component::ParentDir,
+            Component::Normal("bar"),
+            Component::Normal("foobar"),
+        ];
+        assert_eq!(components.as_slice(), expected.as_slice());
+
+        let path = Path::new("./foo");
+        let components = path.components('/').collect::<Vec<_>>();
+        let expected = [Component::CurDir, Component::Normal("foo")];
+        assert_eq!(components.as_slice(), expected.as_slice());
+
+        let path = Path::new("");
+        assert_eq!(path.components('/').count(), 0);
+    }
+}

--- a/uefi/src/fs/uefi_types.rs
+++ b/uefi/src/fs/uefi_types.rs
@@ -1,0 +1,10 @@
+//! Re-export of low-level UEFI types but prefixed with `Uefi`. This simplifies
+//! to differ between high-level and low-level types and interfaces in this
+//! module.
+
+pub use uefi::proto::media::file::{
+    Directory as UefiDirectoryHandle, File as UefiFileTrait, FileAttribute as UefiFileAttribute,
+    FileHandle as UefiFileHandle, FileInfo as UefiFileInfo, FileMode as UefiFileMode,
+    FileType as UefiFileType, RegularFile as UefiRegularFileHandle,
+};
+pub use uefi::proto::media::fs::SimpleFileSystem as SimpleFileSystemProtocol;

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -113,6 +113,9 @@ pub mod allocator;
 #[cfg(feature = "logger")]
 pub mod logger;
 
+#[cfg(feature = "alloc")]
+pub mod fs;
+
 // As long as this is behind "alloc", we can simplify cfg-feature attributes in this module.
 #[cfg(feature = "alloc")]
 pub(crate) mod mem;


### PR DESCRIPTION
Hi! This originated in a personal learning project and I'd like to know what others think about it. Would be cool if we can bring this upstream. It's about creating a high level FS abstraction over the existing FS protocol. It aims to be as close to top-level functions provided by `std::fs` as possible.

## Motivation
Usually, UEFI-application hackers want to do something like this:
- read configuration file from /foo/bar/config
- write to /for/bar/log.txt
- read /foo/bar/kernel.elf


## Code example / API demonstration
```rust
    let mut fs = FileSystem::new(
        "boot",
        system_table.boot_services().get_image_file_system(handle).unwrap()
    );

    fs.write("foobar.bin", [1,2,3]).unwrap();
    fs.read("bar").unwrap_err();
    fs.copy("foobar.bin", "bar").unwrap();
    fs.read("bar").unwrap();
    fs.rename("bar", "barfoo").unwrap();
    assert_eq!(fs.read("barfoo").unwrap().as_slice(), &[1, 2, 3]);

    log::info!("fs integration test worked!");
```

From the module description (initial version; a few changes in the meantime):
```
//! A high-level file system API for UEFI applications. It supports you to conveniently perform the
//! following important operations:
//! - read file to bytes
//! - write bytes to file
//! - create files
//! - iterate directories and walk the file system tree
//!
//! Unlike UNIX-based file systems, there is no virtual file system. Thus, users perform actions on
//! dedicated volumes: For example, the boot volume, such as a CD-rom, USB-stick, or a storage
//! device. There are no symlinks or hard-links. Just plain paths, directories, and regular files.
//! The way to access a volume is to open a [FileSystem].
//!
//! All paths are absolute and follow the FAT-like file system conventions for paths. Thus, there
//! is no current working directory and path components like "." and ".." are not supported. In
//! other words, the current working directory is always "/", i.e., the root, of the opened volume.
//! This may change in the future but is currently sufficient.
//!
//! There are no `File` and `Path` abstractions that get publicly exported. Paths are provided as
//! `&str` and validated internally. There are no `File` objects that are exposed to users.
//!
//! The difference to using the [SimpleFileSystemProtocol] directly is that the abstractions in this
//! module take care of automatic release of resources and support you by returning data owned on
//! the heap (such as file info). There is no synchronization as it is untypically that users
//! bootstrap Application Processors (AP) during the UEFI stage, i.e., before hand-off to a kernel.
```

## Open Questions
- [x] Do we want this at all in uefi-rs?
- [x] Integration tests (I have integration tests in my private project so I know it is working)
- [x] how to integrate it into the existing code base
- [x] verify: apparently there is already a "get boxed file info"-implementation. But I do not know if it respects the dynamically sized C16-string length

## Steps to Undraft
- [x] polish documentation a little
- [x] fix integration test