### PR TITLE
const fn for trivial getters where possible

### DIFF
--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -288,12 +288,12 @@ impl CStr16 {
     }
 
     /// Returns the inner pointer to this C string
-    pub fn as_ptr(&self) -> *const Char16 {
+    pub const fn as_ptr(&self) -> *const Char16 {
         self.0.as_ptr()
     }
 
     /// Get the underlying [`Char16`] slice, including the trailing null.
-    pub fn as_slice_with_nul(&self) -> &[Char16] {
+    pub const fn as_slice_with_nul(&self) -> &[Char16] {
         &self.0
     }
 
@@ -317,7 +317,7 @@ impl CStr16 {
     }
 
     /// Get the number of bytes in the string (including the trailing null character).
-    pub fn num_bytes(&self) -> usize {
+    pub const fn num_bytes(&self) -> usize {
         self.0.len() * 2
     }
 

--- a/src/data_types/unaligned_slice.rs
+++ b/src/data_types/unaligned_slice.rs
@@ -36,12 +36,12 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     }
 
     /// Returns true if the slice has a length of 0.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Returns the number of elements in the slice.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -294,7 +294,7 @@ impl<'boot> GraphicsOutput<'boot> {
     }
 
     /// Returns the frame buffer information for the current mode.
-    pub fn current_mode_info(&self) -> ModeInfo {
+    pub const fn current_mode_info(&self) -> ModeInfo {
         *self.mode.info
     }
 
@@ -377,12 +377,12 @@ impl Mode {
     /// The size of the info structure in bytes.
     ///
     /// Newer versions of the spec might add extra information, in a backwards compatible way.
-    pub fn info_size(&self) -> usize {
+    pub const fn info_size(&self) -> usize {
         self.info_sz
     }
 
     /// Returns a reference to the mode info structure.
-    pub fn info(&self) -> &ModeInfo {
+    pub const fn info(&self) -> &ModeInfo {
         &self.info
     }
 }
@@ -404,17 +404,17 @@ impl ModeInfo {
     /// Returns the (horizontal, vertical) resolution.
     ///
     /// On desktop monitors, this usually means (width, height).
-    pub fn resolution(&self) -> (usize, usize) {
+    pub const fn resolution(&self) -> (usize, usize) {
         (self.hor_res as usize, self.ver_res as usize)
     }
 
     /// Returns the format of the frame buffer.
-    pub fn pixel_format(&self) -> PixelFormat {
+    pub const fn pixel_format(&self) -> PixelFormat {
         self.format
     }
 
     /// Returns the bitmask of the custom pixel format, if available.
-    pub fn pixel_bitmask(&self) -> Option<PixelBitmask> {
+    pub const fn pixel_bitmask(&self) -> Option<PixelBitmask> {
         match self.format {
             PixelFormat::Bitmask => Some(self.mask),
             _ => None,
@@ -425,7 +425,7 @@ impl ModeInfo {
     ///
     /// Due to performance reasons, the stride might not be equal to the width,
     /// instead the stride might be bigger for better alignment.
-    pub fn stride(&self) -> usize {
+    pub const fn stride(&self) -> usize {
         self.stride as usize
     }
 }
@@ -582,7 +582,7 @@ impl<'gop> FrameBuffer<'gop> {
     }
 
     /// Query the framebuffer size in bytes
-    pub fn size(&self) -> usize {
+    pub const fn size(&self) -> usize {
         self.size
     }
 

--- a/src/proto/console/pointer/mod.rs
+++ b/src/proto/console/pointer/mod.rs
@@ -47,12 +47,12 @@ impl<'boot> Pointer<'boot> {
 
     /// Event to be used with `BootServices::wait_for_event()` in order to wait
     /// for input from the pointer device
-    pub fn wait_for_input_event(&self) -> &Event {
+    pub const fn wait_for_input_event(&self) -> &Event {
         &self.wait_for_input
     }
 
     /// Returns a reference to the pointer device information.
-    pub fn mode(&self) -> &PointerMode {
+    pub const fn mode(&self) -> &PointerMode {
         self.mode
     }
 }

--- a/src/proto/console/serial.rs
+++ b/src/proto/console/serial.rs
@@ -44,7 +44,7 @@ impl<'boot> Serial<'boot> {
     }
 
     /// Returns the current I/O mode.
-    pub fn io_mode(&self) -> &IoMode {
+    pub const fn io_mode(&self) -> &IoMode {
         self.io_mode
     }
 

--- a/src/proto/console/text/input.rs
+++ b/src/proto/console/text/input.rs
@@ -44,7 +44,7 @@ impl Input {
 
     /// Event to be used with `BootServices::wait_for_event()` in order to wait
     /// for a key to be available
-    pub fn wait_for_key_event(&self) -> &Event {
+    pub const fn wait_for_key_event(&self) -> &Event {
         &self.wait_for_key
     }
 }

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -129,7 +129,7 @@ impl<'boot> Output<'boot> {
     }
 
     /// Returns whether the cursor is currently shown or not.
-    pub fn cursor_visible(&self) -> bool {
+    pub const fn cursor_visible(&self) -> bool {
         self.data.cursor_visible
     }
 
@@ -142,7 +142,7 @@ impl<'boot> Output<'boot> {
     }
 
     /// Returns the column and row of the cursor.
-    pub fn cursor_position(&self) -> (usize, usize) {
+    pub const fn cursor_position(&self) -> (usize, usize) {
         let column = self.data.cursor_column;
         let row = self.data.cursor_row;
         (column as usize, row as usize)
@@ -260,19 +260,19 @@ pub struct OutputMode {
 impl OutputMode {
     /// Returns the index of this mode.
     #[inline]
-    pub fn index(&self) -> usize {
+    pub const fn index(&self) -> usize {
         self.index
     }
 
     /// Returns the width in columns.
     #[inline]
-    pub fn columns(&self) -> usize {
+    pub const fn columns(&self) -> usize {
         self.dims.0
     }
 
     /// Returns the height in rows.
     #[inline]
-    pub fn rows(&self) -> usize {
+    pub const fn rows(&self) -> usize {
         self.dims.1
     }
 }

--- a/src/proto/debug/mod.rs
+++ b/src/proto/debug/mod.rs
@@ -57,7 +57,7 @@ pub struct DebugSupport {
 
 impl DebugSupport {
     /// Returns the processor architecture of the running CPU.
-    pub fn arch(&self) -> ProcessorArch {
+    pub const fn arch(&self) -> ProcessorArch {
         self.isa
     }
 

--- a/src/proto/device_path/mod.rs
+++ b/src/proto/device_path/mod.rs
@@ -136,22 +136,22 @@ impl DevicePathNode {
     }
 
     /// Type of device
-    pub fn device_type(&self) -> DeviceType {
+    pub const fn device_type(&self) -> DeviceType {
         self.header.device_type
     }
 
     /// Sub type of device
-    pub fn sub_type(&self) -> DeviceSubType {
+    pub const fn sub_type(&self) -> DeviceSubType {
         self.header.sub_type
     }
 
     /// Tuple of the node's type and subtype.
-    pub fn full_type(&self) -> (DeviceType, DeviceSubType) {
+    pub const fn full_type(&self) -> (DeviceType, DeviceSubType) {
         (self.header.device_type, self.header.sub_type)
     }
 
     /// Size (in bytes) of the full [`DevicePathNode`], including the header.
-    pub fn length(&self) -> u16 {
+    pub const fn length(&self) -> u16 {
         self.header.length
     }
 
@@ -281,7 +281,7 @@ impl DevicePath {
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
-    pub fn as_ffi_ptr(&self) -> *const FfiDevicePath {
+    pub const fn as_ffi_ptr(&self) -> *const FfiDevicePath {
         let p = self as *const Self;
         p.cast()
     }
@@ -615,22 +615,22 @@ const HARD_DRIVE_MEDIA_DEVICE_PATH_LENGTH: u16 = 42;
 
 impl HardDriveMediaDevicePath {
     /// Returns the format of the partition (MBR, GPT, or unknown).
-    pub fn partition_format(&self) -> PartitionFormat {
+    pub const fn partition_format(&self) -> PartitionFormat {
         self.partition_format
     }
 
     /// Returns the 1-based index of the partition.
-    pub fn partition_number(&self) -> u32 {
+    pub const fn partition_number(&self) -> u32 {
         self.partition_number
     }
 
     /// Returns the partition size in logical blocks.
-    pub fn partition_size(&self) -> u64 {
+    pub const fn partition_size(&self) -> u64 {
         self.partition_size
     }
 
     /// Returns the starting LBA of the partition.
-    pub fn partition_start(&self) -> u64 {
+    pub const fn partition_start(&self) -> u64 {
         self.partition_start
     }
 
@@ -729,7 +729,7 @@ mod tests {
         raw_data
     }
 
-    /// Check that `node` has the expected content.    
+    /// Check that `node` has the expected content.
     fn check_node(node: &DevicePathNode, device_type: u8, sub_type: u8, node_data: &[u8]) {
         assert_eq!(node.device_type().0, device_type);
         assert_eq!(node.sub_type().0, sub_type);

--- a/src/proto/loaded_image.rs
+++ b/src/proto/loaded_image.rs
@@ -52,7 +52,7 @@ pub enum LoadOptionsError {
 
 impl LoadedImage {
     /// Returns a handle to the storage device on which the image is located.
-    pub fn device(&self) -> Handle {
+    pub const fn device(&self) -> Handle {
         self.device_handle
     }
 
@@ -164,7 +164,7 @@ impl LoadedImage {
     }
 
     /// Returns the base address and the size in bytes of the loaded image.
-    pub fn info(&self) -> (*const c_void, u64) {
+    pub const fn info(&self) -> (*const c_void, u64) {
         (self.image_base, self.image_size)
     }
 }

--- a/src/proto/media/block.rs
+++ b/src/proto/media/block.rs
@@ -128,64 +128,64 @@ pub struct BlockIOMedia {
 
 impl BlockIOMedia {
     /// The current media ID.
-    pub fn media_id(&self) -> u32 {
+    pub const fn media_id(&self) -> u32 {
         self.media_id
     }
 
     /// True if the media is removable.
-    pub fn is_removable_media(&self) -> bool {
+    pub const fn is_removable_media(&self) -> bool {
         self.removable_media
     }
 
     /// True if there is a media currently present in the device.
-    pub fn is_media_present(&self) -> bool {
+    pub const fn is_media_present(&self) -> bool {
         self.media_present
     }
 
     /// True if block IO was produced to abstract partition structure.
-    pub fn is_logical_partition(&self) -> bool {
+    pub const fn is_logical_partition(&self) -> bool {
         self.logical_partition
     }
 
     /// True if the media is marked read-only.
-    pub fn is_read_only(&self) -> bool {
+    pub const fn is_read_only(&self) -> bool {
         self.read_only
     }
 
     /// True if `writeBlocks` function writes data.
-    pub fn is_write_caching(&self) -> bool {
+    pub const fn is_write_caching(&self) -> bool {
         self.write_caching
     }
 
     /// The intrinsic block size of the device.
     ///
     /// If the media changes, then this field is updated. Returns the number of bytes per logical block.
-    pub fn block_size(&self) -> u32 {
+    pub const fn block_size(&self) -> u32 {
         self.block_size
     }
 
     /// Supplies the alignment requirement for any buffer used in a data transfer.
-    pub fn io_align(&self) -> u32 {
+    pub const fn io_align(&self) -> u32 {
         self.io_align
     }
 
     /// The last LBA on the device. If the media changes, then this field is updated.
-    pub fn last_block(&self) -> Lba {
+    pub const fn last_block(&self) -> Lba {
         self.last_block
     }
 
     /// Returns the first LBA that is aligned to a physical block boundary.
-    pub fn lowest_aligned_lba(&self) -> Lba {
+    pub const fn lowest_aligned_lba(&self) -> Lba {
         self.lowest_aligned_lba
     }
 
     /// Returns the number of logical blocks per physical block.
-    pub fn logical_blocks_per_physical_block(&self) -> u32 {
+    pub const fn logical_blocks_per_physical_block(&self) -> u32 {
         self.logical_blocks_per_physical_block
     }
 
     /// Returns the optimal transfer length granularity as a number of logical blocks.
-    pub fn optimal_transfer_length_granularity(&self) -> u32 {
+    pub const fn optimal_transfer_length_granularity(&self) -> u32 {
         self.optimal_transfer_length_granularity
     }
 }

--- a/src/proto/media/file/info.rs
+++ b/src/proto/media/file/info.rs
@@ -189,32 +189,32 @@ impl FileInfo {
     }
 
     /// File size (number of bytes stored in the file)
-    pub fn file_size(&self) -> u64 {
+    pub const fn file_size(&self) -> u64 {
         self.file_size
     }
 
     /// Physical space consumed by the file on the file system volume
-    pub fn physical_size(&self) -> u64 {
+    pub const fn physical_size(&self) -> u64 {
         self.physical_size
     }
 
     /// Time when the file was created
-    pub fn create_time(&self) -> &Time {
+    pub const fn create_time(&self) -> &Time {
         &self.create_time
     }
 
     /// Time when the file was last accessed
-    pub fn last_access_time(&self) -> &Time {
+    pub const fn last_access_time(&self) -> &Time {
         &self.last_access_time
     }
 
     /// Time when the file's contents were last modified
-    pub fn modification_time(&self) -> &Time {
+    pub const fn modification_time(&self) -> &Time {
         &self.modification_time
     }
 
     /// Attribute bits for the file
-    pub fn attribute(&self) -> FileAttribute {
+    pub const fn attribute(&self) -> FileAttribute {
         self.attribute
     }
 
@@ -286,22 +286,22 @@ impl FileSystemInfo {
     }
 
     /// Truth that the volume only supports read access
-    pub fn read_only(&self) -> bool {
+    pub const fn read_only(&self) -> bool {
         self.read_only
     }
 
     /// Number of bytes managed by the file system
-    pub fn volume_size(&self) -> u64 {
+    pub const fn volume_size(&self) -> u64 {
         self.volume_size
     }
 
     /// Number of available bytes for use by the file system
-    pub fn free_space(&self) -> u64 {
+    pub const fn free_space(&self) -> u64 {
         self.free_space
     }
 
     /// Nominal block size by which files are typically grown
-    pub fn block_size(&self) -> u32 {
+    pub const fn block_size(&self) -> u32 {
         self.block_size
     }
 

--- a/src/proto/media/partition.rs
+++ b/src/proto/media/partition.rs
@@ -44,7 +44,7 @@ pub struct MbrPartitionRecord {
 
 impl MbrPartitionRecord {
     /// True if the partition is a bootable legacy partition.
-    pub fn is_bootable(&self) -> bool {
+    pub const fn is_bootable(&self) -> bool {
         self.boot_indicator == 0x80
     }
 }
@@ -100,7 +100,7 @@ bitflags! {
 impl GptPartitionAttributes {
     /// Get bits `48..=63` as a [`u16`]. The meaning of these bits depends
     /// on the partition's type (see [`GptPartitionEntry::partition_type_guid`]).
-    pub fn type_specific_bits(&self) -> u16 {
+    pub const fn type_specific_bits(&self) -> u16 {
         (self.bits >> 48) as u16
     }
 }
@@ -188,7 +188,7 @@ pub struct PartitionInfo {
 
 impl PartitionInfo {
     /// True if the partition is an EFI system partition.
-    pub fn is_system(&self) -> bool {
+    pub const fn is_system(&self) -> bool {
         self.system == 1
     }
 

--- a/src/proto/network/pxe.rs
+++ b/src/proto/network/pxe.rs
@@ -688,39 +688,39 @@ impl<const N: usize> DiscoverInfo<[Server; N]> {
 
 impl<T> DiscoverInfo<T> {
     /// Returns whether discovery should use multicast.
-    pub fn use_m_cast(&self) -> bool {
+    pub const fn use_m_cast(&self) -> bool {
         self.use_m_cast
     }
 
     /// Returns whether discovery should use broadcast.
-    pub fn use_b_cast(&self) -> bool {
+    pub const fn use_b_cast(&self) -> bool {
         self.use_b_cast
     }
 
     /// Returns whether discovery should use unicast.
-    pub fn use_u_cast(&self) -> bool {
+    pub const fn use_u_cast(&self) -> bool {
         self.use_u_cast
     }
 
     /// Returns whether discovery should only accept boot servers in the server
     /// list (boot server verification).
-    pub fn must_use_list(&self) -> bool {
+    pub const fn must_use_list(&self) -> bool {
         self.must_use_list
     }
 
     /// Returns the address used in multicast discovery.
-    pub fn server_m_cast_ip(&self) -> &IpAddress {
+    pub const fn server_m_cast_ip(&self) -> &IpAddress {
         &self.server_m_cast_ip
     }
 
     /// Returns the amount of Boot Server.
-    pub fn ip_cnt(&self) -> u16 {
+    pub const fn ip_cnt(&self) -> u16 {
         self.ip_cnt
     }
 
     /// Returns the Boot Server list used for unicast discovery or boot server
     /// verification.
-    pub fn srv_list(&self) -> &T {
+    pub const fn srv_list(&self) -> &T {
         &self.srv_list
     }
 }
@@ -753,7 +753,7 @@ impl Server {
 
     /// Returns a `None` if the any response should be accepted or the IP
     /// address of a Boot Server whose responses should be accepted.
-    pub fn ip_addr(&self) -> Option<&IpAddress> {
+    pub const fn ip_addr(&self) -> Option<&IpAddress> {
         if self.accept_any_response {
             None
         } else {
@@ -944,22 +944,22 @@ impl DhcpV4Packet {
     pub const DHCP_MAGIK: u32 = 0x63825363;
 
     /// Transaction ID, a random number, used to match this boot request with the responses it generates.
-    pub fn bootp_ident(&self) -> u32 {
+    pub const fn bootp_ident(&self) -> u32 {
         u32::from_be(self.bootp_ident)
     }
 
     /// Filled in by client, seconds elapsed since client started trying to boot.
-    pub fn bootp_seconds(&self) -> u16 {
+    pub const fn bootp_seconds(&self) -> u16 {
         u16::from_be(self.bootp_seconds)
     }
 
     /// The flags.
-    pub fn bootp_flags(&self) -> DhcpV4Flags {
+    pub const fn bootp_flags(&self) -> DhcpV4Flags {
         DhcpV4Flags::from_bits_truncate(u16::from_be(self.bootp_flags))
     }
 
     /// A magic cookie, should be [`Self::DHCP_MAGIK`].
-    pub fn dhcp_magik(&self) -> u32 {
+    pub const fn dhcp_magik(&self) -> u32 {
         u32::from_be(self.dhcp_magik)
     }
 }

--- a/src/proto/pi/mp.rs
+++ b/src/proto/pi/mp.rs
@@ -59,17 +59,17 @@ pub struct ProcessorInformation {
 
 impl ProcessorInformation {
     /// Returns `true` if the processor is playing the role of BSP.
-    pub fn is_bsp(&self) -> bool {
+    pub const fn is_bsp(&self) -> bool {
         self.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT)
     }
 
     /// Returns `true` if the processor is enabled.
-    pub fn is_enabled(&self) -> bool {
+    pub const fn is_enabled(&self) -> bool {
         self.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT)
     }
 
     /// Returns `true` if the processor is healthy.
-    pub fn is_healthy(&self) -> bool {
+    pub const fn is_healthy(&self) -> bool {
         self.status_flag
             .contains(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT)
     }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -11,17 +11,17 @@ pub struct Error<Data: Debug = ()> {
 
 impl<Data: Debug> Error<Data> {
     /// Create an `Error`.
-    pub fn new(status: Status, data: Data) -> Self {
+    pub const fn new(status: Status, data: Data) -> Self {
         Self { status, data }
     }
 
     /// Get error `Status`.
-    pub fn status(&self) -> Status {
+    pub const fn status(&self) -> Status {
         self.status
     }
 
     /// Get error data.
-    pub fn data(&self) -> &Data {
+    pub const fn data(&self) -> &Data {
         &self.data
     }
 

--- a/src/result/status.rs
+++ b/src/result/status.rs
@@ -118,7 +118,7 @@ impl Status {
 
     /// Returns true if the status code indicates an error.
     #[inline]
-    pub fn is_error(self) -> bool {
+    pub const fn is_error(self) -> bool {
         self.0 & ERROR_BIT != 0
     }
 

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -435,42 +435,42 @@ impl Time {
     }
 
     /// Query the year.
-    pub fn year(&self) -> u16 {
+    pub const fn year(&self) -> u16 {
         self.year
     }
 
     /// Query the month.
-    pub fn month(&self) -> u8 {
+    pub const fn month(&self) -> u8 {
         self.month
     }
 
     /// Query the day.
-    pub fn day(&self) -> u8 {
+    pub const fn day(&self) -> u8 {
         self.day
     }
 
     /// Query the hour.
-    pub fn hour(&self) -> u8 {
+    pub const fn hour(&self) -> u8 {
         self.hour
     }
 
     /// Query the minute.
-    pub fn minute(&self) -> u8 {
+    pub const fn minute(&self) -> u8 {
         self.minute
     }
 
     /// Query the second.
-    pub fn second(&self) -> u8 {
+    pub const fn second(&self) -> u8 {
         self.second
     }
 
     /// Query the nanosecond.
-    pub fn nanosecond(&self) -> u32 {
+    pub const fn nanosecond(&self) -> u32 {
         self.nanosecond
     }
 
     /// Query the time offset in minutes from UTC, or None if using local time.
-    pub fn time_zone(&self) -> Option<i16> {
+    pub const fn time_zone(&self) -> Option<i16> {
         if self.time_zone == 2047 {
             None
         } else {
@@ -479,7 +479,7 @@ impl Time {
     }
 
     /// Query the daylight savings time information.
-    pub fn daylight(&self) -> Daylight {
+    pub const fn daylight(&self) -> Daylight {
         self.daylight
     }
 }

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -58,13 +58,13 @@ impl<View: SystemTableView> SystemTable<View> {
     }
 
     /// Return the firmware revision
-    pub fn firmware_revision(&self) -> u32 {
+    pub const fn firmware_revision(&self) -> u32 {
         self.table.fw_revision
     }
 
     /// Returns the revision of this table, which is defined to be
     /// the revision of the UEFI specification implemented by the firmware.
-    pub fn uefi_revision(&self) -> Revision {
+    pub const fn uefi_revision(&self) -> Revision {
         self.table.header.revision
     }
 
@@ -120,7 +120,7 @@ impl SystemTable<Boot> {
     }
 
     /// Access runtime services
-    pub fn runtime_services(&self) -> &RuntimeServices {
+    pub const fn runtime_services(&self) -> &RuntimeServices {
         self.table.runtime
     }
 
@@ -245,7 +245,7 @@ impl SystemTable<Runtime> {
     /// This is unsafe because UEFI runtime services require an elaborate
     /// CPU configuration which may not be preserved by OS loaders. See the
     /// "Calling Conventions" chapter of the UEFI specification for details.
-    pub unsafe fn runtime_services(&self) -> &RuntimeServices {
+    pub const unsafe fn runtime_services(&self) -> &RuntimeServices {
         self.table.runtime
     }
 


### PR DESCRIPTION
This adds `const` to all trivial getters where possible. Although applications in the field will barely benefit from this, I like about `const` that it ensures that a function is pure, i.e., has no side-effects during runtime.

I did this with the help of `cargo clippy -- -D clippy::missing_const_for_fn`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
