### PR TITLE
Fix warning from unneeded `macro_use`

### DIFF
--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -20,7 +20,6 @@
 #![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
 
-#[macro_use]
 extern crate log;
 // Core types.
 extern crate uefi;
@@ -212,7 +211,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             }
 
             // If we don't have any shutdown mechanism handy, the best we can do is loop
-            error!("Could not shut down, please power off the system manually...");
+            log::error!("Could not shut down, please power off the system manually...");
 
             cfg_if! {
                 if #[cfg(target_arch = "x86_64")] {


### PR DESCRIPTION
Fixup for https://github.com/rust-osdev/uefi-rs/pull/526

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
