### PR TITLE
Drop use of unstable try_trait_v2 feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   other than 1. A safe alternative is to use
   [`Vec::into_boxed_slice`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_boxed_slice).
 - Removed `From` conversions from `ucs2::Error` to `Status` and `Error`.
+- Removed use of the unstable `try_trait_v2` feature, which allowed `?`
+  to be used with `Status` in a function returning `uefi::Result`. This
+  can be replaced by calling `status.into()`, or `Result::from(status)`
+  in cases where the compiler needs a type hint.
 
 ## uefi-macros - [Unreleased]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //! For example, a PC with no network card might not contain a network driver,
 //! therefore all the network protocols will be unavailable.
 
-#![feature(try_trait_v2)]
 #![feature(abi_efiapi)]
 #![feature(maybe_uninit_slice)]
 #![feature(negative_impls)]

--- a/src/proto/shim/mod.rs
+++ b/src/proto/shim/mod.rs
@@ -108,14 +108,14 @@ impl ShimLock {
             .map_err(|_| Error::from(Status::BAD_BUFFER_SIZE))?;
 
         let mut context = MaybeUninit::<Context>::uninit();
-        (self.context)(ptr, size, context.as_mut_ptr())?;
+        Result::from((self.context)(ptr, size, context.as_mut_ptr()))?;
         (self.hash)(
             ptr,
             size,
             context.as_mut_ptr(),
             &mut hashes.sha256,
             &mut hashes.sha1,
-        )?;
-        Ok(())
+        )
+        .into()
     }
 }


### PR DESCRIPTION
It seems like there's still a fair amount of discussion around what the
Try API should look like in the tracking issue for try_trait_v2. This
could lead to the API being changed in the nightly compiler, and
breaking uefi-rs compilation (which is particularly annoying when using
a released version rather than the latest git version).

To avoid that possibility, just drop the feature as it is not much used
in uefi-rs and can easily be replaced. As described in the changelog,
most uses can be fixed by adding a call to `into()`. If the compiler
needs a bit more help, `Result::from(status)` can be used.

https://github.com/rust-osdev/uefi-rs/issues/452