### PR TITLE
Make the `cstr16!` macro usable in const contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - The `Revision` type now implements `Display` with correct formatting
   for all UEFI versions. The custom `Debug` impl has been removed and
   replaced with a derived `Debug` impl.
+- `CStr16::from_u16_with_nul_unchecked` and `cstr16!` are now allowed in
+  `const` contexts.
   
 ### Removed
 

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -212,7 +212,7 @@ impl CStr16 {
     ///
     /// It's the callers responsibility to ensure chars is a valid UCS-2
     /// null-terminated string, with no interior null bytes.
-    pub unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
+    pub const unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
         &*(codes as *const [u16] as *const Self)
     }
 
@@ -567,5 +567,12 @@ mod tests {
     fn test_compare_cstr16() {
         let input: &CStr16 = cstr16!("test");
         test_compare_cstrX!(input);
+    }
+
+    /// Test that the `cstr16!` macro can be used in a `const` context.
+    #[test]
+    fn test_cstr16_macro_const() {
+        const S: &CStr16 = cstr16!("ABC");
+        assert_eq!(S.to_u16_slice_with_nul(), [65, 66, 67, 0]);
     }
 }


### PR DESCRIPTION
## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
