### PR TITLE
Relax version requirements for various deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ logger = []
 ignore-logger-errors = []
 
 [dependencies]
-bitflags = "1.3.2"
-log = { version = "0.4.17", default-features = false }
+bitflags = "1.3.1"
+log = { version = "0.4.5", default-features = false }
 ucs2 = "0.3.2"
 uefi-macros = "0.7.0"
 

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -19,9 +19,9 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.38"
-quote = "1.0.18"
-syn = { version = "1.0.94", features = ["full"] }
+proc-macro2 = "1.0.28"
+quote = "1.0.9"
+syn = { version = "1.0.74", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.61"

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -16,7 +16,7 @@ is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 
 [dependencies]
 uefi = { version = "0.16.0", features = ["alloc", "logger"] }
-log = { version = "0.4.14", default-features = false }
+log = { version = "0.4.5", default-features = false }
 cfg-if = "1.0.0"
 qemu-exit = { version = "3.0.1", optional = true }
 


### PR DESCRIPTION
Allow older versions of some dependencies to be used if that's all
that's available. This change will have no effect for typical builds
with Cargo, as Cargo will just pick the latest version and download
it. But in more restrictive/sandboxed build environments where the
latest versions of packages might not be available, it's helpful to
allow a wider range of versions.

Only non-dev dependencies have been changed, and only in the three
published packages.

Tested locally by temporarily prefixing these depdency versions with `=`
to force Cargo to use exactly that version, and verifying that
build/test/run commands still worked.