### PR TITLE
Support ISA-specific `MemoryAttribute`s in `MemoryDescriptor`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   slice.
 - Added `DeviceSubType::MESSAGING_REST_SERVICE` and
   `DeviceSubType::MESSAGING_NVME_OF_NAMESPACE`.
+- Added `MemoryAttribute::SPECIAL_PURPOSE`, `MemoryAttribute::CPU_CRYPTO`,
+  `MemoryAttribute::ISA_VALID`, and `MemoryAttribute::ISA_MASK`.
 
 ### Changed
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -1648,8 +1648,26 @@ bitflags! {
         const MORE_RELIABLE = 0x10000;
         /// This memory range can be set as read-only.
         const READ_ONLY = 0x20000;
+        /// This memory is earmarked for specific purposes such as for specific
+        /// device drivers or applications. This serves as a hint to the OS to
+        /// avoid this memory for core OS data or code that cannot be relocated.
+        const SPECIAL_PURPOSE = 0x4_0000;
+        /// This memory region is capable of being protected with the CPU's memory
+        /// cryptography capabilities.
+        const CPU_CRYPTO = 0x8_0000;
         /// This memory must be mapped by the OS when a runtime service is called.
         const RUNTIME = 0x8000_0000_0000_0000;
+        /// This memory region is described with additional ISA-specific memory
+        /// attributes as specified in `MemoryAttribute::ISA_MASK`.
+        const ISA_VALID = 0x4000_0000_0000_0000;
+        /// These bits are reserved for describing optional ISA-specific cache-
+        /// ability attributes that are not covered by the standard UEFI Memory
+        /// Attribute cacheability bits such as `UNCACHEABLE`, `WRITE_COMBINE`,
+        /// `WRITE_THROUGH`, `WRITE_BACK`, and `UNCACHEABLE_EXPORTED`.
+        ///
+        /// See Section 2.3 "Calling Conventions" in the UEFI Specification
+        /// for further information on each ISA that takes advantage of this.
+        const ISA_MASK = 0x0FFF_F000_0000_0000;
     }
 }
 


### PR DESCRIPTION
This PR adds functionality that was added to UEFI 2.10, mantis #2229 - "Support ISA-specific memory attributes in descriptors". 

## Checklist
- [ X ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ X ] Update the changelog (if necessary)
