### PR TITLE
Add PhysicalAddress and VirtualAddress type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## uefi - [Unreleased]
 
+### Added
+
+- Added `PhysicalAddress` and `VirtualAddress` type aliases.
+
+### Changed
+
+- Fixed the definition of `AllocateType` so that `MaxAddress` and
+  `Address` always take a 64-bit value, regardless of target platform.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -107,6 +107,14 @@ pub trait Align {
     }
 }
 
+/// Physical memory address. This is always a 64-bit value, regardless
+/// of target platform.
+pub type PhysicalAddress = u64;
+
+/// Virtual memory address. This is always a 64-bit value, regardless
+/// of target platform.
+pub type VirtualAddress = u64;
+
 mod guid;
 pub use self::guid::Guid;
 pub use self::guid::{unsafe_guid, Identify};

--- a/src/proto/security/memory_protection.rs
+++ b/src/proto/security/memory_protection.rs
@@ -1,3 +1,4 @@
+use crate::data_types::PhysicalAddress;
 use crate::proto::Protocol;
 use crate::table::boot::MemoryAttribute;
 use crate::{unsafe_guid, Result, Status};
@@ -14,21 +15,21 @@ use core::ops::Range;
 pub struct MemoryProtection {
     get_memory_attributes: unsafe extern "efiapi" fn(
         this: *const Self,
-        base_address: u64,
+        base_address: PhysicalAddress,
         length: u64,
         attributes: *mut MemoryAttribute,
     ) -> Status,
 
     set_memory_attributes: unsafe extern "efiapi" fn(
         this: *const Self,
-        base_address: u64,
+        base_address: PhysicalAddress,
         length: u64,
         attributes: MemoryAttribute,
     ) -> Status,
 
     clear_memory_attributes: unsafe extern "efiapi" fn(
         this: *const Self,
-        base_address: u64,
+        base_address: PhysicalAddress,
         length: u64,
         attributes: MemoryAttribute,
     ) -> Status,
@@ -46,7 +47,10 @@ impl MemoryProtection {
     /// [`READ_PROTECT`]: MemoryAttribute::READ_PROTECT
     /// [`EXECUTE_PROTECT`]: MemoryAttribute::EXECUTE_PROTECT
     /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
-    pub fn get_memory_attributes(&self, byte_region: Range<u64>) -> Result<MemoryAttribute> {
+    pub fn get_memory_attributes(
+        &self,
+        byte_region: Range<PhysicalAddress>,
+    ) -> Result<MemoryAttribute> {
         let mut attributes = MemoryAttribute::empty();
         let (base_address, length) = range_to_base_and_len(byte_region);
         unsafe {
@@ -65,7 +69,7 @@ impl MemoryProtection {
     /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
     pub fn set_memory_attributes(
         &self,
-        byte_region: Range<u64>,
+        byte_region: Range<PhysicalAddress>,
         attributes: MemoryAttribute,
     ) -> Result {
         let (base_address, length) = range_to_base_and_len(byte_region);
@@ -82,7 +86,7 @@ impl MemoryProtection {
     /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
     pub fn clear_memory_attributes(
         &self,
-        byte_region: Range<u64>,
+        byte_region: Range<PhysicalAddress>,
         attributes: MemoryAttribute,
     ) -> Result {
         let (base_address, length) = range_to_base_and_len(byte_region);
@@ -91,7 +95,7 @@ impl MemoryProtection {
 }
 
 /// Convert a byte `Range` to `(base_address, length)`.
-fn range_to_base_and_len(r: Range<u64>) -> (u64, u64) {
+fn range_to_base_and_len(r: Range<PhysicalAddress>) -> (PhysicalAddress, PhysicalAddress) {
     (r.start, r.end.checked_sub(r.start).unwrap())
 }
 


### PR DESCRIPTION
These correspond to `EFI_PHYSICAL_ADDRESS` and `EFI_VIRTUAL_ADDRESS`. These usually end up being converted to a pointer type, but notably they are always 64-bit regardless of the target platform. This change revealed a bug in the `AllocateType` enum; it was using `usize` for a couple members, but that is not correct for all targets, e.g. `i686-unknown-uefi`.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
