### PR TITLE
const fn wherever possible

### DIFF
--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -51,7 +51,7 @@ impl Event {
     /// to it are invalidated and the underlying memory is freed by firmware. The caller must ensure
     /// that any clones of a closed `Event` are never used again.
     #[must_use]
-    pub unsafe fn unsafe_clone(&self) -> Self {
+    pub const unsafe fn unsafe_clone(&self) -> Self {
         Self(self.0)
     }
 }

--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -100,12 +100,12 @@ impl CStr8 {
     ///
     /// It's the callers responsibility to ensure chars is a valid Latin-1
     /// null-terminated string, with no interior null bytes.
-    pub unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
+    pub const unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
         &*(chars as *const [u8] as *const Self)
     }
 
     /// Returns the inner pointer to this CStr8.
-    pub fn as_ptr(&self) -> *const Char8 {
+    pub const fn as_ptr(&self) -> *const Char8 {
         self.0.as_ptr()
     }
 
@@ -116,7 +116,7 @@ impl CStr8 {
     }
 
     /// Converts this CStr8 to a slice of bytes containing the trailing null byte.
-    pub fn to_bytes_with_nul(&self) -> &[u8] {
+    pub const fn to_bytes_with_nul(&self) -> &[u8] {
         unsafe { &*(&self.0 as *const [Char8] as *const [u8]) }
     }
 }
@@ -304,12 +304,12 @@ impl CStr16 {
     }
 
     /// Converts this C string to a u16 slice containing the trailing 0 char
-    pub fn to_u16_slice_with_nul(&self) -> &[u16] {
+    pub const fn to_u16_slice_with_nul(&self) -> &[u16] {
         unsafe { &*(&self.0 as *const [Char16] as *const [u16]) }
     }
 
     /// Returns an iterator over this C string
-    pub fn iter(&self) -> CStr16Iter {
+    pub const fn iter(&self) -> CStr16Iter {
         CStr16Iter {
             inner: self,
             pos: 0,

--- a/src/data_types/unaligned_slice.rs
+++ b/src/data_types/unaligned_slice.rs
@@ -58,7 +58,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     /// Returns an iterator over the slice.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&'a self) -> UnalignedSliceIter<'a, T> {
+    pub const fn iter(&'a self) -> UnalignedSliceIter<'a, T> {
         UnalignedSliceIter {
             slice: self,
             index: 0,

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -475,7 +475,7 @@ pub struct BltPixel {
 
 impl BltPixel {
     /// Create a new pixel from RGB values.
-    pub fn new(red: u8, green: u8, blue: u8) -> Self {
+    pub const fn new(red: u8, green: u8, blue: u8) -> Self {
         Self {
             red,
             green,

--- a/src/proto/device_path/mod.rs
+++ b/src/proto/device_path/mod.rs
@@ -141,7 +141,7 @@ impl DevicePathNode {
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
-    pub fn as_ffi_ptr(&self) -> *const FfiDevicePath {
+    pub const fn as_ffi_ptr(&self) -> *const FfiDevicePath {
         let ptr: *const Self = self;
         ptr.cast::<FfiDevicePath>()
     }
@@ -199,7 +199,7 @@ impl DevicePathInstance {
     /// reached.
     ///
     /// [`DevicePathNodes`]: DevicePathNode
-    pub fn node_iter(&self) -> DevicePathNodeIterator {
+    pub const fn node_iter(&self) -> DevicePathNodeIterator {
         DevicePathNodeIterator {
             nodes: &self.data,
             stop_condition: StopCondition::AnyEndNode,
@@ -271,7 +271,7 @@ impl DevicePath {
     }
 
     /// Get an iterator over the [`DevicePathInstance`]s in this path.
-    pub fn instance_iter(&self) -> DevicePathInstanceIterator {
+    pub const fn instance_iter(&self) -> DevicePathInstanceIterator {
         DevicePathInstanceIterator {
             remaining_path: Some(self),
         }
@@ -281,7 +281,7 @@ impl DevicePath {
     /// `self`. Iteration ends when a path is reached where
     /// [`is_end_entire`][DevicePathNode::is_end_entire] is true. That ending
     /// path is not returned by the iterator.
-    pub fn node_iter(&self) -> DevicePathNodeIterator {
+    pub const fn node_iter(&self) -> DevicePathNodeIterator {
         DevicePathNodeIterator {
             nodes: &self.data,
             stop_condition: StopCondition::EndEntireNode,

--- a/src/proto/media/block.rs
+++ b/src/proto/media/block.rs
@@ -31,7 +31,7 @@ pub struct BlockIO {
 
 impl BlockIO {
     /// Pointer for block IO media.
-    pub fn media(&self) -> &BlockIOMedia {
+    pub const fn media(&self) -> &BlockIOMedia {
         unsafe { &*self.media }
     }
 

--- a/src/proto/media/file/mod.rs
+++ b/src/proto/media/file/mod.rs
@@ -248,7 +248,7 @@ impl<T: File> FileInternal for T {}
 pub struct FileHandle(*mut FileImpl);
 
 impl FileHandle {
-    pub(super) unsafe fn new(ptr: *mut FileImpl) -> Self {
+    pub(super) const unsafe fn new(ptr: *mut FileImpl) -> Self {
         Self(ptr)
     }
 

--- a/src/proto/network/pxe.rs
+++ b/src/proto/network/pxe.rs
@@ -611,7 +611,7 @@ impl BaseCode {
     }
 
     /// Returns a reference to the `Mode` struct.
-    pub fn mode(&self) -> &Mode {
+    pub const fn mode(&self) -> &Mode {
         unsafe { &*self.mode }
     }
 }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -26,6 +26,7 @@ impl<Data: Debug> Error<Data> {
     }
 
     /// Split this error into its inner status and error data
+    #[allow(clippy::missing_const_for_fn)]
     pub fn split(self) -> (Status, Data) {
         (self.status, self.data)
     }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1925,7 +1925,8 @@ impl<'a> Drop for ProtocolsPerHandle<'a> {
 impl<'a> ProtocolsPerHandle<'a> {
     /// Get the protocol interface [`Guids`][Guid] that are installed on the
     /// [`Handle`].
-    pub const fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
+    #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    pub fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.
         unsafe { slice::from_raw_parts(self.protocols, self.count) }
@@ -1951,7 +1952,8 @@ impl<'a> Drop for HandleBuffer<'a> {
 
 impl<'a> HandleBuffer<'a> {
     /// Get an array of [`Handles`][Handle] that support the requested protocol.
-    pub const fn handles(&self) -> &[Handle] {
+    #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    pub fn handles(&self) -> &[Handle] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.
         unsafe { slice::from_raw_parts(self.buffer, self.count) }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1849,7 +1849,7 @@ pub enum SearchType<'guid> {
 
 impl<'guid> SearchType<'guid> {
     /// Constructs a new search type for a specified protocol.
-    pub fn from_proto<P: Protocol>() -> Self {
+    pub const fn from_proto<P: Protocol>() -> Self {
         SearchType::ByProtocol(&P::GUID)
     }
 }
@@ -1925,7 +1925,7 @@ impl<'a> Drop for ProtocolsPerHandle<'a> {
 impl<'a> ProtocolsPerHandle<'a> {
     /// Get the protocol interface [`Guids`][Guid] that are installed on the
     /// [`Handle`].
-    pub fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
+    pub const fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.
         unsafe { slice::from_raw_parts(self.protocols, self.count) }
@@ -1951,7 +1951,7 @@ impl<'a> Drop for HandleBuffer<'a> {
 
 impl<'a> HandleBuffer<'a> {
     /// Get an array of [`Handles`][Handle] that support the requested protocol.
-    pub fn handles(&self) -> &[Handle] {
+    pub const fn handles(&self) -> &[Handle] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.
         unsafe { slice::from_raw_parts(self.buffer, self.count) }

--- a/src/table/runtime.rs
+++ b/src/table/runtime.rs
@@ -405,7 +405,7 @@ impl Time {
     ///
     /// [`FileInfo`]: uefi::proto::media::file::FileInfo
     /// [`File::set_info`]: uefi::proto::media::file::File::set_info
-    pub fn invalid() -> Self {
+    pub const fn invalid() -> Self {
         Self {
             year: 0,
             month: 0,

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -70,7 +70,8 @@ impl<View: SystemTableView> SystemTable<View> {
 
     /// Returns the config table entries, a linear array of structures
     /// pointing to other system-specific tables.
-    pub const fn config_table(&self) -> &[cfg::ConfigTableEntry] {
+    #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
         unsafe { slice::from_raw_parts(self.table.cfg_table, self.table.nr_cfg) }
     }
 

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -70,7 +70,7 @@ impl<View: SystemTableView> SystemTable<View> {
 
     /// Returns the config table entries, a linear array of structures
     /// pointing to other system-specific tables.
-    pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
+    pub const fn config_table(&self) -> &[cfg::ConfigTableEntry] {
         unsafe { slice::from_raw_parts(self.table.cfg_table, self.table.nr_cfg) }
     }
 
@@ -125,7 +125,7 @@ impl SystemTable<Boot> {
     }
 
     /// Access boot services
-    pub fn boot_services(&self) -> &BootServices {
+    pub const fn boot_services(&self) -> &BootServices {
         unsafe { &*self.table.boot }
     }
 
@@ -220,7 +220,7 @@ impl SystemTable<Boot> {
     /// designs that Rust uses for memory allocation, logging, and panic
     /// handling require taking this risk.
     #[must_use]
-    pub unsafe fn unsafe_clone(&self) -> Self {
+    pub const unsafe fn unsafe_clone(&self) -> Self {
         SystemTable {
             table: self.table,
             _marker: PhantomData,


### PR DESCRIPTION
This is a follow-up to #545. It adds `const fn` everywhere possible.

We need to keep in mind that future refactorings might need to drop the `const`. This is considered fine as we do not require things to be `const`. In our case, it mainly helps to know if there will be side effects or not.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
