### PR TITLE
Several small improvements to EqStrUntilNul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## uefi - [Unreleased]
+- Implementations for the trait `EqStrUntilNul` now allow `?Sized` inputs. This means that
+  you can write `some_cstr16.eq_str_until_nul("test")` instead of
+  `some_cstr16.eq_str_until_nul(&"test")` now.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -190,12 +190,15 @@ mod tests {
         );
     }
 
-    /// Tests the trait implementation of trait [EqStrUntilNul].
+    /// Tests the trait implementation of trait [`EqStrUntilNul]` for [`CString16`].
+    ///
+    /// This tests that `String` and `str` from the standard library can be
+    /// checked for equality against a [`CString16`]. It checks both directions,
+    /// i.e., the equality is reflexive.
     #[test]
     fn test_cstring16_eq_std_str() {
         let input = CString16::try_from("test").unwrap();
 
-        // test various comparisons with different order (left, right)
         assert!(input.eq_str_until_nul("test")); // requires ?Sized constraint
         assert!(input.eq_str_until_nul(&"test"));
         assert!(input.eq_str_until_nul(&String::from("test")));

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -128,7 +128,7 @@ impl PartialEq<&CStr16> for CString16 {
     }
 }
 
-impl<StrType: AsRef<str>> EqStrUntilNul<StrType> for CString16 {
+impl<StrType: AsRef<str> + ?Sized> EqStrUntilNul<StrType> for CString16 {
     fn eq_str_until_nul(&self, other: &StrType) -> bool {
         let this = self.as_ref();
         this.eq_str_until_nul(other)
@@ -196,6 +196,7 @@ mod tests {
         let input = CString16::try_from("test").unwrap();
 
         // test various comparisons with different order (left, right)
+        assert!(input.eq_str_until_nul("test")); // requires ?Sized constraint
         assert!(input.eq_str_until_nul(&"test"));
         assert!(input.eq_str_until_nul(&String::from("test")));
 

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -578,4 +578,41 @@ mod tests {
         const S: &CStr16 = cstr16!("ABC");
         assert_eq!(S.to_u16_slice_with_nul(), [65, 66, 67, 0]);
     }
+
+    /// Tests the trait implementation of trait [`EqStrUntilNul]` for [`CStr8`].
+    ///
+    /// This tests that `String` and `str` from the standard library can be
+    /// checked for equality against a [`CStr8`]. It checks both directions,
+    /// i.e., the equality is reflexive.
+    #[test]
+    fn test_cstr8_eq_std_str() {
+        let input: &CStr8 = cstr8!("test");
+
+        // test various comparisons with different order (left, right)
+        assert!(input.eq_str_until_nul("test")); // requires ?Sized constraint
+        assert!(input.eq_str_until_nul(&"test"));
+        assert!(input.eq_str_until_nul(&String::from("test")));
+
+        // now other direction
+        assert!(String::from("test").eq_str_until_nul(input));
+        assert!("test".eq_str_until_nul(input));
+    }
+
+    /// Tests the trait implementation of trait [`EqStrUntilNul]` for [`CStr16`].
+    ///
+    /// This tests that `String` and `str` from the standard library can be
+    /// checked for equality against a [`CStr16`]. It checks both directions,
+    /// i.e., the equality is reflexive.
+    #[test]
+    fn test_cstr16_eq_std_str() {
+        let input: &CStr16 = cstr16!("test");
+
+        assert!(input.eq_str_until_nul("test")); // requires ?Sized constraint
+        assert!(input.eq_str_until_nul(&"test"));
+        assert!(input.eq_str_until_nul(&String::from("test")));
+
+        // now other direction
+        assert!(String::from("test").eq_str_until_nul(input));
+        assert!("test".eq_str_until_nul(input));
+    }
 }


### PR DESCRIPTION
I noticed that there is some small room for improvement for the `EqStrUntilNul` trait.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
