### PR TITLE
`Directory::read_entry_boxed` plus common abstraction `make_boxed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   you can write `some_cstr16.eq_str_until_nul("test")` instead of
   `some_cstr16.eq_str_until_nul(&"test")` now.
 - Added `TryFrom<core::ffi::CStr>` implementation for `CStr8`.
+- Added `Directory::read_entry_boxed` which works similar to `File::get_boxed_info`. This allows
+  easier iteration over the entries in a directory.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -79,3 +79,6 @@ pub mod global_allocator;
 
 #[cfg(feature = "logger")]
 pub mod logger;
+
+#[cfg(feature = "alloc")]
+pub(crate) mod mem;

--- a/uefi/src/mem.rs
+++ b/uefi/src/mem.rs
@@ -1,0 +1,133 @@
+//! This is a utility module with helper methods for allocations/memory.
+
+use crate::ResultExt;
+use crate::{Result, Status};
+use ::alloc::{alloc, boxed::Box};
+use core::alloc::Layout;
+use core::fmt::Debug;
+use core::slice;
+use uefi::data_types::Align;
+use uefi::Error;
+
+/// Helper to return owned versions of certain UEFI data structures on the heap in a [`Box`]. This
+/// function is intended to wrap low-level UEFI functions of this crate that
+/// - can consume an empty buffer without a panic to get the required buffer size in the errors
+///   payload,
+/// - consume a mutable reference to a buffer that will be filled with some data if the provided
+///   buffer size is sufficient, and
+/// - return a mutable typed reference that points to the same memory as the input buffer on
+///   success.
+pub fn make_boxed<'a, Data: Align + ?Sized + Debug + 'a>(
+    mut fetch_data_fn: impl FnMut(&'a mut [u8]) -> Result<&'a mut Data, Option<usize>>,
+) -> Result<Box<Data>> {
+    let required_size = match fetch_data_fn(&mut []).map_err(Error::split) {
+        // This is the expected case: the empty buffer passed in is too
+        // small, so we get the required size.
+        Err((Status::BUFFER_TOO_SMALL, Some(required_size))) => Ok(required_size),
+        // Propagate any other error.
+        Err((status, _)) => Err(Error::from(status)),
+        // Success is unexpected, return an error.
+        Ok(_) => Err(Error::from(Status::UNSUPPORTED)),
+    }?;
+
+    // We add trailing padding because the size of a rust structure must
+    // always be a multiple of alignment.
+    let layout = Layout::from_size_align(required_size, Data::alignment())
+        .unwrap()
+        .pad_to_align();
+
+    // Allocate the buffer.
+    let heap_buf: *mut u8 = unsafe {
+        let ptr = alloc::alloc(layout);
+        if ptr.is_null() {
+            return Err(Status::OUT_OF_RESOURCES.into());
+        }
+        ptr
+    };
+
+    // Read the data into the provided buffer.
+    let data: Result<&mut Data> = {
+        let buffer = unsafe { slice::from_raw_parts_mut(heap_buf, required_size) };
+        fetch_data_fn(buffer).discard_errdata()
+    };
+
+    // If an error occurred, deallocate the memory before returning.
+    let data: &mut Data = match data {
+        Ok(data) => data,
+        Err(err) => {
+            unsafe { alloc::dealloc(heap_buf, layout) };
+            return Err(err);
+        }
+    };
+
+    let data = unsafe { Box::from_raw(data) };
+
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ResultExt;
+    use core::mem::{align_of, size_of};
+
+    #[derive(Debug)]
+    #[repr(C)]
+    struct SomeData([u8; 4]);
+
+    impl Align for SomeData {
+        fn alignment() -> usize {
+            align_of::<Self>()
+        }
+    }
+
+    /// Function that behaves like the other UEFI functions. It takes a
+    /// mutable reference to a buffer memory that represents a [`SomeData`]
+    /// instance.
+    fn uefi_function_stub_read(buf: &mut [u8]) -> Result<&mut SomeData, Option<usize>> {
+        if buf.len() < 4 {
+            return Status::BUFFER_TOO_SMALL.into_with(|| panic!(), |_| Some(4));
+        };
+
+        buf[0] = 1;
+        buf[1] = 2;
+        buf[2] = 3;
+        buf[3] = 4;
+
+        let data = unsafe { &mut *buf.as_mut_ptr().cast::<SomeData>() };
+
+        Ok(data)
+    }
+
+    // Some basic checks so that miri reports everything is fine.
+    #[test]
+    fn some_data_type_size_constraints() {
+        assert_eq!(size_of::<SomeData>(), 4);
+        assert_eq!(align_of::<SomeData>(), 1);
+    }
+
+    #[test]
+    fn basic_stub_read() {
+        assert_eq!(
+            uefi_function_stub_read(&mut []).status(),
+            Status::BUFFER_TOO_SMALL
+        );
+        assert_eq!(
+            *uefi_function_stub_read(&mut []).unwrap_err().data(),
+            Some(4)
+        );
+
+        let mut buf: [u8; 4] = [0; 4];
+        let data = uefi_function_stub_read(&mut buf).unwrap();
+
+        assert_eq!(&data.0, &[1, 2, 3, 4])
+    }
+
+    #[test]
+    fn make_boxed_utility() {
+        let fetch_data_fn = |buf| uefi_function_stub_read(buf);
+        let data: Box<SomeData> = make_boxed(fetch_data_fn).unwrap();
+
+        assert_eq!(&data.0, &[1, 2, 3, 4])
+    }
+}

--- a/uefi/src/mem.rs
+++ b/uefi/src/mem.rs
@@ -17,8 +17,12 @@ use uefi::Error;
 ///   buffer size is sufficient, and
 /// - return a mutable typed reference that points to the same memory as the input buffer on
 ///   success.
-pub fn make_boxed<'a, Data: Align + ?Sized + Debug + 'a>(
-    mut fetch_data_fn: impl FnMut(&'a mut [u8]) -> Result<&'a mut Data, Option<usize>>,
+pub fn make_boxed<
+    'a,
+    Data: Align + ?Sized + Debug + 'a,
+    F: FnMut(&'a mut [u8]) -> Result<&'a mut Data, Option<usize>>,
+>(
+    mut fetch_data_fn: F,
 ) -> Result<Box<Data>> {
     let required_size = match fetch_data_fn(&mut []).map_err(Error::split) {
         // This is the expected case: the empty buffer passed in is too

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -77,7 +77,7 @@ impl Directory {
                     maybe_info.expect("Should have more entries")
                 })
         };
-        let file_info = make_boxed::<FileInfo>(fetch_data_fn)?;
+        let file_info = make_boxed::<FileInfo, _>(fetch_data_fn)?;
         Ok(Some(file_info))
     }
 

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -3,6 +3,16 @@ use crate::data_types::Align;
 use crate::Result;
 use core::ffi::c_void;
 
+#[cfg(feature = "alloc")]
+use {
+    crate::{ResultExt, Status},
+    ::alloc::boxed::Box,
+    alloc::alloc,
+    core::alloc::Layout,
+    core::ptr::NonNull,
+    core::slice,
+};
+
 /// A `FileHandle` that is also a directory.
 ///
 /// Use `File::into_type` or `Directory::new` to create a `Directory`. In
@@ -20,7 +30,7 @@ impl Directory {
         Self(RegularFile::new(handle))
     }
 
-    /// Read the next directory entry
+    /// Read the next directory entry.
     ///
     /// Try to read the next directory entry into `buffer`. If the buffer is too small, report the
     /// required buffer size as part of the error. If there are no more directory entries, return
@@ -54,6 +64,64 @@ impl Directory {
                 None
             }
         })
+    }
+
+    /// Wrapper around [`Self::read_entry`] that returns an owned copy of the data. It has the same
+    /// implications and requirements. On failure, the payload of `Err` is `()´.
+    #[cfg(feature = "alloc")]
+    pub fn read_entry_boxed(&mut self) -> Result<Option<Box<FileInfo>>> {
+        let read_entry_res = self.read_entry(&mut []);
+
+        // If no more entries are available, return early.
+        if let Ok(None) = read_entry_res {
+            return Ok(None);
+        }
+
+        let required_size = match read_entry_res
+            .expect_err("zero sized read unexpectedly succeeded")
+            .split()
+        {
+            // Early return if something has failed.
+            (s, None) => return Err(s.into()),
+            (_, Some(required_size)) => required_size,
+        };
+
+        // We add trailing padding because the size of a rust structure must
+        // always be a multiple of alignment.
+        let layout = Layout::from_size_align(required_size, FileInfo::alignment())
+            .unwrap()
+            .pad_to_align();
+
+        // Allocate the buffer.
+        let heap_buf: NonNull<u8> = unsafe {
+            let ptr = alloc::alloc(layout);
+            match NonNull::new(ptr) {
+                None => return Err(Status::OUT_OF_RESOURCES.into()),
+                Some(ptr) => ptr,
+            }
+        };
+
+        // Get the file info using the allocated buffer for storage.
+        let info = {
+            let buffer = unsafe { slice::from_raw_parts_mut(heap_buf.as_ptr(), layout.size()) };
+            self.read_entry(buffer).discard_errdata()
+        };
+
+        // If an error occurred, deallocate the memory before returning.
+        let info = match info {
+            Ok(info) => info,
+            Err(err) => {
+                unsafe { alloc::dealloc(heap_buf.as_ptr(), layout) };
+                return Err(err);
+            }
+        };
+
+        // Wrap the file info in a box so that it will be deallocated on
+        // drop. This is valid because the memory was allocated with the
+        // global allocator.
+        let info = info.map(|info| unsafe { Box::from_raw(info) });
+
+        Ok(info)
     }
 
     /// Start over the process of enumerating directory entries

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -165,7 +165,7 @@ pub trait File: Sized {
     /// Read the dynamically allocated info for a file.
     fn get_boxed_info<Info: FileProtocolInfo + ?Sized + Debug>(&mut self) -> Result<Box<Info>> {
         let fetch_data_fn = |buf| self.get_info::<Info>(buf);
-        let file_info = make_boxed::<Info>(fetch_data_fn)?;
+        let file_info = make_boxed::<Info, _>(fetch_data_fn)?;
         Ok(file_info)
     }
 

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -17,11 +17,7 @@ use core::fmt::Debug;
 use core::mem;
 use core::ptr;
 #[cfg(feature = "alloc")]
-use {
-    crate::ResultExt,
-    ::alloc::{alloc, alloc::Layout, boxed::Box},
-    core::slice,
-};
+use {alloc::boxed::Box, uefi::mem::make_boxed};
 
 pub use self::info::{FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi};
 pub use self::{dir::Directory, regular::RegularFile};
@@ -166,53 +162,11 @@ pub trait File: Sized {
     }
 
     #[cfg(feature = "alloc")]
-    /// Get the dynamically allocated info for a file
+    /// Read the dynamically allocated info for a file.
     fn get_boxed_info<Info: FileProtocolInfo + ?Sized + Debug>(&mut self) -> Result<Box<Info>> {
-        // Initially try get_info with an empty array, this should always fail
-        // as all Info types at least need room for a null-terminator.
-        let size = match self
-            .get_info::<Info>(&mut [])
-            .expect_err("zero sized get_info unexpectedly succeeded")
-            .split()
-        {
-            (s, None) => return Err(s.into()),
-            (_, Some(size)) => size,
-        };
-
-        // We add trailing padding because the size of a rust structure must
-        // always be a multiple of alignment.
-        let layout = Layout::from_size_align(size, Info::alignment())
-            .unwrap()
-            .pad_to_align();
-
-        // Allocate the buffer.
-        let data: *mut u8 = unsafe {
-            let data = alloc::alloc(layout);
-            if data.is_null() {
-                return Err(Status::OUT_OF_RESOURCES.into());
-            }
-            data
-        };
-
-        // Get the file info using the allocated buffer for storage.
-        let info = {
-            let buffer = unsafe { slice::from_raw_parts_mut(data, layout.size()) };
-            self.get_info::<Info>(buffer).discard_errdata()
-        };
-
-        // If an error occurred, deallocate the memory before returning.
-        let info = match info {
-            Ok(info) => info,
-            Err(err) => {
-                unsafe { alloc::dealloc(data, layout) };
-                return Err(err);
-            }
-        };
-
-        // Wrap the file info in a box so that it will be deallocated on
-        // drop. This is valid because the memory was allocated with the
-        // global allocator.
-        unsafe { Ok(Box::from_raw(info)) }
+        let fetch_data_fn = |buf| self.get_info::<Info>(buf);
+        let file_info = make_boxed::<Info>(fetch_data_fn)?;
+        Ok(file_info)
     }
 
     /// Returns if the underlying file is a regular file.

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -201,7 +201,6 @@ impl Cargo {
                 }
             }
             CargoAction::Miri => {
-                cmd.env("MIRIFLAGS", "-Zmiri-tag-raw-pointers");
                 action = "miri";
                 sub_action = Some("test");
             }


### PR DESCRIPTION
This adds a function to `Directory` to get directory entry information as boxed/owned values. This is done similar to `File::get_boxed_info` [commit1]. Unfortunately, the code is almost identical. I tried to create a new commonly shared abstraction [commit2]. However, it is not that easy to let it compile successfully. I'm seeking for advice.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
