### PR TITLE
`TryFrom<core::ffi::CStr>` implementation for `CStr8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Implementations for the trait `EqStrUntilNul` now allow `?Sized` inputs. This means that
   you can write `some_cstr16.eq_str_until_nul("test")` instead of
   `some_cstr16.eq_str_until_nul(&"test")` now.
+- Added `TryFrom<core::ffi::CStr>` implementation for `CStr8`.
 
 ## uefi-macros - [Unreleased]
 


### PR DESCRIPTION
After this was reverted in 5f4e15870513954d4a3c8b5099f26b42eecaaf28, we now can add it again, as our MSRV is now recent enough.

This reverts https://github.com/rust-osdev/uefi-rs/pull/509 and closes https://github.com/rust-osdev/uefi-rs/issues/510

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
