### PR TITLE
Implement `HardDriveMediaDevicePath` (along with MBR and GPT tests). 

### DIFF
--- a/src/data_types/enums.rs
+++ b/src/data_types/enums.rs
@@ -44,7 +44,7 @@
 macro_rules! newtype_enum {
     (
         $(#[$type_attrs:meta])*
-        pub enum $type:ident : $base_integer:ty => $(#[$impl_attrs:meta])* {
+        $visibility:vis enum $type:ident : $base_integer:ty => $(#[$impl_attrs:meta])* {
             $(
                 $(#[$variant_attrs:meta])*
                 $variant:ident = $value:expr,
@@ -54,7 +54,7 @@ macro_rules! newtype_enum {
         $(#[$type_attrs])*
         #[repr(transparent)]
         #[derive(Clone, Copy, Eq, PartialEq)]
-        pub struct $type(pub $base_integer);
+        $visibility struct $type(pub $base_integer);
 
         $(#[$impl_attrs])*
         #[allow(unused)]


### PR DESCRIPTION
This PR implements the `HardDriveMediaDevicePath` specialization of `DevicePathNode`.
I basically looked at the existing `FilePathMediaDevicePath` and added the new structure with a similar API.

This has been tested on the TianoCore UEFI of QEMU.
I've also added unit tests against the raw bytes of `HardDriveMediaDevicePath` for an MBR and a GPT partition.