### PR TITLE
Use doc_auto_cfg to show feature requirements on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ uefi = { path = "." }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
 #![cfg_attr(feature = "exts", feature(vec_into_raw_parts))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]


### PR DESCRIPTION
Add a `docsrs` config in the `docs.rs` metadata in Cargo.toml. This will
set `--cfg docsrs` when building on docs.rs. Enable the `doc_auto_cfg`
feature when the `docsrs` config is enabled. This feature is currently
unstable, but docs.rs uses a nightly compiler so this works fine.

The effect of this is that docs.rs will show a badge for items that are
only available if some feature is enabled. For example,
`BootServices::find_handles` will have a badge saying "Available on
crate feature exts only."

To view this locally, run this:
```
RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --all-features --open
```

This change has only been applied to the `uefi` package, since the
`uefi-macros` package does not have any features and the `uefi-services`
package's features don't control the visiblity of any public items.

https://github.com/rust-osdev/uefi-rs/issues/486