### PR TITLE
Simplify serial usage in test-runner and check that tests completed

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -75,11 +75,7 @@ fn check_revision(rev: uefi::table::Revision) {
     );
 }
 
-/// Ask the test runner to check the current screen output against a reference
-///
-/// This functionality is very specific to our QEMU-based test runner. Outside
-/// of it, we just pause the tests for a couple of seconds to allow visual
-/// inspection of the output.
+/// Ask the test runner to check the current screen output against a reference.
 fn check_screenshot(bt: &BootServices, name: &str) {
     let serial_handles = bt
         .find_handles::<Serial>()

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -1,3 +1,4 @@
+use crate::{send_request_to_host, HostRequest};
 use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::{BootServices, OpenProtocolAttributes, OpenProtocolParams};
@@ -23,7 +24,7 @@ pub unsafe fn test(image: Handle, bt: &BootServices) {
         fill_color(gop);
         draw_fb(gop);
 
-        crate::check_screenshot(bt, "gop_test");
+        send_request_to_host(bt, HostRequest::Screenshot("gop_test"));
     } else {
         // No tests can be run.
         warn!("UEFI Graphics Output Protocol is not supported");

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -60,7 +60,7 @@ impl Pipe {
     }
 
     /// Create an `Io` object for performing reads and writes.
-    pub fn open_io(&self) -> Result<Io<File, File>> {
+    pub fn open_io(&self) -> Result<Io> {
         let reader;
         let writer;
 

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -337,7 +337,12 @@ fn process_qemu_io(mut monitor_io: Io, mut serial_io: Io, tmp_dir: &Path) -> Res
                 Path::new("uefi-test-runner/screenshots").join(format!("{reference_name}.ppm"));
             let expected = fs_err::read(reference_file)?;
             let actual = fs_err::read(&screenshot_path)?;
-            assert_eq!(expected, actual);
+            // Use `assert` rather than `assert_eq` here to avoid
+            // dumping a huge amount of raw pixel data on failure.
+            assert!(
+                expected == actual,
+                "screenshot does not match reference image"
+            )
         }
     }
 


### PR DESCRIPTION
This contains a number of related improvements to the test runner. The main changes are:
* If the screenshot test fails for some reason, don't dump the raw pixel data to the console. The data is not human-readable anyway, and if your console is slow it can take a while to print it all.
* Drop the second serial device from the test runner. We added this a while ago to fix the conflict in the screenshot test between needing to open the serial device in exclusive mode (so that the timeout and input aren't messed with by other EDK2 code) and needing to continue writing logs after the screenshot. Turns out there's a simpler way to fix this: we can use a single serial device, which does break the console logger, but we can restore the console output with `connect_controller`.
* Add `TESTS_COMPLETE` message that's sent the same way as the `SCREENSHOT` message. This is used to signal at the end of the tests that they completed successfully. If the host never receives that message, it exits with an error.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
