### PR TITLE
remove CStr8 and replace by libcore::ffi::CStr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   `BootServices::open_protocol`) instead.
 - renamed feature `ignore-logger-errors` to `panic-on-logger-errors` so that it is
   additive. It is now a default feature.
+- The library doesn't longer expose the `CStr8` type. It was not relevant in the
+  API so far, and internally it was replaced by `core::ffi::CStr`. (Since Rust 1.62)
 
 ### Removed
 

--- a/src/data_types/chars.rs
+++ b/src/data_types/chars.rs
@@ -9,57 +9,6 @@ use core::fmt;
 #[derive(Clone, Copy, Debug)]
 pub struct CharConversionError;
 
-/// A Latin-1 character
-#[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(transparent)]
-pub struct Char8(u8);
-
-impl TryFrom<char> for Char8 {
-    type Error = CharConversionError;
-
-    fn try_from(value: char) -> Result<Self, Self::Error> {
-        let code_point = value as u32;
-        if code_point <= 0xff {
-            Ok(Char8(code_point as u8))
-        } else {
-            Err(CharConversionError)
-        }
-    }
-}
-
-impl From<Char8> for char {
-    fn from(char: Char8) -> char {
-        char.0 as char
-    }
-}
-
-impl From<u8> for Char8 {
-    fn from(value: u8) -> Self {
-        Char8(value)
-    }
-}
-
-impl From<Char8> for u8 {
-    fn from(char: Char8) -> u8 {
-        char.0
-    }
-}
-
-impl fmt::Debug for Char8 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <char as fmt::Debug>::fmt(&From::from(self.0), f)
-    }
-}
-
-impl fmt::Display for Char8 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <char as fmt::Display>::fmt(&From::from(self.0), f)
-    }
-}
-
-/// Latin-1 version of the NUL character
-pub const NUL_8: Char8 = Char8(0);
-
 /// An UCS-2 code point
 #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -112,14 +112,15 @@ pub use self::guid::Guid;
 pub use self::guid::{unsafe_guid, Identify};
 
 pub mod chars;
-pub use self::chars::{Char16, Char8};
+pub use self::chars::Char16;
 
 #[macro_use]
 mod enums;
 
 mod strs;
+
 pub use self::strs::{
-    CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16,
+    CStr16, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16,
     UnalignedCStr16Error,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub mod data_types;
 #[cfg(feature = "exts")]
 pub use self::data_types::CString16;
 pub use self::data_types::{unsafe_guid, Identify};
-pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
+pub use self::data_types::{CStr16, Char16, Event, Guid, Handle};
 
 mod result;
 pub use self::result::{Error, Result, ResultExt, Status};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,4 +10,4 @@ pub use crate::table::runtime::RuntimeServices;
 pub use crate::table::{Boot, SystemTable};
 
 // Import the macro for creating the custom entry point, as well as the cstr macros.
-pub use uefi_macros::{cstr16, cstr8, entry};
+pub use uefi_macros::{cstr16, entry};

--- a/src/proto/network/pxe.rs
+++ b/src/proto/network/pxe.rs
@@ -9,7 +9,8 @@ use core::{
 use bitflags::bitflags;
 use uefi_macros::{unsafe_guid, Protocol};
 
-use crate::{CStr8, Char8, Result, Status};
+use crate::{Result, Status};
+use core::ffi::{c_char, CStr as CStr8};
 
 use super::{IpAddress, MacAddress};
 
@@ -38,7 +39,7 @@ pub struct BaseCode {
         buffer_size: &mut u64,
         block_size: Option<&usize>,
         server_ip: &IpAddress,
-        filename: *const Char8,
+        filename: *const c_char,
         info: Option<&MtftpInfo>,
         dont_use_buffer: bool,
     ) -> Status,

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -289,33 +289,6 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     result.into()
 }
 
-/// Builds a `CStr8` literal at compile time from a string literal.
-///
-/// This will throw a compile error if an invalid character is in the passed string.
-///
-/// # Example
-/// ```
-/// # use uefi_macros::cstr8;
-/// assert_eq!(cstr8!("test").to_bytes_with_nul(), [116, 101, 115, 116, 0]);
-/// ```
-#[proc_macro]
-pub fn cstr8(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input: LitStr = parse_macro_input!(input);
-    let input = input.value();
-    match input
-        .chars()
-        .map(u8::try_from)
-        .collect::<Result<Vec<u8>, _>>()
-    {
-        Ok(c) => {
-            quote!(unsafe { ::uefi::CStr8::from_bytes_with_nul_unchecked(&[ #(#c),* , 0 ]) }).into()
-        }
-        Err(_) => syn::Error::new_spanned(input, "invalid character in string")
-            .into_compile_error()
-            .into(),
-    }
-}
-
 /// Builds a `CStr16` literal at compile time from a string literal.
 ///
 /// This will throw a compile error if an invalid character is in the passed string.

--- a/uefi-test-runner/src/proto/network.rs
+++ b/uefi-test-runner/src/proto/network.rs
@@ -1,10 +1,12 @@
+use core::ffi::CStr as CStr8;
 use uefi::{
     prelude::BootServices,
     proto::network::{
         pxe::{BaseCode, DhcpV4Packet, IpFilter, IpFilters, UdpOpFlags},
         IpAddress,
     },
-    CStr8,
+    table::boot::{OpenProtocolAttributes, OpenProtocolParams},
+    Handle,
 };
 
 pub fn test(bt: &BootServices) {


### PR DESCRIPTION
This is a cleanup PR. It removes everything related to CStr8. I replaced it with `core::ffi::CStr` which is available since Rust 1.62.0.