### PR TITLE
More protocol safety improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@
 ### Changed
 
 - Marked `BootServices::handle_protocol` as `unsafe`. (This method is
-  also deprecated -- use `open_protocol` instead.)
+  also deprecated -- use `open_protocol_exclusive` or `open_protocol` instead.)
 - Deprecated `BootServices::locate_protocol` and marked it `unsafe`. Use
   `BootServices::get_handle_for_protocol` and
-  `BootServices::open_protocol` instead.
+  `BootServices::open_protocol_exclusive` (or
+  `BootServices::open_protocol`) instead.
 - renamed feature `ignore-logger-errors` to `panic-on-logger-errors` so that it is
   additive. It is now a default feature.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
   Now you can compare everything that is `AsRef<str>` (such as `String` and `str`
   from the standard library) to uefi strings. Please head to the documentation of
   `EqStrUntilNul` to find out limitations and further information.
+- Added `BootServices::image_handle` to get the handle of the executing
+  image. The image is set automatically by the `#[entry]` macro; if a
+  program does not use that macro then it should call
+  `BootServices::set_image_handle`.
+- Added `BootServices::open_protocol_exclusive`. This provides a safe
+  and convenient subset of `open_protocol` that can be used whenever a
+  resource doesn't need to be shared. In same cases sharing is useful
+  (e.g. you might want to draw to the screen using the graphics
+  protocol, but still allow stdout output to go to the screen as
+  well), and in those cases `open_protocol` can still be used.
 
 ### Changed
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1007,6 +1007,26 @@ impl BootServices {
         })
     }
 
+    /// Open a protocol interface for a handle in exclusive mode.
+    ///
+    /// If successful, a [`ScopedProtocol`] is returned that will
+    /// automatically close the protocol interface when dropped.
+    ///
+    /// [`handle_protocol`]: BootServices::handle_protocol
+    pub fn open_protocol_exclusive<P: ProtocolPointer + ?Sized>(
+        &self,
+        handle: Handle,
+    ) -> Result<ScopedProtocol<P>> {
+        self.open_protocol::<P>(
+            OpenProtocolParams {
+                handle,
+                agent: self.image_handle(),
+                controller: None,
+            },
+            OpenProtocolAttributes::Exclusive,
+        )
+    }
+
     /// Test whether a handle supports a protocol.
     pub fn test_protocol<P: Protocol>(&self, params: OpenProtocolParams) -> Result<()> {
         const TEST_PROTOCOL: u32 = 0x04;

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -179,7 +179,47 @@ fn get_function_arg_name(f: &ItemFn, arg_index: usize, errors: &mut TokenStream2
     }
 }
 
-/// Custom attribute for a UEFI executable entrypoint
+/// Custom attribute for a UEFI executable entry point.
+///
+/// This attribute modifies a function to mark it as the entry point for
+/// a UEFI executable. The function must have two parameters, [`Handle`]
+/// and [`SystemTable<Boot>`], and return a [`Status`]. The function can
+/// optionally be `unsafe`.
+///
+/// Due to internal implementation details the parameters must both be
+/// named, so `arg` or `_arg` are allowed, but not `_`.
+///
+/// The [`BootServices::set_image_handle`] function will be called
+/// automatically with the image [`Handle`] argument.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![no_main]
+/// #![no_std]
+/// #![feature(abi_efiapi)]
+/// # // A bit of boilerplate needed to make the example compile in the
+/// # // context of `cargo test`.
+/// # #![feature(lang_items)]
+/// # #[lang = "eh_personality"]
+/// # fn eh_personality() {}
+/// # #[panic_handler]
+/// # fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+/// #     loop {}
+/// # }
+///
+/// use uefi::prelude::*;
+///
+/// #[entry]
+/// fn main(image: Handle, st: SystemTable<Boot>) -> Status {
+///     Status::SUCCESS
+/// }
+/// ```
+///
+/// [`Handle`]: https://docs.rs/uefi/latest/uefi/data_types/struct.Handle.html
+/// [`SystemTable<Boot>`]: https://docs.rs/uefi/latest/uefi/table/struct.SystemTable.html
+/// [`Status`]: https://docs.rs/uefi/latest/uefi/struct.Status.html
+/// [`BootServices::set_image_handle`]: https://docs.rs/uefi/latest/uefi/table/boot/struct.BootServices.html#method.set_image_handle
 #[proc_macro_attribute]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     // This code is inspired by the approach in this embedded Rust crate:

