### PR TITLE
Update deprecation version in ScopedProtocol::interface

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1396,7 +1396,7 @@ pub struct OpenProtocolParams {
 /// protocol and why [`UnsafeCell`] is used.
 pub struct ScopedProtocol<'a, P: Protocol + ?Sized> {
     /// The protocol interface.
-    #[deprecated(since = "0.16.0", note = "use Deref and DerefMut instead")]
+    #[deprecated(since = "0.17.0", note = "use Deref and DerefMut instead")]
     pub interface: &'a UnsafeCell<P>,
 
     open_params: OpenProtocolParams,


### PR DESCRIPTION
The replacement for accessing this field (Deref/DerefMut on
ScopedProtocol) isn't part of 0.16.0, so it isn't correct to mark the
field deprecated in that version. Bump to 0.17.0, which should be the
next version of uefi.

Fixes https://github.com/rust-osdev/uefi-rs/issues/484