### PR TITLE
xtask: Fully drop support for build-std

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-08-25"
-components = ["rust-src"]
+channel = "nightly-2022-11-22"
+targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ prerequisites for running the tests.
 For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
 
 The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-08-25.
+The nightly MSRV is currently 2022-11-22.
 
 [unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
 

--- a/uefi/README.md
+++ b/uefi/README.md
@@ -52,7 +52,7 @@ For additional information, refer to the [UEFI specification][spec].
 For instructions on how to create your own UEFI apps, see the [tutorial].
 
 The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-08-25.
+The nightly MSRV is currently 2022-11-22.
 
 [unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
 [tutorial]: https://rust-osdev.github.io/uefi-rs/HEAD/tutorial/introduction.html

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -212,19 +212,6 @@ pub fn fix_nested_cargo_env(cmd: &mut Command) {
     cmd.env("PATH", sanitized_path(orig_path));
 }
 
-/// Check if the three UEFI targets are installed via rustup (only
-/// supported since nightly-2022-11-10).
-fn is_target_installed(target: &str) -> Result<bool> {
-    let output = Command::new("rustup")
-        .args(["target", "list", "--installed"])
-        .output()?;
-    if !output.status.success() {
-        bail!("failed to get installed targets");
-    }
-    let stdout = String::from_utf8(output.stdout)?;
-    Ok(stdout.lines().any(|x| x == target))
-}
-
 #[derive(Debug)]
 pub struct Cargo {
     pub action: CargoAction,
@@ -290,13 +277,6 @@ impl Cargo {
 
         if let Some(target) = self.target {
             cmd.args(["--target", target.as_triple()]);
-
-            // If the target is not installed, use build-std. Keep this
-            // around until our minimum-supported nightly version is at
-            // least 2022-11-10.
-            if !is_target_installed(target.as_triple())? {
-                cmd.args(["-Zbuild-std=core,alloc"]);
-            }
         }
 
         if self.packages.is_empty() {


### PR DESCRIPTION
This requires an MSRV bump to 2022-11-22. (The build-std targets were actually added in 2022-11-10, but there were some bugs in the dist at that time that cause linker errors on i686.)

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
