### PR TITLE
CStr8 cleanup and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 - Implemented `core::fmt::Write` for the `Serial` protocol.
 - Added the `MemoryProtection` protocol.
 - Added `BootServices::get_handle_for_protocol`.
-- Added trait `EqStrUntilNul` and implemented it for `CStr16` and `CString16`.
-  Now you can compare everything that is `AsRef<str>` (such as `String` and `str`
-  from the standard library) to uefi strings. Please head to the documentation of
-  `EqStrUntilNul` to find out limitations and further information.
+- Added trait `EqStrUntilNul` and implemented it for `CStr8`, `CStr16`, and `CString16`
+  (CString8 doesn't exist yet). Now you can compare everything that is `AsRef<str>`
+  (such as `String` and `str` from the standard library) to UEFI strings. Please head to the
+  documentation of `EqStrUntilNul` to find out limitations and further information.
 - Added `BootServices::image_handle` to get the handle of the executing
   image. The image is set automatically by the `#[entry]` macro; if a
   program does not use that macro then it should call
@@ -27,6 +27,7 @@
 - Added `DiskIo` and `DiskIo2` protocols.
 - Added `HardDriveMediaDevicePath` and related types.
 - Added `PartialOrd` and `Ord` to the traits derived by `Guid`.
+- Added `TryFrom<core::ffi::CStr>` implementation for `CStr8`.
 
 ### Fixed
 

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -103,7 +103,7 @@ impl CStr8 {
     ///
     /// # Safety
     ///
-    /// It's the callers responsability to ensure chars is a valid Latin-1
+    /// It's the callers responsibility to ensure chars is a valid Latin-1
     /// null-terminated string, with no interior null bytes.
     pub unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
         &*(chars as *const [u8] as *const Self)
@@ -185,7 +185,7 @@ impl CStr16 {
     /// # Safety
     ///
     /// The function will start accessing memory from `ptr` until the first
-    /// null byte. It's the callers responsability to ensure `ptr` points to
+    /// null byte. It's the callers responsibility to ensure `ptr` points to
     /// a valid string, in accessible memory.
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char16) -> &'ptr Self {
         let mut len = 0;
@@ -223,7 +223,7 @@ impl CStr16 {
     ///
     /// # Safety
     ///
-    /// It's the callers responsability to ensure chars is a valid UCS-2
+    /// It's the callers responsibility to ensure chars is a valid UCS-2
     /// null-terminated string, with no interior null bytes.
     pub unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
         &*(codes as *const [u16] as *const Self)


### PR DESCRIPTION
- CStr8 can now be constructed from core::ffi::CStr
- CStr8 now also implements EqStrUntilNul
- some streamlining with the existing and more mature CStr16 type

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)
