### PR TITLE
rustdoc cleanup: use rustdoc attribute

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-04-18"
+channel = "nightly-2022-09-14"
 components = ["rust-src"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
           cargo xtask clippy --warnings-as-errors
 
       - name: Run cargo doc
-        run: cargo xtask doc --warnings-as-errors
+        run: cargo xtask doc
 
   miri:
     name: Run unit tests and doctests under Miri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the definition of `AllocateType` so that `MaxAddress` and
   `Address` always take a 64-bit value, regardless of target platform.
+- The MSRV is `nightly-2022-09-14` (`1.65.0`)
 
 ## uefi-macros - [Unreleased]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@
 // Enable some additional warnings and lints.
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
+#![deny(rustdoc::all)]
+// todo remove once https://github.com/rust-lang/rust/issues/101730 is stable
+#![feature(rustdoc_missing_doc_code_examples)]
+#![allow(rustdoc::missing_doc_code_examples)]
 
 // `uefi-exts` requires access to memory allocation APIs.
 #[cfg(feature = "exts")]

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -1,4 +1,10 @@
 #![recursion_limit = "128"]
+#![deny(rustdoc::all)]
+// todo remove once https://github.com/rust-lang/rust/issues/101730 is stable
+#![feature(rustdoc_missing_doc_code_examples)]
+#![allow(rustdoc::missing_doc_code_examples)]
+
+//! Code generation macros for the `uefi` crate.
 
 extern crate proc_macro;
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -19,6 +19,10 @@
 #![no_std]
 #![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
+#![deny(rustdoc::all)]
+// todo remove once https://github.com/rust-lang/rust/issues/101730 is stable
+#![feature(rustdoc_missing_doc_code_examples)]
+#![allow(rustdoc::missing_doc_code_examples)]
 
 #[macro_use]
 extern crate log;

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -146,9 +146,6 @@ impl Cargo {
             }
             CargoAction::Doc { open } => {
                 action = "doc";
-                if self.warnings_as_errors {
-                    cmd.env("RUSTDOCFLAGS", "-Dwarnings");
-                }
                 if open {
                     extra_args.push("--open");
                 }
@@ -237,11 +234,11 @@ mod tests {
             packages: vec![Package::Uefi, Package::Xtask],
             release: false,
             target: None,
-            warnings_as_errors: true,
+            warnings_as_errors: false,
         };
         assert_eq!(
             command_to_string(&cargo.command().unwrap()),
-            "RUSTDOCFLAGS=-Dwarnings cargo doc --package uefi --package xtask --features alloc --open"
+            "cargo doc --package uefi --package xtask --features alloc --open"
         );
     }
 }


### PR DESCRIPTION
- Cleanup of rustdoc.
- Use rustdoc attribute instead of a program argument. 
- Fixed a rustdoc bug.

The disadvantage is now that people can't run `cargo doc` as this fails now. They must use `cargo xtask doc` or `cargo doc --features alloc,exts,logger`.

PS: We are right now in a time where there are changes regarding the "missing_doc_code_examples" lint inside latest upstream/nightly Rust. 14 days ago, this [tracking issue](https://github.com/rust-lang/rust/issues/101730) was created. Relevant for us is that `#![allow(missing_doc_code_examples)]` is deprecated but `#![allow(rustdoc::missing_doc_code_examples)]` requires `#![feature(rustdoc_missing_doc_code_examples)]`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)
