### PR TITLE
uefi-services: Change panic handler log message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@
 
 - The `no_panic_handler` feature has been replaced with an additive
   `panic_handler` feature. The new feature is enabled by default.
+- Changed the panic handler log message to use `println!` instead of
+  `error!`. This removes an extraneous file name and line number from
+  the log message.
 
 ## uefi - 0.16.1
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -181,7 +181,7 @@ unsafe extern "efiapi" fn exit_boot_services(_e: Event, _ctx: Option<NonNull<c_v
 #[cfg(feature = "panic_handler")]
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    error!("{}", info);
+    println!("[PANIC]: {}", info);
 
     // Give the user some time to read the message
     if let Some(st) = unsafe { SYSTEM_TABLE.as_ref() } {


### PR DESCRIPTION
The panic handler now displays its log message using `println!` instead of `error!`. The message prefix is altered from [ERROR] to [PANIC]. The extraneous filename and line number printed by `error!` are also removed from the log message.

Previously, the panic handler in `uefi-services` would use `error!` to print a log message. By using `error!`, the log message would also include the file name and line number of the panic handler function. As the file name and line number where the panic originated from are logged using the `PanicInfo` struct, this information is not necessary. By printing the log message with `println!` instead of `error!` this unnecessary information can be removed.

## Example

I temporarily added a panic call to the uefi test runner to show the panic log messages:

```rust
    // ...

    // uefi-test-runner/src/main.rs@21
    // Initialize utilities (logging, memory allocation...)
    uefi_services::init(&mut st).expect("Failed to initialize utilities");

    // test a call to panic
    panic!("Here is a panic!");

    // unit tests here

    // output firmware-vendor (CStr16 to Rust string)
    let mut buf = String::new();

    // ...
```

Log message before this commit:
```
[ERROR]: uefi-services/src/lib.rs@184: panicked at 'Here is a panic!', uefi-test-runner/src/main.rs:25:5
```

Log message after commit:
```
[PANIC]: panicked at 'Here is a panic!', uefi-test-runner/src/main.rs:25:5
```

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
