### PR TITLE
Tweak pull request template wrapping

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,5 @@
 *Descriptive summary of your bugfix, feature, or refactoring.*
 
 ## Checklist
-- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
-      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
-      help.
+- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
 - [ ] Update the changelog (if necessary)


### PR DESCRIPTION
Github renders the line breaks in the template, so for the "sensible git history" item it gets split across three lines in the PR description. Change it to a single line just to be a little prettier.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [x] Update the changelog (if necessary)
