### PR TITLE
ci: Test the build on an old nightly

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Oldest nightly that currently works with `cargo xtask build`.
+channel = "nightly-2022-04-18"
+components = ["rust-src"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,3 +157,21 @@ jobs:
 
       - name: Build
         run: cargo xtask build
+
+  # Run the build with our current nightly MSRV (specified in
+  # ./msrv_toolchain.toml). This serves to check that we don't
+  # accidentally start relying on a new feature without intending
+  # to. Having a test for this makes it easier for us to be intentional
+  # about making changes that require a newer version.
+  build_msrv:
+    name: Check that the build works on our nightly MSRV
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Set toolchain
+      run: cp .github/workflows/msrv_toolchain.toml rust-toolchain.toml
+
+    - name: Build
+      run: cargo xtask build

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ prerequisites for running the tests.
 
 For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
 
+The uefi-rs crates currently require some [unstable features].
+The nightly MSRV is currently 2022-04-18.
+
+[unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
+
 ## Contributing
 
 We welcome issues and pull requests! For instructions on how to set up a development


### PR DESCRIPTION
Add a CI job that runs `cargo xtask build` with an old nightly. Currently the oldest nightly that works is 2022-04-18. There's nothing particularly magic about that version; we can require a newer version when we deem it appropriate. Having this CI job just makes it easy for us to identify in advance when a PR is going to require a newer nightly, while still allowing other CI jobs to use latest nightly.

This change is related to (but not a fix for): https://github.com/rust-osdev/uefi-rs/issues/510

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)
