### PR TITLE
msrv: 1.67 nightly (2022-11-16)

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-11-16"
 components = ["rust-src"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## uefi - [Unreleased]
+- The guaranteed MSRV is now `nightly-2022-11-16` (1.67).
 
 ## uefi-macros - [Unreleased]
+- The guaranteed MSRV is now `nightly-2022-11-16` (1.67).
 
 ## uefi-services - [Unreleased]
+- The guaranteed MSRV is now `nightly-2022-11-16` (1.67).
 
 ## uefi - 0.18.0 (2022-11-15)
 

--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -16,7 +16,7 @@ components = ["rust-src"]
 ```
 
 Note that nightly releases can sometimes break, so you might opt to pin
-to a specific release. For example, `channel = "nightly-2022-09-01"`.
+to a specific release. For example, `channel = "nightly-2022-11-16"`.
 
 ## Build the application
 


### PR DESCRIPTION
After releasing v0.18, we finally can bump the MSRV to the latest possible nightly.
This will enable us to use lots of new features.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
