### PR TITLE
"is_regular_file" for file trait + integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 ### Fixed
 
 - Corrected the name of `BlockIOMedia::is_media_preset` to `is_media_present`.
+- The `File` trait now knows the methods `is_regular_file` and `is_directory`.
+  Developers profit from this on the struct `FileHandle`, for example.
 
 ### Changed
 

--- a/src/proto/media/file/dir.rs
+++ b/src/proto/media/file/dir.rs
@@ -67,4 +67,12 @@ impl File for Directory {
     fn handle(&mut self) -> &mut FileHandle {
         self.0.handle()
     }
+
+    fn is_regular_file(&self) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn is_directory(&self) -> Result<bool> {
+        Ok(true)
+    }
 }

--- a/src/proto/media/file/regular.rs
+++ b/src/proto/media/file/regular.rs
@@ -104,4 +104,12 @@ impl File for RegularFile {
     fn handle(&mut self) -> &mut FileHandle {
         &mut self.0
     }
+
+    fn is_regular_file(&self) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn is_directory(&self) -> Result<bool> {
+        Ok(false)
+    }
 }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 
 /// Errors emitted from UEFI entry point must propagate erronerous UEFI statuses,
 /// and may optionally propagate additional entry point-specific data.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Error<Data: Debug = ()> {
     status: Status,
     data: Data,


### PR DESCRIPTION
This MR adds the "is_regular_file" and "is_regular_directory"-methods for the File-trait which is especially useful if you work with the generic `FileHandle` abstraction. 

~~Furthermore, it splits up the existing integration test a little for a clearer separation of concerns. The simple file system protocol test now tests creating a file in the root volume. On this file, I test my newly created additions.~~

~~Additionally, `FileHandle::into_type` now returns a direct value instead of a Result. If we have a failure there, it is a hard-bug in the uefi-rs lib and not something the user should take care of.~~