### PR TITLE
Switch the toolchain back to latest nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,5 @@
 [toolchain]
-# Pinned due to https://github.com/rust-osdev/uefi-rs/issues/500.
-#
-# Compilation started failing 2022-09-02. The previous several builds
-# don't have miri available though, so pin to a slightly older version.
-channel = "nightly-2022-08-26"
+channel = "nightly"
 
 # Install the `rust-src` component so that `-Zbuild-std` works. This in
 # addition to the components included in the default profile.

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-# Pinned due to https://github.com/rust-osdev/uefi-rs/issues/500.
-channel = "nightly-2022-09-01"
+channel = "nightly"
 components = ["rust-src"]

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -141,7 +141,7 @@ impl Cargo {
             CargoAction::Clippy => {
                 action = "clippy";
                 if self.warnings_as_errors {
-                    tool_args.extend(&["-D", "warnings"]);
+                    tool_args.extend(["-D", "warnings"]);
                 }
             }
             CargoAction::Doc { open } => {
@@ -172,7 +172,7 @@ impl Cargo {
         }
 
         if let Some(target) = self.target {
-            cmd.args(&[
+            cmd.args([
                 "--target",
                 target.as_triple(),
                 "-Zbuild-std=core,compiler_builtins,alloc",
@@ -184,11 +184,11 @@ impl Cargo {
             bail!("packages cannot be empty");
         }
         for package in &self.packages {
-            cmd.args(&["--package", package.as_str()]);
+            cmd.args(["--package", package.as_str()]);
         }
 
         if !self.features.is_empty() {
-            cmd.args(&[
+            cmd.args([
                 "--features",
                 &Feature::comma_separated_string(&self.features),
             ]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -154,7 +154,7 @@ fn test_latest_release() -> Result<()> {
     let tmp_dir = tmp_dir.path();
     let mut cp_cmd = Command::new("cp");
     cp_cmd
-        .args(&["--recursive", "--verbose", "template"])
+        .args(["--recursive", "--verbose", "template"])
         .arg(tmp_dir);
     run_cmd(cp_cmd)?;
 
@@ -163,7 +163,7 @@ fn test_latest_release() -> Result<()> {
     let mut build_cmd = Command::new("cargo");
     fix_nested_cargo_env(&mut build_cmd);
     build_cmd
-        .args(&["build", "--target", "x86_64-unknown-uefi"])
+        .args(["build", "--target", "x86_64-unknown-uefi"])
         .current_dir(tmp_dir.join("template"));
 
     // Check that the command is indeed in BUILDING.md, then verify the

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -90,7 +90,7 @@ fn windows_open_pipe(path: &Path) -> Result<File> {
     loop {
         attempt += 1;
 
-        match OpenOptions::new().read(true).write(true).open(&path) {
+        match OpenOptions::new().read(true).write(true).open(path) {
             Ok(file) => return Ok(file),
             Err(err) => {
                 if attempt >= max_attempts {

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -420,27 +420,27 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // QEMU by defaults enables a ton of devices which slow down boot.
     cmd.arg("-nodefaults");
 
-    cmd.args(&["-device", "virtio-rng-pci"]);
+    cmd.args(["-device", "virtio-rng-pci"]);
 
     match arch {
         UefiArch::AArch64 => {
             // Use a generic ARM environment. Sadly qemu can't emulate a
             // RPi 4 like machine though.
-            cmd.args(&["-machine", "virt"]);
+            cmd.args(["-machine", "virt"]);
 
             // A72 is a very generic 64-bit ARM CPU in the wild.
-            cmd.args(&["-cpu", "cortex-a72"]);
+            cmd.args(["-cpu", "cortex-a72"]);
         }
         UefiArch::IA32 => {}
         UefiArch::X86_64 => {
             // Use a modern machine.
-            cmd.args(&["-machine", "q35"]);
+            cmd.args(["-machine", "q35"]);
 
             // Multi-processor services protocol test needs exactly 4 CPUs.
-            cmd.args(&["-smp", "4"]);
+            cmd.args(["-smp", "4"]);
 
             // Allocate some memory.
-            cmd.args(&["-m", "256M"]);
+            cmd.args(["-m", "256M"]);
 
             // Enable hardware-accelerated virtualization if possible.
             if platform::is_linux() && !opt.disable_kvm && !opt.ci {
@@ -453,11 +453,11 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
             }
 
             // Map the QEMU exit signal to port f4.
-            cmd.args(&["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"]);
+            cmd.args(["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"]);
 
             // OVMF debug builds can output information to a serial `debugcon`.
             // Only enable when debugging UEFI boot.
-            // cmd.args(&[
+            // cmd.args([
             //     "-debugcon",
             //     "file:debug.log",
             //     "-global",
@@ -489,9 +489,9 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
 
     // When running in headless mode we don't have video, but we can still have
     // QEMU emulate a display and take screenshots from it.
-    cmd.args(&["-vga", "std"]);
+    cmd.args(["-vga", "std"]);
     if opt.headless {
-        cmd.args(&["-display", "none"]);
+        cmd.args(["-display", "none"]);
     }
 
     let test_disk = tmp_dir.join("test_disk.fat.img");
@@ -511,14 +511,14 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // and send the response. That second will also receive logs up
     // until the test runner opens the handle in exclusive mode, but we
     // can just read and ignore those lines.
-    cmd.args(&["-serial", "stdio"]);
-    cmd.args(&["-serial", serial_pipe.qemu_arg()]);
+    cmd.args(["-serial", "stdio"]);
+    cmd.args(["-serial", serial_pipe.qemu_arg()]);
 
     // Map the QEMU monitor to a pair of named pipes
-    cmd.args(&["-qmp", qemu_monitor_pipe.qemu_arg()]);
+    cmd.args(["-qmp", qemu_monitor_pipe.qemu_arg()]);
 
     // Attach network device with DHCP configured for PXE
-    cmd.args(&[
+    cmd.args([
         "-nic",
         "user,model=e1000,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",
     ]);


### PR DESCRIPTION
The bug in nightly Rust that was causing problems for us has been fixed, so switch back to latest nightly. (The other changes are due to the current nightly clippy warning about some unnecessary borrows.)

Fixes https://github.com/rust-osdev/uefi-rs/issues/500

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
