### PR TITLE
Update changelog for uefi-macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@
 
 ## uefi-macros - [Unreleased]
 
+### Changed
+
+- The `#[entry]` macro now calls `BootServices::set_image_handle` to set
+  the global image handle. Due to this change, the two arguments to main
+  must both be named (e.g. `image: Handle` and `_image: Handle` are both
+  OK, but not `_: Handle`).
+
 ## uefi-services - [Unreleased]
 
 ### Added


### PR DESCRIPTION
The change to `#[entry]` is mentioned in the `uefi` section already since it's also relevant there, but worth mentioning in the
`uefi-macros` section as well so that it's clear why there's a new version and to note that the arguments to main must now be named.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
