### PR TITLE
Install UEFI targets via rustup

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,7 +26,9 @@ outside of the `uefi-rs` repo.
   ```toml
   [toolchain]
   channel = "nightly"
-  components = ["rust-src"]
+
+  # Install the x86_64 UEFI target; aarch64 and i686 are also available.
+  targets = ["x86_64-unknown-uefi"]
   ```
 
 - Build the crate:

--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -3,8 +3,7 @@
 ## Nightly toolchain
 
 Rust's nightly toolchain is currently required because uefi-rs uses some
-unstable features. The [`build-std`] feature we use to build the
-standard libraries is also unstable.
+unstable features.
 
 The easiest way to set this up is using a [rustup toolchain file]. In
 the root of your repository, add `rust-toolchain.toml`:
@@ -12,51 +11,24 @@ the root of your repository, add `rust-toolchain.toml`:
 ```toml
 [toolchain]
 channel = "nightly"
-components = ["rust-src"]
+targets = ["x86_64-unknown-uefi"]
 ```
 
+Here we have specified the `x86_64-unknown-uefi` target; there are also
+`i686-unknown-uefi` and `aarch64-unknown-uefi` targets available.
+
 Note that nightly releases can sometimes break, so you might opt to pin
-to a specific release. For example, `channel = "nightly-2022-09-01"`.
+to a specific release. For example, `channel = "nightly-2022-11-10"`.
 
 ## Build the application
 
 Run this command to build the application:
 
 ```sh
-cargo build --target x86_64-unknown-uefi \
-    -Zbuild-std=core,alloc
+cargo build --target x86_64-unknown-uefi
 ```
 
 This will produce an x86-64 executable:
 `target/x86_64-unknown-uefi/debug/my-uefi-app.efi`.
 
-## Simplifying the build command
-
-The above build command is verbose and not easy to remember. With a bit
-of configuration we can simplify it a lot.
-
-Create a `.cargo` directory in the root of the project:
-
-```sh
-mkdir .cargo
-```
-
-Create `.cargo/config.toml` with these contents:
-
-```toml
-[build]
-target = "x86_64-unknown-uefi"
-
-[unstable]
-build-std = ["core", "alloc"]
-```
-
-Now you can build much more simply:
-
-```sh
-cargo build
-```
-
-[`build-std`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
-[`rust-toolchain.toml`]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
-[rustup toolchain file]: https://rust-lang.github.io/rustup/concepts/toolchains.html
+[rustup toolchain file]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,3 @@
 [toolchain]
 channel = "nightly"
-
-# Install the `rust-src` component so that `-Zbuild-std` works. This in
-# addition to the components included in the default profile.
-components = ["rust-src"]
+targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -1,2 +1,0 @@
-[unstable]
-build-std = ["core", "alloc"]

--- a/template/README.md
+++ b/template/README.md
@@ -8,7 +8,6 @@ how to build and run a UEFI application developed using `uefi-rs`.
 
 ## File structure
 
-- [`.cargo/config`](./.cargo/config) sets some `build-std` options.
 - [`rust-toolchain.toml`](rust-toolchain.toml) sets the nightly channel.
 - [`Cargo.toml`](./Cargo.toml) shows the necessary dependencies.
 - [`src/main.rs`](./src/main.rs) has a minimal entry point that

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-components = ["rust-src"]
+targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]


### PR DESCRIPTION
As of `nightly-2022-11-10` the UEFI targets are tier 2 and available via rustup. That means we can switch to building without `build-std`.

In order to continue testing the older nightly, `cargo xtask build` checks if the targets are installed and switches back to `build-std` if not.

Fixes https://github.com/rust-osdev/uefi-rs/issues/504

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
