### PR TITLE
Add temporary workaround for yanked dependency

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,7 +11,8 @@ clap = { version = "4.0.4", features = ["derive"] }
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }
 fs-err = "2.6.0"
 heck = "0.4.0"
-mbrman = "0.5.0"
+# Use git as a temporary workaround for https://github.com/rust-osdev/uefi-rs/issues/573.
+mbrman = { git = "https://github.com/cecton/mbrman.git", rev = "78565860e55c272488d94480e72a4e2cd159ad8e" }
 nix = "0.25.0"
 proc-macro2 = "1.0.46"
 quote = "1.0.21"


### PR DESCRIPTION
This is a hopefully very temporary workaround for https://github.com/rust-osdev/uefi-rs/issues/573.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
