### PR TITLE
Fix location of a changelog item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@
 
 ## uefi-services - [Unreleased]
 
+### Changed
+
+- Changed the panic handler log message to use `println!` instead of
+  `error!`. This removes an extraneous file name and line number from
+  the log message.
+
 ## uefi - 0.17.0
 
 ### Added
@@ -118,10 +124,6 @@
 
 - The `no_panic_handler` feature has been replaced with an additive
   `panic_handler` feature. The new feature is enabled by default.
-- Changed the panic handler log message to use `println!` instead of
-  `error!`. This removes an extraneous file name and line number from
-  the log message.
-
 ## uefi - 0.16.1
 
 ### Added


### PR DESCRIPTION
The panic handler change accidentally went under the previous release's section. Move it up to the current unreleased version.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
