### PR TITLE
Fixes and improvements for `Revision`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   may not have the same semantics as the UEFI revision.
 - Changed `Revision` to `repr(transparent)`.
 - Add `Revision::EFI_2_100` constant.
+- The `Revision` type now implements `Display` with correct formatting
+  for all UEFI versions. The custom `Debug` impl has been removed and
+  replaced with a derived `Debug` impl.
 
 ## uefi-macros - [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Changed `SystemTable::firmware_revision` to return a `u32` instead of
   a `Revision`. The firmware revision's format is vendor specific and
   may not have the same semantics as the UEFI revision.
+- Changed `Revision` to `repr(transparent)`.
 
 ## uefi-macros - [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - The conversion methods on `DevicePathToText` and `DevicePathFromText`
   now return a `uefi::Result` instead of an `Option`.
 - `Event` is now a newtype around `NonNull<c_void>` instead of `*mut c_void`.
+- Changed `SystemTable::firmware_revision` to return a `u32` instead of
+  a `Revision`. The firmware revision's format is vendor specific and
+  may not have the same semantics as the UEFI revision.
 
 ## uefi-macros - [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   a `Revision`. The firmware revision's format is vendor specific and
   may not have the same semantics as the UEFI revision.
 - Changed `Revision` to `repr(transparent)`.
+- Add `Revision::EFI_2_100` constant.
 
 ## uefi-macros - [Unreleased]
 

--- a/src/table/revision.rs
+++ b/src/table/revision.rs
@@ -7,6 +7,7 @@ use core::fmt;
 /// The minor revision number is incremented on minor changes,
 /// it is stored as a two-digit binary-coded decimal.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
 pub struct Revision(u32);
 
 // Allow missing docs, there's nothing useful to document about these

--- a/src/table/revision.rs
+++ b/src/table/revision.rs
@@ -27,6 +27,7 @@ impl Revision {
     pub const EFI_2_70: Self = Self::new(2, 70);
     pub const EFI_2_80: Self = Self::new(2, 80);
     pub const EFI_2_90: Self = Self::new(2, 90);
+    pub const EFI_2_100: Self = Self::new(2, 100);
 }
 
 impl Revision {

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -58,7 +58,7 @@ impl<View: SystemTableView> SystemTable<View> {
     }
 
     /// Return the firmware revision
-    pub fn firmware_revision(&self) -> Revision {
+    pub fn firmware_revision(&self) -> u32 {
         self.table.fw_revision
     }
 
@@ -296,8 +296,7 @@ struct SystemTableImpl {
     header: Header,
     /// Null-terminated string representing the firmware's vendor.
     fw_vendor: *const Char16,
-    /// Revision of the UEFI specification the firmware conforms to.
-    fw_revision: Revision,
+    fw_revision: u32,
     stdin_handle: Handle,
     stdin: *mut text::Input,
     stdout_handle: Handle,


### PR DESCRIPTION
* Changed firmware-revision to an opaque `u32` instead of a `Revision`. The `Revision` type is specific to a UEFI revision, but the firmware revision doesn't have any defined semantics (it's not necessarily a major.minor format).
* Fixed the repr for `Revision` to be transparent
* Added `EFI_2_100` for the latest spec revision
* Added a new `Display` impl for `Revision` that formats correctly for all spec versions.
* Replaced the custom `Debug` impl with a derived impl; the new `Display` impl can be used for pretty formatting.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)
