### PR TITLE
is_media_preset -> is_media_present in BlockIOMedia

### DIFF
--- a/src/proto/media/block.rs
+++ b/src/proto/media/block.rs
@@ -138,7 +138,7 @@ impl BlockIOMedia {
     }
 
     /// True if there is a media currently present in the device.
-    pub fn is_media_preset(&self) -> bool {
+    pub fn is_media_present(&self) -> bool {
         self.media_present
     }
 


### PR DESCRIPTION
This is a breaking typo fix. But as `main` already contains some breaking changes since 0.16, I feel that it's the right time to fix it.