### PR TITLE
Change DevicePath[From|To]Text methods to return a Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fixed the definition of `AllocateType` so that `MaxAddress` and
   `Address` always take a 64-bit value, regardless of target platform.
+- The conversion methods on `DevicePathToText` and `DevicePathFromText`
+  now return a `uefi::Result` instead of an `Option`.
 
 ## uefi-macros - [Unreleased]
 


### PR DESCRIPTION
The specification of the conversion functions is a little unusual in that they return a pointer rather than `EFI_STATUS`, and that's reflected in us previously returning an `Option` here, but `Result` is more appropriate for a Rust API.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
