### PR TITLE
Add `unstable` feature and improve CI for feature flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,3 +159,13 @@ jobs:
 
     - name: Build
       run: cargo xtask build
+
+  build_feature_permutations:
+    name: Check that the build works for all feature combinations
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo xtask build --feature-permutations

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -19,6 +19,7 @@ logger = []
 # were observed on the VirtualBox UEFI implementation (see uefi-rs#121).
 # In those cases, this feature can be excluded by removing the default features.
 panic-on-logger-errors = []
+unstable = []
 
 [dependencies]
 bitflags = "1.3.1"

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -32,6 +32,12 @@
 //!   is not a high-performance logger.
 //! - `panic-on-logger-errors` (enabled by default): Panic if a text
 //!   output error occurs in the logger.
+//! - `unstable`: Enable functionality that depends on [unstable
+//!   features] in the nightly compiler. Note that currently the `uefi`
+//!   crate _always_ requires unstable features even if the `unstable`
+//!   feature is not enabled, but once a couple more required features
+//!   are stabilized we intend to make the `uefi` crate work on the
+//!   stable channel by default.
 //!
 //! The `global_allocator` and `logger` features require special
 //! handling to perform initialization and tear-down. The
@@ -48,13 +54,14 @@
 //!
 //! [`GlobalAlloc`]: alloc::alloc::GlobalAlloc
 //! [`uefi-services`]: https://crates.io/crates/uefi-services
+//! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
 #![feature(abi_efiapi)]
 #![feature(maybe_uninit_slice)]
 #![feature(negative_impls)]
 #![feature(ptr_metadata)]
-#![feature(error_in_core)]
 #![cfg_attr(feature = "alloc", feature(vec_into_raw_parts))]
+#![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 // Enable some additional warnings and lints.

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -46,4 +46,5 @@ impl<Data: Debug + Display> Display for Error<Data> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<Data: Debug + Display> core::error::Error for Error<Data> {}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.0.4", features = ["derive"] }
 fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a32b4e0344fcdde77359ef9e75432" }
 fs-err = "2.6.0"
 heck = "0.4.0"
+itertools = "0.10.5"
 # Use git as a temporary workaround for https://github.com/rust-osdev/uefi-rs/issues/573.
 mbrman = { git = "https://github.com/cecton/mbrman.git", rev = "78565860e55c272488d94480e72a4e2cd159ad8e" }
 nix = "0.25.0"

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -45,21 +45,52 @@ impl Package {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Feature {
-    GlobalAllocator,
+    // `uefi` features.
     Alloc,
+    GlobalAllocator,
     Logger,
+    PanicOnLoggerErrors,
+    Unstable,
 
+    // `uefi-services` features.
+    PanicHandler,
+    Qemu,
+    ServicesLogger,
+
+    // `uefi-test-runner` features.
     Ci,
 }
 
 impl Feature {
     fn as_str(&self) -> &'static str {
         match self {
-            Self::GlobalAllocator => "global_allocator",
             Self::Alloc => "alloc",
+            Self::GlobalAllocator => "global_allocator",
             Self::Logger => "logger",
+            Self::PanicOnLoggerErrors => "panic-on-logger-errors",
+            Self::Unstable => "unstable",
+
+            Self::PanicHandler => "uefi-services/panic_handler",
+            Self::Qemu => "uefi-services/qemu",
+            Self::ServicesLogger => "uefi-services/logger",
 
             Self::Ci => "uefi-test-runner/ci",
+        }
+    }
+
+    /// Get the features for the given package.
+    pub fn package_features(package: Package) -> Vec<Self> {
+        match package {
+            Package::Uefi => vec![
+                Self::Alloc,
+                Self::GlobalAllocator,
+                Self::Logger,
+                Self::PanicOnLoggerErrors,
+                Self::Unstable,
+            ],
+            Package::UefiServices => vec![Self::PanicHandler, Self::Qemu, Self::ServicesLogger],
+            Package::UefiTestRunner => vec![Self::Ci],
+            _ => vec![],
         }
     }
 

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -62,6 +62,11 @@ pub struct BuildOpt {
 
     #[clap(flatten)]
     pub build_mode: BuildModeOpt,
+
+    /// Build multiple times to check that different feature
+    /// combinations work.
+    #[clap(long, action)]
+    pub feature_permutations: bool,
 }
 
 /// Run clippy on all the packages.


### PR DESCRIPTION
Note: the first commit in this PR is from https://github.com/rust-osdev/uefi-rs/pull/589 so that we don't have to resolve merge conflicts later.

This PR adds an `unstable` feature to the uefi crate. It will be used to gate new unstable features as we work towards being able to compile on the stable channel. Re naming, both `nightly` and `unstable` are used frequently by other crates. [`nightly` is slightly more common](https://github.com/rust-osdev/uefi-rs/pull/584#discussion_r1032697720), but I think `unstable` is more accurate since unstable features can be enabled on non-nightly builds of the compiler, and the documentation for these features is the [Unstable Book](https://doc.rust-lang.org/unstable-book/), as opposed to the "Nightly Book".

Also in this PR is a new build mode: `cargo xtask build --feature-permutations`. This builds both `uefi` and `uefi-services` a bunch of times with different feature flags set, to make sure that compilation still works in all cases. There's a new CI job to run this command as well.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
