### PR TITLE
Allow uefi-services to work when the "logger" feature is disabled in uefi

### DIFF
--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -15,13 +15,14 @@ is-it-maintained-issue-resolution = { repository = "rust-osdev/uefi-rs" }
 is-it-maintained-open-issues = { repository = "rust-osdev/uefi-rs" }
 
 [dependencies]
-uefi = { version = "0.17.0", features = ["alloc", "logger"] }
+uefi = { version = "0.17.0", features = ["alloc"] }
 log = { version = "0.4.5", default-features = false }
 cfg-if = "1.0.0"
 qemu-exit = { version = "3.0.1", optional = true }
 
 [features]
-default = ["panic_handler"]
+default = ["panic_handler", "logger"]
 # Enable QEMU-specific functionality
 qemu = ["qemu-exit"]
 panic_handler = []
+logger = ["uefi/logger"]

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -43,6 +43,7 @@ use uefi::{Event, Result};
 static mut SYSTEM_TABLE: Option<SystemTable<Boot>> = None;
 
 /// Global logger object
+#[cfg(feature = "logger")]
 static mut LOGGER: Option<uefi::logger::Logger> = None;
 
 /// Obtains a pointer to the system table.
@@ -77,7 +78,10 @@ pub fn init(st: &mut SystemTable<Boot>) -> Result {
         SYSTEM_TABLE = Some(st.unsafe_clone());
 
         // Setup logging and memory allocation
+
+        #[cfg(feature = "logger")]
         init_logger(st);
+
         let boot_services = st.boot_services();
         uefi::alloc::init(boot_services);
 
@@ -144,6 +148,7 @@ macro_rules! println {
 ///
 /// This is unsafe because you must arrange for the logger to be reset with
 /// disable() on exit from UEFI boot services.
+#[cfg(feature = "logger")]
 unsafe fn init_logger(st: &mut SystemTable<Boot>) {
     let stdout = st.stdout();
 
@@ -170,6 +175,8 @@ unsafe extern "efiapi" fn exit_boot_services(_e: Event, _ctx: Option<NonNull<c_v
     //
     // info!("Shutting down the UEFI utility library");
     SYSTEM_TABLE = None;
+
+    #[cfg(feature = "logger")]
     if let Some(ref mut logger) = LOGGER {
         logger.disable();
     }


### PR DESCRIPTION
Hello! We are using these crates in our project (Theseus OS), and we would like to use `uefi` without the `logger` feature.
However, I discovered that the `uefi-services` crate forces us to have the `logger` feature enabled in `uefi`, as per its manifest.

Due to how the `log` crate is implemented, it is impossible to set a logger twice; because `uefi-services` sets the default one up (and disables it when boot services are exited), we can't set our own logger up.

This PR simply adds a `logger` feature to `uefi-services`, which propagates to the same feature in `uefi`. This allows us to use both crates without the built-in logger.