### PR TITLE
Add option to disable network tests

### DIFF
--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -101,6 +101,10 @@ pub struct QemuOpt {
     #[clap(long, action)]
     pub disable_kvm: bool,
 
+    /// Disable network tests.
+    #[clap(long, action)]
+    pub disable_network: bool,
+
     /// Disable some tests that don't work in the CI.
     #[clap(long, action)]
     pub ci: bool,

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -523,7 +523,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
 
     // Attach network device with DHCP configured for PXE. Skip this for
     // examples since it slows down the boot some.
-    let echo_service = if opt.example.is_none() {
+    let echo_service = if !opt.disable_network && opt.example.is_none() {
         cmd.args([
             "-nic",
             "user,model=e1000,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",


### PR DESCRIPTION
`cargo xtask run` now takes a `--disable-network` arg that turns off the network protocol tests by not creating a network device.

The purpose of this flag is to make the QEMU tests faster when iterating on something locally. Disabling the network stuff drops the time down from ~12.5s to ~4.5s. The extra time doesn't matter when running in CI, but for quick local testing it can add up.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
