### PR TITLE
Update `mbrman` to 0.5.0

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.0.4", features = ["derive"] }
 # The latest fatfs release (0.3.5) is old, use git instead to pick up some fixes.
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }
 fs-err = "2.6.0"
-mbrman = "0.4.2"
+mbrman = "0.5.0"
 nix = "0.25.0"
 regex = "1.5.4"
 serde_json = "1.0.73"

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use fatfs::{Date, DateTime, FileSystem, FormatVolumeOptions, FsOptions, StdIoWrapper, Time};
-use mbrman::{MBRPartitionEntry, CHS, MBR};
+use mbrman::{MBRPartitionEntry, BOOT_INACTIVE, CHS, MBR};
 use std::io::{Cursor, Read, Write};
 use std::ops::Range;
 use std::path::Path;
@@ -23,7 +23,7 @@ pub fn create_mbr_test_disk(path: &Path) -> Result<()> {
 
         let mut mbr = MBR::new_from(&mut cur, SECTOR_SIZE as u32, [0xff; 4])?;
         mbr[1] = MBRPartitionEntry {
-            boot: false,
+            boot: BOOT_INACTIVE,
             first_chs: CHS::empty(),
             sys: 0x06,
             last_chs: CHS::empty(),


### PR DESCRIPTION
Updates the `xtask` package's `mbrman` dependency to 0.5.0. This new version has a small breaking change which we had to fix.

Supersedes #531.

<!--
## Checklist
- [X] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
-->