--- a/uefi-macros/tests/ui/entry_unnamed_image_arg.rs
+++ b/uefi-macros/tests/ui/entry_unnamed_image_arg.rs
@@ -1,0 +1,11 @@
+#![allow(unused_imports)]
+#![no_main]
+#![feature(abi_efiapi)]
+
+use uefi::prelude::*;
+use uefi_macros::entry;
+
+#[entry]
+fn unnamed_image_arg(_: Handle, _st: SystemTable<Boot>) -> Status {
+    Status::SUCCESS
+}

--- a/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
@@ -1,0 +1,5 @@
+error: Entry method's arguments must be named
+ --> tests/ui/entry_unnamed_image_arg.rs:9:22
+  |
+9 | fn unnamed_image_arg(_: Handle, _st: SystemTable<Boot>) -> Status {
+  |                      ^^^^^^^^^

--- a/uefi-macros/tests/ui/entry_unnamed_table_arg.rs
+++ b/uefi-macros/tests/ui/entry_unnamed_table_arg.rs
@@ -1,0 +1,11 @@
+#![allow(unused_imports)]
+#![no_main]
+#![feature(abi_efiapi)]
+
+use uefi::prelude::*;
+use uefi_macros::entry;
+
+#[entry]
+fn unnamed_table_arg(_image: Handle, _: SystemTable<Boot>) -> Status {
+    Status::SUCCESS
+}

--- a/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
@@ -1,0 +1,5 @@
+error: Entry method's arguments must be named
+ --> tests/ui/entry_unnamed_table_arg.rs:9:38
+  |
+9 | fn unnamed_table_arg(_image: Handle, _: SystemTable<Boot>) -> Status {
+  |                                      ^^^^^^^^^^^^^^^^^^^^

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -10,7 +10,6 @@ extern crate alloc;
 use alloc::string::String;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
-use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
 use uefi_services::{print, println};
 
 mod boot;
@@ -81,7 +80,7 @@ fn check_revision(rev: uefi::table::Revision) {
 /// This functionality is very specific to our QEMU-based test runner. Outside
 /// of it, we just pause the tests for a couple of seconds to allow visual
 /// inspection of the output.
-fn check_screenshot(image: Handle, bt: &BootServices, name: &str) {
+fn check_screenshot(bt: &BootServices, name: &str) {
     if cfg!(feature = "qemu") {
         let serial_handles = bt
             .find_handles::<Serial>()
@@ -96,14 +95,7 @@ fn check_screenshot(image: Handle, bt: &BootServices, name: &str) {
             .expect("Second serial device is missing");
 
         let mut serial = bt
-            .open_protocol::<Serial>(
-                OpenProtocolParams {
-                    handle: serial_handle,
-                    agent: image,
-                    controller: None,
-                },
-                OpenProtocolAttributes::Exclusive,
-            )
+            .open_protocol_exclusive::<Serial>(serial_handle)
             .expect("Could not open serial protocol");
 
         // Set a large timeout to avoid problems with Travis

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -2,7 +2,7 @@ use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub unsafe fn test(image: Handle, bt: &BootServices) {
     info!("Running graphics output protocol test");
     if let Ok(handle) = bt.get_handle_for_protocol::<GraphicsOutput>() {
         let gop = &mut bt
@@ -23,7 +23,7 @@ pub fn test(image: Handle, bt: &BootServices) {
         fill_color(gop);
         draw_fb(gop);
 
-        crate::check_screenshot(image, bt, "gop_test");
+        crate::check_screenshot(bt, "gop_test");
     } else {
         // No tests can be run.
         warn!("UEFI Graphics Output Protocol is not supported");

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -6,9 +6,11 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     stdout::test(st.stdout());
 
     let bt = st.boot_services();
-    serial::test(image, bt);
-    gop::test(image, bt);
-    pointer::test(image, bt);
+    unsafe {
+        serial::test(image, bt);
+        gop::test(image, bt);
+    }
+    pointer::test(bt);
 }
 
 mod gop;

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,19 +1,11 @@
 use uefi::proto::console::pointer::Pointer;
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
-use uefi::Handle;
+use uefi::table::boot::BootServices;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running pointer protocol test");
     if let Ok(handle) = bt.get_handle_for_protocol::<Pointer>() {
         let mut pointer = bt
-            .open_protocol::<Pointer>(
-                OpenProtocolParams {
-                    handle,
-                    agent: image,
-                    controller: None,
-                },
-                OpenProtocolAttributes::Exclusive,
-            )
+            .open_protocol_exclusive::<Pointer>(handle)
             .expect("failed to open pointer protocol");
 
         pointer

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -2,7 +2,7 @@ use uefi::proto::console::serial::{ControlBits, Serial};
 use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
 use uefi::Handle;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub unsafe fn test(image: Handle, bt: &BootServices) {
     info!("Running serial protocol test");
     if let Ok(handle) = bt.get_handle_for_protocol::<Serial>() {
         let mut serial = bt

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -1,20 +1,12 @@
 use core::ffi::c_void;
 use uefi::proto::debug::{DebugSupport, ExceptionType, ProcessorArch, SystemContext};
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
-use uefi::Handle;
+use uefi::table::boot::BootServices;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
     if let Ok(handles) = bt.find_handles::<DebugSupport>() {
         for handle in handles {
-            if let Ok(mut debug_support) = bt.open_protocol::<DebugSupport>(
-                OpenProtocolParams {
-                    handle,
-                    agent: image,
-                    controller: None,
-                },
-                OpenProtocolAttributes::Exclusive,
-            ) {
+            if let Ok(mut debug_support) = bt.open_protocol_exclusive::<DebugSupport>(handle) {
                 // make sure that the max processor index is a sane value, i.e. it works
                 let maximum_processor_index = debug_support.get_maximum_processor_index();
                 assert_ne!(

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -1,56 +1,30 @@
 use uefi::prelude::*;
 use uefi::proto::device_path::{text::*, DevicePath};
 use uefi::proto::loaded_image::LoadedImage;
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
+use uefi::table::boot::BootServices;
 
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Running device path protocol test");
 
     let loaded_image = bt
-        .open_protocol::<LoadedImage>(
-            OpenProtocolParams {
-                handle: image,
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
-        )
+        .open_protocol_exclusive::<LoadedImage>(image)
         .expect("Failed to open LoadedImage protocol");
 
     let device_path = bt
-        .open_protocol::<DevicePath>(
-            OpenProtocolParams {
-                handle: loaded_image.device(),
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
-        )
+        .open_protocol_exclusive::<DevicePath>(loaded_image.device())
         .expect("Failed to open DevicePath protocol");
 
     let device_path_to_text = bt
-        .open_protocol::<DevicePathToText>(
-            OpenProtocolParams {
-                handle: bt
-                    .get_handle_for_protocol::<DevicePathToText>()
-                    .expect("Failed to get DevicePathToText handle"),
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
+        .open_protocol_exclusive::<DevicePathToText>(
+            bt.get_handle_for_protocol::<DevicePathToText>()
+                .expect("Failed to get DevicePathToText handle"),
         )
         .expect("Failed to open DevicePathToText protocol");
 
     let device_path_from_text = bt
-        .open_protocol::<DevicePathFromText>(
-            OpenProtocolParams {
-                handle: bt
-                    .get_handle_for_protocol::<DevicePathFromText>()
-                    .expect("Failed to get DevicePathFromText handle"),
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
+        .open_protocol_exclusive::<DevicePathFromText>(
+            bt.get_handle_for_protocol::<DevicePathFromText>()
+                .expect("Failed to get DevicePathFromText handle"),
         )
         .expect("Failed to open DevicePathFromText protocol");
 

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -1,19 +1,12 @@
 use uefi::prelude::*;
 use uefi::proto::loaded_image::LoadedImage;
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
+use uefi::table::boot::BootServices;
 
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Running loaded image protocol test");
 
     let loaded_image = bt
-        .open_protocol::<LoadedImage>(
-            OpenProtocolParams {
-                handle: image,
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
-        )
+        .open_protocol_exclusive::<LoadedImage>(image)
         .expect("Failed to open LoadedImage protocol");
 
     let load_options = loaded_image.load_options_as_bytes();

--- a/uefi-test-runner/src/proto/media/known_disk.rs
+++ b/uefi-test-runner/src/proto/media/known_disk.rs
@@ -145,17 +145,19 @@ fn test_create_file(directory: &mut Directory) {
 fn get_block_media_id(handle: Handle, bt: &BootServices) -> u32 {
     // This cannot be opened in `EXCLUSIVE` mode, as doing so
     // unregisters the `DiskIO` protocol from the handle.
-    let block_io = bt
-        .open_protocol::<BlockIO>(
-            OpenProtocolParams {
-                handle,
-                agent: bt.image_handle(),
-                controller: None,
-            },
-            OpenProtocolAttributes::GetProtocol,
-        )
-        .expect("Failed to get block I/O protocol");
-    block_io.media().media_id()
+    unsafe {
+        let block_io = bt
+            .open_protocol::<BlockIO>(
+                OpenProtocolParams {
+                    handle,
+                    agent: bt.image_handle(),
+                    controller: None,
+                },
+                OpenProtocolAttributes::GetProtocol,
+            )
+            .expect("Failed to get block I/O protocol");
+        block_io.media().media_id()
+    }
 }
 
 /// Tests raw disk I/O.

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -12,13 +12,13 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     find_protocol(bt);
     test_protocols_per_handle(image, bt);
 
-    debug::test(image, bt);
+    debug::test(bt);
     device_path::test(image, bt);
     loaded_image::test(image, bt);
-    media::test(image, bt);
-    network::test(image, bt);
-    pi::test(image, bt);
-    rng::test(image, bt);
+    media::test(bt);
+    network::test(bt);
+    pi::test(bt);
+    rng::test(bt);
 
     #[cfg(any(
         target_arch = "i386",
@@ -26,7 +26,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
         target_arch = "arm",
         target_arch = "aarch64"
     ))]
-    shim::test(image, bt);
+    shim::test(bt);
 }
 
 fn find_protocol(bt: &BootServices) {

--- a/uefi-test-runner/src/proto/network.rs
+++ b/uefi-test-runner/src/proto/network.rs
@@ -4,25 +4,15 @@ use uefi::{
         pxe::{BaseCode, DhcpV4Packet, IpFilter, IpFilters, UdpOpFlags},
         IpAddress,
     },
-    table::boot::{OpenProtocolAttributes, OpenProtocolParams},
-    CStr8, Handle,
+    CStr8,
 };
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Testing Network protocols");
 
     if let Ok(handles) = bt.find_handles::<BaseCode>() {
         for handle in handles {
-            let mut base_code = bt
-                .open_protocol::<BaseCode>(
-                    OpenProtocolParams {
-                        handle,
-                        agent: image,
-                        controller: None,
-                    },
-                    OpenProtocolAttributes::Exclusive,
-                )
-                .unwrap();
+            let mut base_code = bt.open_protocol_exclusive::<BaseCode>(handle).unwrap();
 
             info!("Starting PXE Base Code");
             base_code

--- a/uefi-test-runner/src/proto/pi/mod.rs
+++ b/uefi-test-runner/src/proto/pi/mod.rs
@@ -1,9 +1,9 @@
 use uefi::prelude::*;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Testing Platform Initialization protocols");
 
-    mp::test(image, bt);
+    mp::test(bt);
 }
 
 mod mp;

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -2,13 +2,13 @@ use core::ffi::c_void;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use uefi::proto::pi::mp::MpServices;
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
-use uefi::{Handle, Status};
+use uefi::table::boot::BootServices;
+use uefi::Status;
 
 /// Number of cores qemu is configured to have
 const NUM_CPUS: usize = 4;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     // These tests break CI. See #103.
     if cfg!(feature = "ci") {
         return;
@@ -17,14 +17,7 @@ pub fn test(image: Handle, bt: &BootServices) {
     info!("Running UEFI multi-processor services protocol test");
     if let Ok(handle) = bt.get_handle_for_protocol::<MpServices>() {
         let mp_support = &bt
-            .open_protocol::<MpServices>(
-                OpenProtocolParams {
-                    handle,
-                    agent: image,
-                    controller: None,
-                },
-                OpenProtocolAttributes::Exclusive,
-            )
+            .open_protocol_exclusive::<MpServices>(handle)
             .expect("failed to open multi-processor services protocol");
 
         test_get_number_of_processors(mp_support);

--- a/uefi-test-runner/src/proto/rng.rs
+++ b/uefi-test-runner/src/proto/rng.rs
@@ -1,21 +1,13 @@
-use uefi::prelude::*;
 use uefi::proto::rng::{Rng, RngAlgorithmType};
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
+use uefi::table::boot::BootServices;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running rng protocol test");
 
     let handle = bt.get_handle_for_protocol::<Rng>().expect("No Rng handles");
 
     let mut rng = bt
-        .open_protocol::<Rng>(
-            OpenProtocolParams {
-                handle,
-                agent: image,
-                controller: None,
-            },
-            OpenProtocolAttributes::Exclusive,
-        )
+        .open_protocol_exclusive::<Rng>(handle)
         .expect("Failed to open Rng protocol");
 
     let mut list = [RngAlgorithmType::EMPTY_ALGORITHM; 4];

--- a/uefi-test-runner/src/proto/shim.rs
+++ b/uefi-test-runner/src/proto/shim.rs
@@ -1,20 +1,12 @@
 use uefi::proto::shim::ShimLock;
-use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
-use uefi::Handle;
+use uefi::table::boot::BootServices;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running shim lock protocol test");
 
     if let Ok(handle) = bt.get_handle_for_protocol::<ShimLock>() {
         let shim_lock = bt
-            .open_protocol::<ShimLock>(
-                OpenProtocolParams {
-                    handle,
-                    agent: image,
-                    controller: None,
-                },
-                OpenProtocolAttributes::Exclusive,
-            )
+            .open_protocol_exclusive::<ShimLock>(handle)
             .expect("failed to open shim lock protocol");
 
         // An empty buffer should definitely be invalid, so expect


### PR DESCRIPTION
This is a change I've been noodling on for a bit related to https://github.com/rust-osdev/uefi-rs/issues/359. The basic issue is that in order to use protocols fully safely, with no chance of either the handle or protocol being modified or removed while in use, we need to ensure that protocols are opened in exclusive mode with the correct agent handle set. We've made some good steps towards that by deprecating and marking unsafe things like `handle_protocol`, but there are still unsafe ways to use `open_protocol`.

To resolve this (to the extent possible given the design of UEFI), I've added a new `open_protocol_exclusive` function. This function is fully safe; it ensures that the correct agent is set through the use of a new global image handle set by the `#[entry]` macro, and always opens the protocol in exclusive mode. This is a much nicer interface to use than `open_protocol`, since you only have to provide the `Handle` you want to open.

There are still some cases where the full power of `open_protocol` is needed; uefi-test-runner has some examples of this. For those cases though the caller needs to be aware that they are responsible for ensuring that the handle and protocol are valid until the protocol is no longer in use, so I've marked `open_protocol` as unsafe. Since most uses can be replaced with `open_protocol_exclusive`, this is hopefully not too much of a burden.

Having a global image handle and marking `open_protocol` as unsafe are fairly significant changes to the API (although notably we haven't done a release yet that includes https://github.com/rust-osdev/uefi-rs/pull/434, so users of `open_protocol` will already have to make some code adjustments when they next upgrade), but I think it will provide a nice boost in both safety and ease of use.
