### PR TITLE
Add `guid!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ## uefi-macros - [Unreleased]
 
+### Added
+
+- Added a `guid!` macro. This is similar to `Guid::from_values`, but
+  takes a more convenient string argument like the `unsafe_guid!`
+  attribute macro.
+
 ## uefi-services - [Unreleased]
 
 ## uefi - 0.17.0

--- a/src/data_types/guid.rs
+++ b/src/data_types/guid.rs
@@ -110,7 +110,7 @@ pub use uefi_macros::unsafe_guid;
 
 #[cfg(test)]
 mod tests {
-    use uefi::unsafe_guid;
+    use uefi::{guid, unsafe_guid};
     extern crate alloc;
     use super::*;
 
@@ -126,7 +126,15 @@ mod tests {
     }
 
     #[test]
-    fn test_unsafe_guid() {
+    fn test_guid_macro() {
+        assert_eq!(
+            guid!("12345678-9abc-def0-1234-56789abcdef0"),
+            Guid::from_values(0x12345678, 0x9abc, 0xdef0, 0x1234, 0x56789abcdef0)
+        );
+    }
+
+    #[test]
+    fn test_unsafe_guid_macro() {
         #[unsafe_guid("12345678-9abc-def0-1234-56789abcdef0")]
         struct X;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod data_types;
 pub use self::data_types::CString16;
 pub use self::data_types::{unsafe_guid, Identify};
 pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
+pub use uefi_macros::guid;
 
 mod result;
 pub use self::result::{Error, Result, ResultExt, Status};

--- a/src/proto/device_path/mod.rs
+++ b/src/proto/device_path/mod.rs
@@ -684,7 +684,7 @@ newtype_enum! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::CString16;
+    use crate::{guid, CString16};
     use alloc_api::vec::Vec;
 
     /// Create a node to `path` from raw data.
@@ -857,12 +857,8 @@ mod tests {
         assert_eq!(hdm.partition_start(), 128);
         assert_eq!(
             hdm.partition_signature(),
-            Some(PartitionSignature::GUID(Guid::from_values(
-                0x41aa39a0,
-                0x3d35,
-                0x4f84,
-                0xb195,
-                0xae3a950bfbad
+            Some(PartitionSignature::GUID(guid!(
+                "41aa39a0-3d35-4f84-b195-ae3a950bfbad"
             )))
         );
     }

--- a/src/proto/media/partition.rs
+++ b/src/proto/media/partition.rs
@@ -1,7 +1,7 @@
 //! Partition information protocol.
 
 use crate::proto::Protocol;
-use crate::{unsafe_guid, Char16, Guid};
+use crate::{guid, unsafe_guid, Char16, Guid};
 use bitflags::bitflags;
 
 newtype_enum! {
@@ -55,31 +55,13 @@ newtype_enum! {
     /// Partition Type GUIDs.
     pub enum GptPartitionType: Guid => {
         /// Indicates a partition entry is unused.
-        UNUSED_ENTRY = Guid::from_values(
-            0x00000000,
-            0x0000,
-            0x0000,
-            0x0000,
-            0x000000000000,
-        ),
+        UNUSED_ENTRY = guid!("00000000-0000-0000-0000-000000000000"),
 
         /// EFI System Partition.
-        EFI_SYSTEM_PARTITION = Guid::from_values(
-            0xc12a7328,
-            0xf81f,
-            0x11d2,
-            0xba4b,
-            0x00a0c93ec93b,
-        ),
+        EFI_SYSTEM_PARTITION = guid!("c12a7328-f81f-11d2-ba4b-00a0c93ec93b"),
 
         /// Partition containing a legacy MBR.
-        LEGACY_MBR = Guid::from_values(
-            0x024dee41,
-            0x33e7,
-            0x11d3,
-            0x9d69,
-            0x0008c781f39f,
-        ),
+        LEGACY_MBR = guid!("024dee41-33e7-11d3-9d69-0008c781f39f"),
     }
 }
 

--- a/src/proto/rng.rs
+++ b/src/proto/rng.rs
@@ -1,6 +1,6 @@
 //! `Rng` protocol.
 
-use crate::{data_types::Guid, proto::Protocol, unsafe_guid, Result, Status};
+use crate::{data_types::Guid, guid, proto::Protocol, unsafe_guid, Result, Status};
 use core::{mem, ptr};
 
 newtype_enum! {
@@ -9,69 +9,27 @@ newtype_enum! {
     pub enum RngAlgorithmType: Guid => {
         /// Indicates a empty algorithm, used to instantiate a buffer
         /// for `get_info`
-        EMPTY_ALGORITHM = Guid::from_values(
-            0x00000000,
-            0x0000,
-            0x0000,
-            0x0000,
-            0x000000000000,
-        ),
+        EMPTY_ALGORITHM = guid!("00000000-0000-0000-0000-000000000000"),
 
         /// The “raw” algorithm, when supported, is intended to provide
         /// entropy directly from the source, without it going through
         /// some deterministic random bit generator.
-        ALGORITHM_RAW = Guid::from_values(
-            0xe43176d7,
-            0xb6e8,
-            0x4827,
-            0xb784,
-            0x7ffdc4b68561,
-        ),
+        ALGORITHM_RAW = guid!("e43176d7-b6e8-4827-b784-7ffdc4b68561"),
 
         /// ALGORITHM_SP800_90_HASH_256
-        ALGORITHM_SP800_90_HASH_256 = Guid::from_values(
-            0xa7af67cb,
-            0x603b,
-            0x4d42,
-            0xba21,
-            0x70bfb6293f96,
-        ),
+        ALGORITHM_SP800_90_HASH_256 = guid!("a7af67cb-603b-4d42-ba21-70bfb6293f96"),
 
         /// ALGORITHM_SP800_90_HMAC_256
-        ALGORITHM_SP800_90_HMAC_256 = Guid::from_values(
-            0xc5149b43,
-            0xae85,
-            0x4f53,
-            0x9982,
-            0xb94335d3a9e7,
-        ),
+        ALGORITHM_SP800_90_HMAC_256 = guid!("c5149b43-ae85-4f53-9982-b94335d3a9e7"),
 
         /// ALGORITHM_SP800_90_CTR_256
-        ALGORITHM_SP800_90_CTR_256 = Guid::from_values(
-            0x44f0de6e,
-            0x4d8c,
-            0x4045,
-            0xa8c7,
-            0x4dd168856b9e,
-        ),
+        ALGORITHM_SP800_90_CTR_256 = guid!("44f0de6e-4d8c-4045-a8c7-4dd168856b9e"),
 
         /// ALGORITHM_X9_31_3DES
-        ALGORITHM_X9_31_3DES = Guid::from_values(
-            0x63c4785a,
-            0xca34,
-            0x4012,
-            0xa3c8,
-            0x0b6a324f5546,
-        ),
+        ALGORITHM_X9_31_3DES = guid!("63c4785a-ca34-4012-a3c8-0b6a324f5546"),
 
         /// ALGORITHM_X9_31_AES
-        ALGORITHM_X9_31_AES = Guid::from_values(
-            0xacd03321,
-            0x777e,
-            0x4d3d,
-            0xb1c8,
-            0x20cfd88820c9,
-        ),
+        ALGORITHM_X9_31_AES = guid!("acd03321-777e-4d3d-b1c8-20cfd88820c9"),
     }
 }
 

--- a/src/table/cfg.rs
+++ b/src/table/cfg.rs
@@ -7,7 +7,7 @@
 //! This module contains the actual entries of the configuration table,
 //! as well as GUIDs for many known vendor tables.
 
-use crate::Guid;
+use crate::{guid, Guid};
 use bitflags::bitflags;
 use core::ffi::c_void;
 
@@ -25,24 +25,22 @@ pub struct ConfigTableEntry {
     pub address: *const c_void,
 }
 /// Entry pointing to the old ACPI 1 RSDP.
-pub const ACPI_GUID: Guid = Guid::from_values(0xeb9d2d30, 0x2d88, 0x11d3, 0x9a16, 0x0090273fc14d);
+pub const ACPI_GUID: Guid = guid!("eb9d2d30-2d88-11d3-9a16-0090273fc14d");
 
 ///Entry pointing to the ACPI 2 RSDP.
-pub const ACPI2_GUID: Guid = Guid::from_values(0x8868e871, 0xe4f1, 0x11d3, 0xbc22, 0x0080c73c8881);
+pub const ACPI2_GUID: Guid = guid!("8868e871-e4f1-11d3-bc22-0080c73c8881");
 
 /// Entry pointing to the SMBIOS 1.0 table.
-pub const SMBIOS_GUID: Guid = Guid::from_values(0xeb9d2d31, 0x2d88, 0x11d3, 0x9a16, 0x0090273fc14d);
+pub const SMBIOS_GUID: Guid = guid!("eb9d2d31-2d88-11d3-9a16-0090273fc14d");
 
 /// Entry pointing to the SMBIOS 3.0 table.
-pub const SMBIOS3_GUID: Guid =
-    Guid::from_values(0xf2fd1544, 0x9794, 0x4a2c, 0x992e, 0xe5bbcf20e394);
+pub const SMBIOS3_GUID: Guid = guid!("f2fd1544-9794-4a2c-992e-e5bbcf20e394");
 
 /// GUID of the UEFI properties table.
 ///
 /// The properties table is used to provide additional info
 /// about the UEFI implementation.
-pub const PROPERTIES_TABLE_GUID: Guid =
-    Guid::from_values(0x880aaca3, 0x4adc, 0x4a04, 0x9079, 0xb747340825e5);
+pub const PROPERTIES_TABLE_GUID: Guid = guid!("880aaca3-4adc-4a04-9079-b747340825e5");
 
 /// This table contains additional information about the UEFI implementation.
 #[repr(C)]
@@ -71,30 +69,23 @@ bitflags! {
 /// Hand-off Blocks are used to pass data from the early pre-UEFI environment to the UEFI drivers.
 ///
 /// Most OS loaders or applications should not mess with this.
-pub const HAND_OFF_BLOCK_LIST_GUID: Guid =
-    Guid::from_values(0x7739f24c, 0x93d7, 0x11d4, 0x9a3a, 0x0090273fc14d);
+pub const HAND_OFF_BLOCK_LIST_GUID: Guid = guid!("7739f24c-93d7-11d4-9a3a-0090273fc14d");
 
 /// Table used in the early boot environment to record memory ranges.
-pub const MEMORY_TYPE_INFORMATION_GUID: Guid =
-    Guid::from_values(0x4c19049f, 0x4137, 0x4dd3, 0x9c10, 0x8b97a83ffdfa);
+pub const MEMORY_TYPE_INFORMATION_GUID: Guid = guid!("4c19049f-4137-4dd3-9c10-8b97a83ffdfa");
 
 /// Used to identify Hand-off Blocks which store
 /// status codes reported during the pre-UEFI environment.
-pub const MEMORY_STATUS_CODE_RECORD_GUID: Guid =
-    Guid::from_values(0x60cc026, 0x4c0d, 0x4dda, 0x8f41, 0x595fef00a502);
+pub const MEMORY_STATUS_CODE_RECORD_GUID: Guid = guid!("060cc026-4c0d-4dda-8f41-595fef00a502");
 
 /// Table which provides Driver eXecution Environment services.
-pub const DXE_SERVICES_GUID: Guid =
-    Guid::from_values(0x5ad34ba, 0x6f02, 0x4214, 0x952e, 0x4da0398e2bb9);
+pub const DXE_SERVICES_GUID: Guid = guid!("05ad34ba-6f02-4214-952e-4da0398e2bb9");
 
 /// LZMA-compressed filesystem.
-pub const LZMA_COMPRESS_GUID: Guid =
-    Guid::from_values(0xee4e5898, 0x3914, 0x4259, 0x9d6e, 0xdc7bd79403cf);
+pub const LZMA_COMPRESS_GUID: Guid = guid!("ee4e5898-3914-4259-9d6e-dc7bd79403cf");
 
 /// A custom compressed filesystem used by the Tiano UEFI implementation.
-pub const TIANO_COMPRESS_GUID: Guid =
-    Guid::from_values(0xa31280ad, 0x481e, 0x41b6, 0x95e8, 0x127f4c984779);
+pub const TIANO_COMPRESS_GUID: Guid = guid!("a31280ad-481e-41b6-95e8-127f4c984779");
 
 /// Pointer to the debug image info table.
-pub const DEBUG_IMAGE_INFO_GUID: Guid =
-    Guid::from_values(0x49152e77, 0x1ada, 0x4764, 0xb7a2, 0x7afefed95e8b);
+pub const DEBUG_IMAGE_INFO_GUID: Guid = guid!("49152e77-1ada-4764-b7a2-7afefed95e8b");

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -5,7 +5,7 @@ use super::{Header, Revision};
 use crate::data_types::FromSliceWithNulError;
 use crate::result::Error;
 use crate::table::boot::MemoryDescriptor;
-use crate::{CStr16, Char16, Guid, Result, Status};
+use crate::{guid, CStr16, Char16, Guid, Result, Status};
 #[cfg(feature = "exts")]
 use alloc_api::{vec, vec::Vec};
 use bitflags::bitflags;
@@ -606,22 +606,10 @@ newtype_enum! {
     /// defines some special values, and vendors will define their own.
     pub enum VariableVendor: Guid => {
         /// Used to access global variables.
-        GLOBAL_VARIABLE = Guid::from_values(
-            0x8be4df61,
-            0x93ca,
-            0x11d2,
-            0xaa0d,
-            0x00e098032b8c,
-        ),
+        GLOBAL_VARIABLE = guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c"),
 
         /// Used to access EFI signature database variables.
-        IMAGE_SECURITY_DATABASE = Guid::from_values(
-            0xd719b2cb,
-            0x3d3a,
-            0x4596,
-            0xa3bc,
-            0xdad00e67656f,
-        ),
+        IMAGE_SECURITY_DATABASE = guid!("d719b2cb-3d3a-4596-a3bc-dad00e67656f"),
     }
 }
 

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -80,6 +80,35 @@ pub fn unsafe_guid(args: TokenStream, input: TokenStream) -> TokenStream {
     result.into()
 }
 
+/// Create a `Guid` at compile time.
+///
+/// # Example
+///
+/// ```
+/// use uefi::{guid, Guid};
+/// const EXAMPLE_GUID: Guid = guid!("12345678-9abc-def0-1234-56789abcdef0");
+/// ```
+#[proc_macro]
+pub fn guid(args: TokenStream) -> TokenStream {
+    let (time_low, time_mid, time_high_and_version, clock_seq_and_variant, node) =
+        match parse_guid(parse_macro_input!(args as LitStr)) {
+            Ok(data) => data,
+            Err(tokens) => return tokens.into(),
+        };
+
+    quote!({
+        const g: ::uefi::Guid = ::uefi::Guid::from_values(
+            #time_low,
+            #time_mid,
+            #time_high_and_version,
+            #clock_seq_and_variant,
+            #node,
+        );
+        g
+    })
+    .into()
+}
+
 fn parse_guid(guid_lit: LitStr) -> Result<(u32, u16, u16, u16, u64), TokenStream2> {
     let guid_str = guid_lit.value();
 

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -1,7 +1,7 @@
 use log::info;
+use uefi::guid;
 use uefi::prelude::*;
 use uefi::table::runtime::{VariableAttributes, VariableVendor};
-use uefi::Guid;
 
 fn test_variables(rt: &RuntimeServices) {
     let name = cstr16!("UefiRsTestVar");
@@ -9,13 +9,7 @@ fn test_variables(rt: &RuntimeServices) {
     let test_attrs = VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS;
 
     // Arbitrary GUID generated for this test.
-    let vendor = VariableVendor(Guid::from_values(
-        0x9baf21cf,
-        0xe187,
-        0x497e,
-        0xae77,
-        0x5bd8b0e09703,
-    ));
+    let vendor = VariableVendor(guid!("9baf21cf-e187-497e-ae77-5bd8b0e09703"));
 
     info!("Testing set_variable");
     rt.set_variable(name, &vendor, test_attrs, test_value)


### PR DESCRIPTION
This is similar to `Guid::from_values`, but takes a more convenient string argument like the `unsafe_guid!` attribute macro.

In the second commit, various uses of `Guid::from_value` are converted to use `guid!` instead. Should be no functional change from that, just a little shorter and easier to read.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits): See the
      [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for
      help.
- [ ] Update the changelog (if necessary)
