### PR TITLE
Added `read_entry_boxed_in` and `get_boxed_info_in` that use the `allocator_api`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install qemu-system-x86 ovmf -y
 
-    - name: Build
+    - name: Build (without unstable)
       run: cargo xtask build --target x86_64
 
     - name: Run VM tests
@@ -77,8 +77,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Run cargo test
+      - name: Run cargo test (without unstable)
         run: cargo xtask test
+
+      # At least one unit test, for make_boxed() currently, has different behaviour dependent on
+      # the unstable feature.
+      - name: Run cargo test (with unstable)
+        run: cargo xtask test --include-unstable
 
   lints:
     name: Lints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 # Changelog
 
 ## uefi - [Unreleased]
+
+### Added
 - Implementations for the trait `EqStrUntilNul` now allow `?Sized` inputs. This means that
   you can write `some_cstr16.eq_str_until_nul("test")` instead of
   `some_cstr16.eq_str_until_nul(&"test")` now.
 - Added `TryFrom<core::ffi::CStr>` implementation for `CStr8`.
 - Added `Directory::read_entry_boxed` which works similar to `File::get_boxed_info`. This allows
-  easier iteration over the entries in a directory.
+  easier iteration over the entries in a directory. (requires the **alloc** feature)
+- Added `Directory::read_entry_boxed_in` and `File::get_boxed_info_in` that use the `allocator_api`
+  feature. (requires the **unstable** and **alloc** features)
 - Added an `core::error::Error` implementation for `Error` to ease
-  integration with error-handling crates.
+  integration with error-handling crates. (requires the **unstable** feature)
+
+### Changed
+
+### Removed
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 edition = "2021"
 
 [dependencies]
-uefi = { path = "../uefi", features = ['alloc'] }
+# TODO we should let the uefi-test-runner run with and without unstable.
+uefi = { path = "../uefi", features = ["alloc", "unstable"] }
 uefi-services = { path = "../uefi-services" }
 
 log = { version = "0.4.17", default-features = false }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -19,6 +19,7 @@ logger = []
 # were observed on the VirtualBox UEFI implementation (see uefi-rs#121).
 # In those cases, this feature can be excluded by removing the default features.
 panic-on-logger-errors = []
+# Generic gate to code that uses unstable features of Rust. You usually need a nightly toolchain.
 unstable = []
 
 [dependencies]

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -38,6 +38,8 @@
 //!   feature is not enabled, but once a couple more required features
 //!   are stabilized we intend to make the `uefi` crate work on the
 //!   stable channel by default.
+//!   As example, in conjunction with the `alloc`-feature, this gate allows
+//!   the `allocator_api` on certain functions.
 //!
 //! The `global_allocator` and `logger` features require special
 //! handling to perform initialization and tear-down. The
@@ -62,6 +64,7 @@
 #![feature(ptr_metadata)]
 #![cfg_attr(feature = "alloc", feature(vec_into_raw_parts))]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
+#![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 // Enable some additional warnings and lints.
@@ -101,5 +104,6 @@ pub mod global_allocator;
 #[cfg(feature = "logger")]
 pub mod logger;
 
+// As long as this is behind "alloc", we can simplify cfg-feature attributes in this module.
 #[cfg(feature = "alloc")]
 pub(crate) mod mem;

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -95,8 +95,18 @@ impl Feature {
     }
 
     /// Set of features that enables more code in the root uefi crate.
-    pub fn more_code() -> Vec<Self> {
-        vec![Self::GlobalAllocator, Self::Alloc, Self::Logger]
+    /// # Parameters
+    /// - `include_unstable` - add all functionality behind the `unstable` feature
+    /// - `runtime_features` - add all functionality that effect the runtime of Rust
+    pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
+        let mut base_features = vec![Self::Alloc, Self::Logger];
+        if include_unstable {
+            base_features.extend([Self::Unstable])
+        }
+        if runtime_features {
+            base_features.extend([Self::GlobalAllocator])
+        }
+        base_features
     }
 
     fn comma_separated_string(features: &[Feature]) -> String {
@@ -316,8 +326,20 @@ mod tests {
     #[test]
     fn test_comma_separated_features() {
         assert_eq!(
-            Feature::comma_separated_string(&Feature::more_code()),
-            "global_allocator,alloc,logger"
+            Feature::comma_separated_string(&Feature::more_code(false, false)),
+            "alloc,logger"
+        );
+        assert_eq!(
+            Feature::comma_separated_string(&Feature::more_code(false, true)),
+            "alloc,logger,global_allocator"
+        );
+        assert_eq!(
+            Feature::comma_separated_string(&Feature::more_code(true, false)),
+            "alloc,logger,unstable"
+        );
+        assert_eq!(
+            Feature::comma_separated_string(&Feature::more_code(true, true)),
+            "alloc,logger,unstable,global_allocator"
         );
     }
 

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -150,7 +150,12 @@ pub struct QemuOpt {
 
 /// Run unit tests and doctests on the host.
 #[derive(Debug, Parser)]
-pub struct TestOpt;
+pub struct TestOpt {
+    /// Include all features behind the "unstable" gate. uefi-rs must build without unstable
+    /// functionality on stable (eventually) and with it in our nightly MSRV.
+    #[clap(long, action)]
+    pub include_unstable: bool,
+}
 
 /// Build the template against the crates.io packages.
 #[derive(Debug, Parser)]


### PR DESCRIPTION
This closes #483. It builds on the foundation created in #559.

It adds the methods `read_entry_boxed_in` and `get_boxed_info_in` that need the new `unstable_alloc` feature. `Dir::read_entry_boxed` and `File::get_boxed_info` will work with both, stable and nightly Rust (i.e., default allocation and allocator api).

**However, there is one problem**: We need to discuss how we integrate unstable features into cargo xtask build/test.

I tested it manually, but we need to test in CI if everything builds with `unstable_alloc` and without.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
