### PR TITLE
Implement Error trait for uefi::Error

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-08-25"
 components = ["rust-src"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added `TryFrom<core::ffi::CStr>` implementation for `CStr8`.
 - Added `Directory::read_entry_boxed` which works similar to `File::get_boxed_info`. This allows
   easier iteration over the entries in a directory.
+- Added an `core::error::Error` implementation for `Error` to ease
+  integration with error-handling crates.
 
 ## uefi-macros - [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ prerequisites for running the tests.
 For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
 
 The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-08-08.
+The nightly MSRV is currently 2022-08-25.
 
 [unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -41,6 +41,7 @@
 #![feature(maybe_uninit_slice)]
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
+#![feature(error_in_core)]
 #![cfg_attr(feature = "alloc", feature(vec_into_raw_parts))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -45,3 +45,5 @@ impl<Data: Debug + Display> Display for Error<Data> {
         write!(f, "UEFI Error {}: {}", self.status(), self.data())
     }
 }
+
+impl<Data: Debug + Display> core::error::Error for Error<Data> {}

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -1,5 +1,5 @@
 use super::Status;
-use core::fmt::Debug;
+use core::fmt::{Debug, Display};
 
 /// Errors emitted from UEFI entry point must propagate erronerous UEFI statuses,
 /// and may optionally propagate additional entry point-specific data.
@@ -37,5 +37,11 @@ impl<Data: Debug> Error<Data> {
 impl From<Status> for Error<()> {
     fn from(status: Status) -> Self {
         Self { status, data: () }
+    }
+}
+
+impl<Data: Debug + Display> Display for Error<Data> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "UEFI Error {}: {}", self.status(), self.data())
     }
 }

--- a/uefi/src/result/status.rs
+++ b/uefi/src/result/status.rs
@@ -168,6 +168,12 @@ impl From<Status> for Result<(), ()> {
     }
 }
 
+impl core::fmt::Display for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
In order to use error-handling crates, such as [anyhow](https://crates.io/crates/anyhow), the `uefi::Error` type needs to implement the [`Error`](https://doc.rust-lang.org/core/error/trait.Error.html) trait.

To do this, I had to bump the minimum nightly version a couple of days to enable the `error_in_core` feature.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
