### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/data_types/guid.rs
+++ b/src/data_types/guid.rs
@@ -89,6 +89,10 @@ impl Guid {
 
 impl fmt::Display for Guid {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let a = self.a;
+        let b = self.b;
+        let c = self.c;
+
         let d = {
             let mut buf = [0u8; 2];
             buf[..].copy_from_slice(&self.d[0..2]);
@@ -102,11 +106,7 @@ impl fmt::Display for Guid {
             u64::from_be_bytes(buf)
         };
 
-        write!(
-            fmt,
-            "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
-            self.a, self.b, self.c, d, e
-        )
+        write!(fmt, "{a:08x}-{b:04x}-{c:04x}-{d:04x}-{e:012x}",)
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -148,12 +148,13 @@ impl<'writer, 'a, W: fmt::Write> fmt::Write for DecoratedLog<'writer, 'a, W> {
             )?;
             self.at_line_start = false;
         }
-        write!(self.writer, "{}", first)?;
+        write!(self.writer, "{first}")?;
 
         // For the remainder of the line iterator (if any), we know that we are
         // truly at the beginning of lines of output.
         for line in lines {
-            write!(self.writer, "\n{}: {}", self.log_level, line)?;
+            let level = self.log_level;
+            write!(self.writer, "\n{level}: {line}")?;
         }
 
         // If the string ends with a newline character, we must 1/propagate it

--- a/src/table/revision.rs
+++ b/src/table/revision.rs
@@ -52,7 +52,9 @@ impl fmt::Debug for Revision {
     /// Formats the revision in the `major.minor.patch` format.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (major, minor) = (self.major(), self.minor());
-        write!(f, "{}.{}.{}", major, minor / 10, minor % 10)
+        let minor = minor / 10;
+        let patch = minor % 10;
+        write!(f, "{major}.{minor}.{patch}")
     }
 }
 

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -519,11 +519,11 @@ impl fmt::Display for Time {
             let fraction_part = offset_in_hours - (integer_part as f32);
             // most time zones
             if fraction_part == 0.0 {
-                write!(f, "UTC+{}", offset_in_hours)?;
+                write!(f, "UTC+{offset_in_hours}")?;
             }
             // time zones with 30min offset (and perhaps other special time zones)
             else {
-                write!(f, "UTC+{:.1}", offset_in_hours)?;
+                write!(f, "UTC+{offset_in_hours:.1}")?;
             }
         }
 
@@ -636,8 +636,8 @@ impl fmt::Display for VariableKey {
         write!(f, "VariableKey {{ name: ")?;
 
         match self.name() {
-            Ok(name) => write!(f, "\"{}\"", name)?,
-            Err(err) => write!(f, "Err({:?})", err)?,
+            Ok(name) => write!(f, "\"{name}\"")?,
+            Err(err) => write!(f, "Err({err:?})")?,
         }
 
         write!(f, ", vendor: ")?;

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -19,8 +19,8 @@ impl Pipe {
     pub fn new(dir: &Path, base_name: &'static str) -> Result<Self> {
         if platform::is_unix() {
             let qemu_arg = format!("pipe:{}", dir.join(base_name).to_str().unwrap());
-            let input_path = dir.join(format!("{}.in", base_name));
-            let output_path = dir.join(format!("{}.out", base_name));
+            let input_path = dir.join(format!("{base_name}.in"));
+            let output_path = dir.join(format!("{base_name}.out"));
 
             // This part has to be conditionally compiled because the
             // `nix` interfaces don't exist when compiling under
@@ -43,11 +43,11 @@ impl Pipe {
 
             Ok(Self {
                 // QEMU adds the "\\.\pipe\" prefix automatically.
-                qemu_arg: format!("pipe:{}", base_name),
+                qemu_arg: format!("pipe:{base_name}"),
 
                 // On Windows the pipe is duplex, so only one path
                 // needed.
-                input_path: format!(r"\\.\pipe\{}", base_name).into(),
+                input_path: format!(r"\\.\pipe\{base_name}").into(),
                 output_path: PathBuf::new(),
             })
         } else {

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -289,7 +289,7 @@ fn echo_filtered_stdout<R: Read, W: Write>(mut child_io: Io<R, W>) {
         let stripped = String::from_utf8(stripped.into()).expect("line is not utf8");
 
         // Print out the processed QEMU output for logging & inspection.
-        println!("{}", stripped);
+        println!("{stripped}");
     }
 }
 
@@ -334,7 +334,7 @@ fn process_qemu_io<R: Read, W: Write>(
             // Compare screenshot to the reference file specified by the user.
             // TODO: Add an operating mode where the reference is created if it doesn't exist.
             let reference_file =
-                Path::new("uefi-test-runner/screenshots").join(format!("{}.ppm", reference_name));
+                Path::new("uefi-test-runner/screenshots").join(format!("{reference_name}.ppm"));
             let expected = fs_err::read(reference_file)?;
             let actual = fs_err::read(&screenshot_path)?;
             assert_eq!(expected, actual);
@@ -390,10 +390,10 @@ impl Drop for ChildWrapper {
         // Try to stop the process, then wait for it to exit. Log errors
         // but otherwise ignore.
         if let Err(err) = self.0.kill() {
-            eprintln!("failed to kill process: {}", err);
+            eprintln!("failed to kill process: {err}");
         }
         if let Err(err) = self.0.wait() {
-            eprintln!("failed to wait for process exit: {}", err);
+            eprintln!("failed to wait for process exit: {err}");
         }
     }
 }
@@ -564,7 +564,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // terminated by a signal.
     let qemu_exit_code = status
         .code()
-        .context(format!("qemu was terminated by a signal: {:?}", status))?;
+        .context(format!("qemu was terminated by a signal: {status:?}"))?;
 
     let successful_exit_code = match arch {
         UefiArch::AArch64 | UefiArch::IA32 => 0,


### PR DESCRIPTION
Clippy now warns when arguments in a format string could be specified inline, e.g. `format!({var})` instead of `format!({}, var)`. Note that only standalone variables can be used in this way, e.g. `{var}` works, but not `{self.var}`.

I think it helps readability to be consistent within a format string and only use one style, so in cases where any of the arguments could be done in the new style I introduced new local variables as needed.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
