### PR TITLE
Don't explicitly require compiler-builtins(-mem)

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-04-18"
+channel = "nightly-2022-08-08"
 components = ["rust-src"]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ prerequisites for running the tests.
 For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
 
 The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-04-18.
+The nightly MSRV is currently 2022-08-08.
 
 [unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
 

--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -24,8 +24,7 @@ Run this command to build the application:
 
 ```sh
 cargo build --target x86_64-unknown-uefi \
-    -Zbuild-std=core,compiler_builtins,alloc \
-    -Zbuild-std-features=compiler-builtins-mem
+    -Zbuild-std=core,alloc
 ```
 
 This will produce an x86-64 executable:
@@ -49,8 +48,7 @@ Create `.cargo/config.toml` with these contents:
 target = "x86_64-unknown-uefi"
 
 [unstable]
-build-std = ["core", "compiler_builtins", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std = ["core", "alloc"]
 ```
 
 Now you can build much more simply:

--- a/template/.cargo/config
+++ b/template/.cargo/config
@@ -1,3 +1,2 @@
 [unstable]
-build-std = ["core", "compiler_builtins", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std = ["core", "alloc"]

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -221,12 +221,7 @@ impl Cargo {
         }
 
         if let Some(target) = self.target {
-            cmd.args([
-                "--target",
-                target.as_triple(),
-                "-Zbuild-std=core,compiler_builtins,alloc",
-                "-Zbuild-std-features=compiler-builtins-mem",
-            ]);
+            cmd.args(["--target", target.as_triple(), "-Zbuild-std=core,alloc"]);
         }
 
         if self.packages.is_empty() {


### PR DESCRIPTION
They are implicit on uefi as of https://github.com/rust-lang/compiler-builtins/pull/473 from June, so we can simplify the examples and the build stuff a bit. This is sort of a follow-up to #298.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)

I'm not sure whether updating the changelog is necessary as this doesn't really break anything.
Though, this only works with a nightly compiler newer than 2022-08-07, so I guess you might