### PR TITLE
ci: Simplify some jobs with ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,16 +15,13 @@ on:
 jobs:
   test_aarch64:
     name: Build and run tests on AArch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
 
     - name: Install qemu and OVMF
       run: |
-        # Ubuntu 20.04 provides qemu 4.2, which crashes on exit in this
-        # test. Add a PPA to provide a more recent version of qemu.
-        sudo add-apt-repository ppa:canonical-server/server-backports
         sudo apt-get update
         sudo apt-get install qemu-system-arm qemu-efi-aarch64 -y
 
@@ -56,37 +53,21 @@ jobs:
 
   test_ia32:
     name: Build and run tests on IA32
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
 
-    - name: Install qemu
+    - name: Install qemu and OVMF
       run: |
-        # Ubuntu 20.04 provides qemu 4.2, which crashes on exit in this
-        # test. Add a PPA to provide a more recent version of qemu.
-        sudo add-apt-repository ppa:canonical-server/server-backports
         sudo apt-get update
-        sudo apt-get install qemu-system-x86 -y
-
-    # Starting in ubuntu 21.04 there's an `ovmf-ia32` package, but the
-    # github runners are on ubuntu 20.04. For now, install the OVMF
-    # files from a repo that provides unofficial nightly builds:
-    # https://github.com/retrage/edk2-nightly
-    - name: Install OVMF
-      env:
-        # Pin to a specific commit in the retrage/edk2-nightly repo to
-        # guard against external changes breaking the CI.
-        EDK2_NIGHTLY_COMMIT: 'ebb83e5475d49418afc32857f66111949928bcdc'
-      run: |
-        curl -o OVMF32_CODE.fd https://raw.githubusercontent.com/retrage/edk2-nightly/${EDK2_NIGHTLY_COMMIT}/bin/RELEASEIa32_OVMF_CODE.fd
-        curl -o OVMF32_VARS.fd https://raw.githubusercontent.com/retrage/edk2-nightly/${EDK2_NIGHTLY_COMMIT}/bin/RELEASEIa32_OVMF_VARS.fd
+        sudo apt-get install qemu-system-x86 ovmf-ia32 -y
 
     - name: Build
       run: cargo xtask build --target ia32
 
     - name: Run VM tests
-      run: cargo xtask run --target ia32 --headless --ci --ovmf-code OVMF32_CODE.fd --ovmf-vars OVMF32_VARS.fd
+      run: cargo xtask run --target ia32 --headless --ci
       timeout-minutes: 2
 
   test:

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -403,8 +403,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
 
     let qemu_exe = match arch {
         UefiArch::AArch64 => "qemu-system-aarch64",
-        UefiArch::IA32 => "qemu-system-i386",
-        UefiArch::X86_64 => "qemu-system-x86_64",
+        UefiArch::IA32 | UefiArch::X86_64 => "qemu-system-x86_64",
     };
     let mut cmd = Command::new(qemu_exe);
 
@@ -435,8 +434,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
             // A72 is a very generic 64-bit ARM CPU in the wild.
             cmd.args(["-cpu", "cortex-a72"]);
         }
-        UefiArch::IA32 => {}
-        UefiArch::X86_64 => {
+        UefiArch::IA32 | UefiArch::X86_64 => {
             // Use a modern machine.
             cmd.args(["-machine", "q35"]);
 


### PR DESCRIPTION
The aarch64 and ia32 jobs had some extra complexity to get a working OVMF on ubuntu-20.04. Now that there are ubuntu-22.04 runners available, switch the jobs to that version and use the provided OVMF packages.

This change exposed an issue with `--target ia32`; it didn't work with the `ovmf-ia32` package on Ubuntu. Fixed by running the ia32 target using the same settings as x86_64. The important difference is really `-machine q35`, but we might as well share all the settings.

Running the 32-bit firmware on a 64-bit machine is actually a slightly more realistic test than running it on a 32-bit machine, since (at least to my knowledge) ia32 UEFI on a 64-bit CPU is more commonly found on real hardware than on a 32-bit CPU.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
