### PR TITLE
clippy: require must_use_candidate lint

### DIFF
--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -29,6 +29,7 @@
 #![no_std]
 #![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
+#![deny(clippy::must_use_candidate)]
 
 extern crate log;
 // Core types.
@@ -64,6 +65,7 @@ static mut LOGGER: Option<uefi::logger::Logger> = None;
 /// `init` must have been called first by the UEFI app.
 ///
 /// The returned pointer is only valid until boot services are exited.
+#[must_use]
 pub fn system_table() -> NonNull<SystemTable<Boot>> {
     unsafe {
         let table_ref = SYSTEM_TABLE

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -73,6 +73,7 @@ pub trait Align {
     /// Calculate the offset from `val` necessary to make it aligned,
     /// rounding up. For example, if `val` is 1 and the alignment is 8,
     /// this will return 7. Returns 0 if `val == 0`.
+    #[must_use]
     fn offset_up_to_alignment(val: usize) -> usize {
         assert!(Self::alignment() != 0);
         let r = val % Self::alignment();
@@ -84,6 +85,7 @@ pub trait Align {
     }
 
     /// Round `val` up so that it is aligned.
+    #[must_use]
     fn round_up_to_alignment(val: usize) -> usize {
         val + Self::offset_up_to_alignment(val)
     }

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -78,6 +78,7 @@ impl CStr8 {
     /// The function will start accessing memory from `ptr` until the first
     /// null byte. It's the callers responsibility to ensure `ptr` points to
     /// a valid null-terminated string in accessible memory.
+    #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char8) -> &'ptr Self {
         let mut len = 0;
         while *ptr.add(len) != NUL_8 {
@@ -106,22 +107,26 @@ impl CStr8 {
     ///
     /// It's the callers responsibility to ensure chars is a valid Latin-1
     /// null-terminated string, with no interior null bytes.
+    #[must_use]
     pub const unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
         &*(chars as *const [u8] as *const Self)
     }
 
     /// Returns the inner pointer to this CStr8.
+    #[must_use]
     pub const fn as_ptr(&self) -> *const Char8 {
         self.0.as_ptr()
     }
 
     /// Converts this CStr8 to a slice of bytes without the terminating null byte.
+    #[must_use]
     pub fn to_bytes(&self) -> &[u8] {
         let chars = self.to_bytes_with_nul();
         &chars[..chars.len() - 1]
     }
 
     /// Converts this CStr8 to a slice of bytes containing the trailing null byte.
+    #[must_use]
     pub const fn to_bytes_with_nul(&self) -> &[u8] {
         unsafe { &*(&self.0 as *const [Char8] as *const [u8]) }
     }
@@ -189,6 +194,7 @@ impl CStr16 {
     /// The function will start accessing memory from `ptr` until the first
     /// null byte. It's the callers responsibility to ensure `ptr` points to
     /// a valid string, in accessible memory.
+    #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char16) -> &'ptr Self {
         let mut len = 0;
         while *ptr.add(len) != NUL_16 {
@@ -227,6 +233,7 @@ impl CStr16 {
     ///
     /// It's the callers responsibility to ensure chars is a valid UCS-2
     /// null-terminated string, with no interior null bytes.
+    #[must_use]
     pub const unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
         &*(codes as *const [u16] as *const Self)
     }
@@ -303,27 +310,32 @@ impl CStr16 {
     }
 
     /// Returns the inner pointer to this C string
+    #[must_use]
     pub const fn as_ptr(&self) -> *const Char16 {
         self.0.as_ptr()
     }
 
     /// Get the underlying [`Char16`] slice, including the trailing null.
+    #[must_use]
     pub const fn as_slice_with_nul(&self) -> &[Char16] {
         &self.0
     }
 
     /// Converts this C string to a u16 slice
+    #[must_use]
     pub fn to_u16_slice(&self) -> &[u16] {
         let chars = self.to_u16_slice_with_nul();
         &chars[..chars.len() - 1]
     }
 
     /// Converts this C string to a u16 slice containing the trailing 0 char
+    #[must_use]
     pub const fn to_u16_slice_with_nul(&self) -> &[u16] {
         unsafe { &*(&self.0 as *const [Char16] as *const [u16]) }
     }
 
     /// Returns an iterator over this C string
+    #[must_use]
     pub const fn iter(&self) -> CStr16Iter {
         CStr16Iter {
             inner: self,
@@ -332,6 +344,7 @@ impl CStr16 {
     }
 
     /// Get the number of bytes in the string (including the trailing null character).
+    #[must_use]
     pub const fn num_bytes(&self) -> usize {
         self.0.len() * 2
     }

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -36,17 +36,20 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     }
 
     /// Returns true if the slice has a length of 0.
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 
     /// Returns the number of elements in the slice.
+    #[must_use]
     pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns the element at `index`, or `None` if the `index` is out
     /// of bounds.
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<T> {
         if index < self.len {
             Some(unsafe { self.data.add(index).read_unaligned() })
@@ -58,6 +61,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     /// Returns an iterator over the slice.
     ///
     /// The iterator yields all items from start to end.
+    #[must_use]
     pub const fn iter(&'a self) -> UnalignedSliceIter<'a, T> {
         UnalignedSliceIter {
             slice: self,
@@ -111,6 +115,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
 
     /// Copies `self` into a new `Vec`.
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_vec(&self) -> Vec<T> {
         let len = self.len();
         let mut v = Vec::with_capacity(len);

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -67,6 +67,7 @@
 // Enable some additional warnings and lints.
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
+#![deny(clippy::must_use_candidate)]
 
 // Enable once we use vec![] or similar
 // #[cfg_attr(feature = "alloc", macro_use)]

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -109,6 +109,7 @@ impl<'boot> GraphicsOutput<'boot> {
     }
 
     /// Returns information about all available graphics modes.
+    #[must_use]
     pub fn modes(&'_ self) -> impl ExactSizeIterator<Item = Mode> + '_ {
         ModeIter {
             gop: self,
@@ -294,6 +295,7 @@ impl<'boot> GraphicsOutput<'boot> {
     }
 
     /// Returns the frame buffer information for the current mode.
+    #[must_use]
     pub const fn current_mode_info(&self) -> ModeInfo {
         *self.mode.info
     }
@@ -377,11 +379,13 @@ impl Mode {
     /// The size of the info structure in bytes.
     ///
     /// Newer versions of the spec might add extra information, in a backwards compatible way.
+    #[must_use]
     pub const fn info_size(&self) -> usize {
         self.info_sz
     }
 
     /// Returns a reference to the mode info structure.
+    #[must_use]
     pub const fn info(&self) -> &ModeInfo {
         &self.info
     }
@@ -404,16 +408,19 @@ impl ModeInfo {
     /// Returns the (horizontal, vertical) resolution.
     ///
     /// On desktop monitors, this usually means (width, height).
+    #[must_use]
     pub const fn resolution(&self) -> (usize, usize) {
         (self.hor_res as usize, self.ver_res as usize)
     }
 
     /// Returns the format of the frame buffer.
+    #[must_use]
     pub const fn pixel_format(&self) -> PixelFormat {
         self.format
     }
 
     /// Returns the bitmask of the custom pixel format, if available.
+    #[must_use]
     pub const fn pixel_bitmask(&self) -> Option<PixelBitmask> {
         match self.format {
             PixelFormat::Bitmask => Some(self.mask),
@@ -425,6 +432,7 @@ impl ModeInfo {
     ///
     /// Due to performance reasons, the stride might not be equal to the width,
     /// instead the stride might be bigger for better alignment.
+    #[must_use]
     pub const fn stride(&self) -> usize {
         self.stride as usize
     }
@@ -475,6 +483,7 @@ pub struct BltPixel {
 
 impl BltPixel {
     /// Create a new pixel from RGB values.
+    #[must_use]
     pub const fn new(red: u8, green: u8, blue: u8) -> Self {
         Self {
             red,
@@ -582,6 +591,7 @@ impl<'gop> FrameBuffer<'gop> {
     }
 
     /// Query the framebuffer size in bytes
+    #[must_use]
     pub const fn size(&self) -> usize {
         self.size
     }
@@ -607,6 +617,7 @@ impl<'gop> FrameBuffer<'gop> {
     /// - You must honor the pixel format and stride specified by the mode info
     /// - There is no bound checking on memory accesses in release mode
     #[inline]
+    #[must_use]
     pub unsafe fn read_byte(&self, index: usize) -> u8 {
         debug_assert!(index < self.size, "Frame buffer accessed out of bounds");
         self.base.add(index).read_volatile()
@@ -647,6 +658,7 @@ impl<'gop> FrameBuffer<'gop> {
     /// - You must honor the pixel format and stride specified by the mode info
     /// - There is no bound checking on memory accesses in release mode
     #[inline]
+    #[must_use]
     pub unsafe fn read_value<T>(&self, index: usize) -> T {
         debug_assert!(
             index.saturating_add(mem::size_of::<T>()) <= self.size,

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -47,11 +47,13 @@ impl<'boot> Pointer<'boot> {
 
     /// Event to be used with `BootServices::wait_for_event()` in order to wait
     /// for input from the pointer device
+    #[must_use]
     pub const fn wait_for_input_event(&self) -> &Event {
         &self.wait_for_input
     }
 
     /// Returns a reference to the pointer device information.
+    #[must_use]
     pub const fn mode(&self) -> &PointerMode {
         self.mode
     }

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -44,6 +44,7 @@ impl<'boot> Serial<'boot> {
     }
 
     /// Returns the current I/O mode.
+    #[must_use]
     pub const fn io_mode(&self) -> &IoMode {
         self.io_mode
     }

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -44,6 +44,7 @@ impl Input {
 
     /// Event to be used with `BootServices::wait_for_event()` in order to wait
     /// for a key to be available
+    #[must_use]
     pub const fn wait_for_key_event(&self) -> &Event {
         &self.wait_for_key
     }

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -129,6 +129,7 @@ impl<'boot> Output<'boot> {
     }
 
     /// Returns whether the cursor is currently shown or not.
+    #[must_use]
     pub const fn cursor_visible(&self) -> bool {
         self.data.cursor_visible
     }
@@ -142,6 +143,7 @@ impl<'boot> Output<'boot> {
     }
 
     /// Returns the column and row of the cursor.
+    #[must_use]
     pub const fn cursor_position(&self) -> (usize, usize) {
         let column = self.data.cursor_column;
         let row = self.data.cursor_row;
@@ -260,18 +262,21 @@ pub struct OutputMode {
 impl OutputMode {
     /// Returns the index of this mode.
     #[inline]
+    #[must_use]
     pub const fn index(&self) -> usize {
         self.index
     }
 
     /// Returns the width in columns.
     #[inline]
+    #[must_use]
     pub const fn columns(&self) -> usize {
         self.dims.0
     }
 
     /// Returns the height in rows.
     #[inline]
+    #[must_use]
     pub const fn rows(&self) -> usize {
         self.dims.1
     }

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -57,6 +57,7 @@ pub struct DebugSupport {
 
 impl DebugSupport {
     /// Returns the processor architecture of the running CPU.
+    #[must_use]
     pub const fn arch(&self) -> ProcessorArch {
         self.isa
     }

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -91,11 +91,13 @@ pub mod hardware {
 
     impl Pci {
         /// PCI function number.
+        #[must_use]
         pub fn function(&self) -> u8 {
             self.function
         }
 
         /// PCI device number.
+        #[must_use]
         pub fn device(&self) -> u8 {
             self.device
         }
@@ -132,6 +134,7 @@ pub mod hardware {
 
     impl Pccard {
         /// Function number starting from 0.
+        #[must_use]
         pub fn function(&self) -> u8 {
             self.function
         }
@@ -169,16 +172,19 @@ pub mod hardware {
 
     impl MemoryMapped {
         /// Memory type.
+        #[must_use]
         pub fn memory_type(&self) -> MemoryType {
             self.memory_type
         }
 
         /// Starting memory address.
+        #[must_use]
         pub fn start_address(&self) -> u64 {
             self.start_address
         }
 
         /// Ending memory address.
+        #[must_use]
         pub fn end_address(&self) -> u64 {
             self.end_address
         }
@@ -217,11 +223,13 @@ pub mod hardware {
 
     impl Vendor {
         /// Vendor-assigned GUID that defines the data that follows.
+        #[must_use]
         pub fn vendor_guid(&self) -> Guid {
             self.vendor_guid
         }
 
         /// Vendor-defined data.
+        #[must_use]
         pub fn vendor_defined_data(&self) -> &[u8] {
             &self.vendor_defined_data
         }
@@ -268,6 +276,7 @@ pub mod hardware {
 
     impl Controller {
         /// Controller number.
+        #[must_use]
         pub fn controller_number(&self) -> u32 {
             self.controller_number
         }
@@ -305,6 +314,7 @@ pub mod hardware {
 
     impl Bmc {
         /// Host interface type.
+        #[must_use]
         pub fn interface_type(&self) -> crate::proto::device_path::hardware::BmcInterfaceType {
             self.interface_type
         }
@@ -312,6 +322,7 @@ pub mod hardware {
         /// Base address of the BMC. If the least-significant bit of the
         /// field is a 1 then the address is in I/O space, otherwise the
         /// address is memory-mapped.
+        #[must_use]
         pub fn base_address(&self) -> u64 {
             self.base_address
         }
@@ -358,12 +369,14 @@ pub mod acpi {
     impl Acpi {
         /// Device's PnP hardware ID stored in a numeric 32-bit
         /// compressed EISA-type ID.
+        #[must_use]
         pub fn hid(&self) -> u32 {
             self.hid
         }
 
         /// Unique ID that is required by ACPI if two devices have the
         /// same HID.
+        #[must_use]
         pub fn uid(&self) -> u32 {
             self.uid
         }
@@ -404,18 +417,21 @@ pub mod acpi {
     impl Expanded {
         /// Device's PnP hardware ID stored in a numeric 32-bit compressed
         /// EISA-type ID.
+        #[must_use]
         pub fn hid(&self) -> u32 {
             self.hid
         }
 
         /// Unique ID that is required by ACPI if two devices have the
         /// same HID.
+        #[must_use]
         pub fn uid(&self) -> u32 {
             self.uid
         }
 
         /// Device's compatible PnP hardware ID stored in a numeric 32-bit
         /// compressed EISA-type ID.
+        #[must_use]
         pub fn cid(&self) -> u32 {
             self.cid
         }
@@ -424,6 +440,7 @@ pub mod acpi {
         /// string. This value must match the corresponding HID in the
         /// ACPI name space. If the length of this string not including
         /// the null-terminator is 0, then the numeric HID is used.
+        #[must_use]
         pub fn hid_str(&self) -> &[u8] {
             self.get_hid_str()
         }
@@ -432,6 +449,7 @@ pub mod acpi {
         /// same HID. This value is stored as a null-terminated ASCII
         /// string. If the length of this string not including the
         /// null-terminator is 0, then the numeric UID is used.
+        #[must_use]
         pub fn uid_str(&self) -> &[u8] {
             self.get_uid_str()
         }
@@ -440,6 +458,7 @@ pub mod acpi {
         /// null-terminated ASCII string. If the length of this string
         /// not including the null-terminator is 0, then the numeric CID
         /// is used.
+        #[must_use]
         pub fn cid_str(&self) -> &[u8] {
             self.get_cid_str()
         }
@@ -485,6 +504,7 @@ pub mod acpi {
         /// ADR values. For video output devices the value of this field
         /// comes from Table B-2 ACPI 3.0 specification. At least one
         /// ADR value is required.
+        #[must_use]
         pub fn adr(&self) -> UnalignedSlice<u32> {
             let ptr: *const [u32] = addr_of!(self.adr);
             let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
@@ -532,6 +552,7 @@ pub mod acpi {
 
     impl Nvdimm {
         /// NFIT device handle.
+        #[must_use]
         pub fn nfit_device_handle(&self) -> u32 {
             self.nfit_device_handle
         }
@@ -686,16 +707,19 @@ pub mod messaging {
 
     impl Atapi {
         /// Whether the ATAPI device is primary or secondary.
+        #[must_use]
         pub fn primary_secondary(&self) -> crate::proto::device_path::messaging::PrimarySecondary {
             self.primary_secondary
         }
 
         /// Whether the ATAPI device is master or slave.
+        #[must_use]
         pub fn master_slave(&self) -> crate::proto::device_path::messaging::MasterSlave {
             self.master_slave
         }
 
         /// Logical Unit Number (LUN).
+        #[must_use]
         pub fn logical_unit_number(&self) -> u16 {
             self.logical_unit_number
         }
@@ -734,11 +758,13 @@ pub mod messaging {
 
     impl Scsi {
         /// Target ID on the SCSI bus.
+        #[must_use]
         pub fn target_id(&self) -> u16 {
             self.target_id
         }
 
         /// Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> u16 {
             self.logical_unit_number
         }
@@ -777,11 +803,13 @@ pub mod messaging {
 
     impl FibreChannel {
         /// Fibre Channel World Wide Name.
+        #[must_use]
         pub fn world_wide_name(&self) -> u64 {
             self.world_wide_name
         }
 
         /// Fibre Channel Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> u64 {
             self.logical_unit_number
         }
@@ -821,11 +849,13 @@ pub mod messaging {
 
     impl FibreChannelEx {
         /// Fibre Channel end device port name (aka World Wide Name).
+        #[must_use]
         pub fn world_wide_name(&self) -> [u8; 8usize] {
             self.world_wide_name
         }
 
         /// Fibre Channel Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> [u8; 8usize] {
             self.logical_unit_number
         }
@@ -865,6 +895,7 @@ pub mod messaging {
     impl Ieee1394 {
         /// 1394 Global Unique ID. Note that this is not the same as a
         /// UEFI GUID.
+        #[must_use]
         pub fn guid(&self) -> [u8; 8usize] {
             self.guid
         }
@@ -902,11 +933,13 @@ pub mod messaging {
 
     impl Usb {
         /// USB parent port number.
+        #[must_use]
         pub fn parent_port_number(&self) -> u8 {
             self.parent_port_number
         }
 
         /// USB interface number.
+        #[must_use]
         pub fn interface(&self) -> u8 {
             self.interface
         }
@@ -946,6 +979,7 @@ pub mod messaging {
     impl Sata {
         /// The HBA port number that facilitates the connection to the
         /// device or a port multiplier. The value 0xffff is reserved.
+        #[must_use]
         pub fn hba_port_number(&self) -> u16 {
             self.hba_port_number
         }
@@ -953,11 +987,13 @@ pub mod messaging {
         /// the port multiplier port number that facilitates the
         /// connection to the device. Must be set to 0xffff if the
         /// device is directly connected to the HBA.
+        #[must_use]
         pub fn port_multiplier_port_number(&self) -> u16 {
             self.port_multiplier_port_number
         }
 
         /// Logical unit number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> u16 {
             self.logical_unit_number
         }
@@ -1000,21 +1036,25 @@ pub mod messaging {
 
     impl UsbWwid {
         /// USB interface number.
+        #[must_use]
         pub fn interface_number(&self) -> u16 {
             self.interface_number
         }
 
         /// USB vendor ID.
+        #[must_use]
         pub fn device_vendor_id(&self) -> u16 {
             self.device_vendor_id
         }
 
         /// USB product ID.
+        #[must_use]
         pub fn device_product_id(&self) -> u16 {
             self.device_product_id
         }
 
         /// Last 64 (or fewer) characters of the USB Serial number.
+        #[must_use]
         pub fn serial_number(&self) -> UnalignedSlice<u16> {
             let ptr: *const [u16] = addr_of!(self.serial_number);
             let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
@@ -1065,6 +1105,7 @@ pub mod messaging {
 
     impl DeviceLogicalUnit {
         /// Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> u8 {
             self.logical_unit_number
         }
@@ -1104,26 +1145,31 @@ pub mod messaging {
 
     impl UsbClass {
         /// USB vendor ID.
+        #[must_use]
         pub fn vendor_id(&self) -> u16 {
             self.vendor_id
         }
 
         /// USB product ID.
+        #[must_use]
         pub fn product_id(&self) -> u16 {
             self.product_id
         }
 
         /// USB device class.
+        #[must_use]
         pub fn device_class(&self) -> u8 {
             self.device_class
         }
 
         /// USB device subclass.
+        #[must_use]
         pub fn device_subclass(&self) -> u8 {
             self.device_subclass
         }
 
         /// USB device protocol.
+        #[must_use]
         pub fn device_protocol(&self) -> u8 {
             self.device_protocol
         }
@@ -1163,6 +1209,7 @@ pub mod messaging {
 
     impl I2o {
         /// Target ID (TID).
+        #[must_use]
         pub fn target_id(&self) -> u32 {
             self.target_id
         }
@@ -1199,12 +1246,14 @@ pub mod messaging {
 
     impl MacAddress {
         /// MAC address for a network interface, padded with zeros.
+        #[must_use]
         pub fn mac_address(&self) -> [u8; 32usize] {
             self.mac_address
         }
 
         /// Network interface type. See
         /// <https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml#smi-numbers-5>
+        #[must_use]
         pub fn interface_type(&self) -> u8 {
             self.interface_type
         }
@@ -1248,42 +1297,50 @@ pub mod messaging {
 
     impl Ipv4 {
         /// Local IPv4 address.
+        #[must_use]
         pub fn local_ip_address(&self) -> [u8; 4usize] {
             self.local_ip_address
         }
 
         /// Remote IPv4 address.
+        #[must_use]
         pub fn remote_ip_address(&self) -> [u8; 4usize] {
             self.remote_ip_address
         }
 
         /// Local port number.
+        #[must_use]
         pub fn local_port(&self) -> u16 {
             self.local_port
         }
 
         /// Remote port number.
+        #[must_use]
         pub fn remote_port(&self) -> u16 {
             self.remote_port
         }
 
         /// Network protocol. See
         /// <https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml>
+        #[must_use]
         pub fn protocol(&self) -> u16 {
             self.protocol
         }
 
         /// Whether the source IP address is static or assigned via DHCP.
+        #[must_use]
         pub fn ip_address_origin(&self) -> crate::proto::device_path::messaging::Ipv4AddressOrigin {
             self.ip_address_origin
         }
 
         /// Gateway IP address.
+        #[must_use]
         pub fn gateway_ip_address(&self) -> [u8; 4usize] {
             self.gateway_ip_address
         }
 
         /// Subnet mask.
+        #[must_use]
         pub fn subnet_mask(&self) -> [u8; 4usize] {
             self.subnet_mask
         }
@@ -1333,42 +1390,50 @@ pub mod messaging {
 
     impl Ipv6 {
         /// Local Ipv6 address.
+        #[must_use]
         pub fn local_ip_address(&self) -> [u8; 16usize] {
             self.local_ip_address
         }
 
         /// Remote Ipv6 address.
+        #[must_use]
         pub fn remote_ip_address(&self) -> [u8; 16usize] {
             self.remote_ip_address
         }
 
         /// Local port number.
+        #[must_use]
         pub fn local_port(&self) -> u16 {
             self.local_port
         }
 
         /// Remote port number.
+        #[must_use]
         pub fn remote_port(&self) -> u16 {
             self.remote_port
         }
 
         /// Network protocol. See
         /// <https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml>
+        #[must_use]
         pub fn protocol(&self) -> u16 {
             self.protocol
         }
 
         /// Origin of the local IP address.
+        #[must_use]
         pub fn ip_address_origin(&self) -> crate::proto::device_path::messaging::Ipv6AddressOrigin {
             self.ip_address_origin
         }
 
         /// Prefix length.
+        #[must_use]
         pub fn prefix_length(&self) -> u8 {
             self.prefix_length
         }
 
         /// Gateway IP address.
+        #[must_use]
         pub fn gateway_ip_address(&self) -> [u8; 16usize] {
             self.gateway_ip_address
         }
@@ -1411,6 +1476,7 @@ pub mod messaging {
 
     impl Vlan {
         /// VLAN identifier (0-4094).
+        #[must_use]
         pub fn vlan_id(&self) -> u16 {
             self.vlan_id
         }
@@ -1450,6 +1516,7 @@ pub mod messaging {
 
     impl Infiniband {
         /// Flags to identify/manage InfiniBand elements.
+        #[must_use]
         pub fn resource_flags(
             &self,
         ) -> crate::proto::device_path::messaging::InfinibandResourceFlags {
@@ -1458,22 +1525,26 @@ pub mod messaging {
 
         /// 128-bit Global Identifier for remote fabric port. Note that
         /// this is not the same as a UEFI GUID.
+        #[must_use]
         pub fn port_gid(&self) -> [u8; 16usize] {
             self.port_gid
         }
 
         /// IOC GUID if bit 0 of `resource_flags` is unset, or Service
         /// ID if bit 0 of `resource_flags` is set.
+        #[must_use]
         pub fn ioc_guid_or_service_id(&self) -> u64 {
             self.ioc_guid_or_service_id
         }
 
         /// 64-bit persistent ID of remote IOC port.
+        #[must_use]
         pub fn target_port_id(&self) -> u64 {
             self.target_port_id
         }
 
         /// 64-bit persistent ID of remote device..
+        #[must_use]
         pub fn device_id(&self) -> u64 {
             self.device_id
         }
@@ -1517,21 +1588,25 @@ pub mod messaging {
 
     impl Uart {
         /// Baud rate setting, or 0 to use the device's default.
+        #[must_use]
         pub fn baud_rate(&self) -> u64 {
             self.baud_rate
         }
 
         /// Number of data bits, or 0 to use the device's default.
+        #[must_use]
         pub fn data_bits(&self) -> u8 {
             self.data_bits
         }
 
         /// Parity setting.
+        #[must_use]
         pub fn parity(&self) -> crate::proto::device_path::messaging::Parity {
             self.parity
         }
 
         /// Number of stop bits.
+        #[must_use]
         pub fn stop_bits(&self) -> crate::proto::device_path::messaging::StopBits {
             self.stop_bits
         }
@@ -1572,11 +1647,13 @@ pub mod messaging {
 
     impl Vendor {
         /// Vendor-assigned GUID that defines the data that follows.
+        #[must_use]
         pub fn vendor_guid(&self) -> Guid {
             self.vendor_guid
         }
 
         /// Vendor-defined data.
+        #[must_use]
         pub fn vendor_defined_data(&self) -> &[u8] {
             &self.vendor_defined_data
         }
@@ -1626,21 +1703,25 @@ pub mod messaging {
 
     impl SasEx {
         /// SAS address.
+        #[must_use]
         pub fn sas_address(&self) -> [u8; 8usize] {
             self.sas_address
         }
 
         /// Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> [u8; 8usize] {
             self.logical_unit_number
         }
 
         /// Information about the device and its interconnect.
+        #[must_use]
         pub fn info(&self) -> u16 {
             self.info
         }
 
         /// Relative Target Port (RTP).
+        #[must_use]
         pub fn relative_target_port(&self) -> u16 {
             self.relative_target_port
         }
@@ -1683,22 +1764,26 @@ pub mod messaging {
 
     impl Iscsi {
         /// Network protocol.
+        #[must_use]
         pub fn protocol(&self) -> crate::proto::device_path::messaging::IscsiProtocol {
             self.protocol
         }
 
         /// iSCSI login options (bitfield).
+        #[must_use]
         pub fn options(&self) -> crate::proto::device_path::messaging::IscsiLoginOptions {
             self.options
         }
 
         /// iSCSI Logical Unit Number.
+        #[must_use]
         pub fn logical_unit_number(&self) -> [u8; 8usize] {
             self.logical_unit_number
         }
 
         /// iSCSI Target Portal group tag the initiator intends to
         /// establish a session with.
+        #[must_use]
         pub fn target_portal_group_tag(&self) -> u16 {
             self.target_portal_group_tag
         }
@@ -1708,6 +1793,7 @@ pub mod messaging {
         /// The UEFI Specification does not specify how the string is
         /// encoded, but gives one example that appears to be
         /// null-terminated ASCII.
+        #[must_use]
         pub fn iscsi_target_name(&self) -> &[u8] {
             &self.iscsi_target_name
         }
@@ -1759,12 +1845,14 @@ pub mod messaging {
     impl NvmeNamespace {
         /// Namespace identifier (NSID). The values 0 and 0xffff_ffff
         /// are invalid.
+        #[must_use]
         pub fn namespace_identifier(&self) -> u32 {
             self.namespace_identifier
         }
 
         /// IEEE Extended Unique Identifier (EUI-64), or 0 if the device
         /// does not have a EUI-64.
+        #[must_use]
         pub fn ieee_extended_unique_identifier(&self) -> u64 {
             self.ieee_extended_unique_identifier
         }
@@ -1803,6 +1891,7 @@ pub mod messaging {
 
     impl Uri {
         /// URI as defined by [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986).
+        #[must_use]
         pub fn value(&self) -> &[u8] {
             &self.value
         }
@@ -1849,11 +1938,13 @@ pub mod messaging {
 
     impl Ufs {
         /// Target ID on the UFS interface (PUN).
+        #[must_use]
         pub fn target_id(&self) -> u8 {
             self.target_id
         }
 
         /// Logical Unit Number (LUN).
+        #[must_use]
         pub fn logical_unit_number(&self) -> u8 {
             self.logical_unit_number
         }
@@ -1890,6 +1981,7 @@ pub mod messaging {
 
     impl Sd {
         /// Slot number.
+        #[must_use]
         pub fn slot_number(&self) -> u8 {
             self.slot_number
         }
@@ -1925,6 +2017,7 @@ pub mod messaging {
 
     impl Bluetooth {
         /// 48-bit bluetooth device address.
+        #[must_use]
         pub fn device_address(&self) -> [u8; 6usize] {
             self.device_address
         }
@@ -1960,6 +2053,7 @@ pub mod messaging {
 
     impl Wifi {
         /// Service set identifier (SSID).
+        #[must_use]
         pub fn ssid(&self) -> [u8; 32usize] {
             self.ssid
         }
@@ -1995,6 +2089,7 @@ pub mod messaging {
 
     impl Emmc {
         /// Slot number.
+        #[must_use]
         pub fn slot_number(&self) -> u8 {
             self.slot_number
         }
@@ -2031,11 +2126,13 @@ pub mod messaging {
 
     impl BluetoothLe {
         /// 48-bit bluetooth device address.
+        #[must_use]
         pub fn device_address(&self) -> [u8; 6usize] {
             self.device_address
         }
 
         /// Address type.
+        #[must_use]
         pub fn address_type(&self) -> crate::proto::device_path::messaging::BluetoothLeAddressType {
             self.address_type
         }
@@ -2073,11 +2170,13 @@ pub mod messaging {
 
     impl Dns {
         /// Whether the addresses are IPv4 or IPv6.
+        #[must_use]
         pub fn address_type(&self) -> crate::proto::device_path::messaging::DnsAddressType {
             self.address_type
         }
 
         /// One or more instances of the DNS server address.
+        #[must_use]
         pub fn addresses(&self) -> UnalignedSlice<IpAddress> {
             let ptr: *const [IpAddress] = addr_of!(self.addresses);
             let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
@@ -2126,6 +2225,7 @@ pub mod messaging {
 
     impl NvdimmNamespace {
         /// Namespace unique label identifier.
+        #[must_use]
         pub fn uuid(&self) -> [u8; 16usize] {
             self.uuid
         }
@@ -2163,11 +2263,13 @@ pub mod messaging {
 
     impl RestService {
         /// Type of REST service.
+        #[must_use]
         pub fn service_type(&self) -> crate::proto::device_path::messaging::RestServiceType {
             self.service_type
         }
 
         /// Whether the service is in-band or out-of-band.
+        #[must_use]
         pub fn access_mode(&self) -> crate::proto::device_path::messaging::RestServiceAccessMode {
             self.access_mode
         }
@@ -2217,17 +2319,20 @@ pub mod messaging {
 
     impl NvmeOfNamespace {
         /// Namespace Identifier Type (NIDT).
+        #[must_use]
         pub fn nidt(&self) -> u8 {
             self.nidt
         }
 
         /// Namespace Identifier (NID).
+        #[must_use]
         pub fn nid(&self) -> [u8; 16usize] {
             self.nid
         }
 
         /// Unique identifier of an NVM subsystem stored as a
         /// null-terminated UTF-8 string. Maximum length of 224 bytes.
+        #[must_use]
         pub fn subsystem_nqn(&self) -> &[u8] {
             &self.subsystem_nqn
         }
@@ -2316,6 +2421,7 @@ pub mod messaging {
         /// service type is [`VENDOR`], otherwise returns None.
         ///
         /// [`VENDOR`]: uefi::proto::device_path::messaging::RestServiceType
+        #[must_use]
         pub fn vendor_guid_and_data(&self) -> Option<(Guid, &[u8])> {
             if self.service_type == RestServiceType::VENDOR
                 && self.vendor_guid_and_data.len() >= size_of::<Guid>()
@@ -2355,21 +2461,25 @@ pub mod media {
 
     impl HardDrive {
         /// Index of the partition, starting from 1.
+        #[must_use]
         pub fn partition_number(&self) -> u32 {
             self.partition_number
         }
 
         /// Starting LBA (logical block address) of the partition.
+        #[must_use]
         pub fn partition_start(&self) -> u64 {
             self.partition_start
         }
 
         /// Size of the partition in blocks.
+        #[must_use]
         pub fn partition_size(&self) -> u64 {
             self.partition_size
         }
 
         /// Partition format.
+        #[must_use]
         pub fn partition_format(&self) -> crate::proto::device_path::media::PartitionFormat {
             self.partition_format
         }
@@ -2413,16 +2523,19 @@ pub mod media {
     impl CdRom {
         /// Boot entry number from the boot catalog, or 0 for the
         /// default entry.
+        #[must_use]
         pub fn boot_entry(&self) -> u32 {
             self.boot_entry
         }
 
         /// Starting RBA (Relative logical Block Address).
+        #[must_use]
         pub fn partition_start(&self) -> u64 {
             self.partition_start
         }
 
         /// Size of the partition in blocks.
+        #[must_use]
         pub fn partition_size(&self) -> u64 {
             self.partition_size
         }
@@ -2461,11 +2574,13 @@ pub mod media {
 
     impl Vendor {
         /// Vendor-assigned GUID that defines the data that follows.
+        #[must_use]
         pub fn vendor_guid(&self) -> Guid {
             self.vendor_guid
         }
 
         /// Vendor-defined data.
+        #[must_use]
         pub fn vendor_defined_data(&self) -> &[u8] {
             &self.vendor_defined_data
         }
@@ -2512,6 +2627,7 @@ pub mod media {
 
     impl FilePath {
         /// Null-terminated path.
+        #[must_use]
         pub fn path_name(&self) -> UnalignedSlice<u16> {
             let ptr: *const [u16] = addr_of!(self.path_name);
             let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
@@ -2559,6 +2675,7 @@ pub mod media {
 
     impl Protocol {
         /// The ID of the protocol.
+        #[must_use]
         pub fn protocol_guid(&self) -> Guid {
             self.protocol_guid
         }
@@ -2594,6 +2711,7 @@ pub mod media {
 
     impl PiwgFirmwareFile {
         /// Contents are defined in the UEFI PI Specification.
+        #[must_use]
         pub fn data(&self) -> &[u8] {
             &self.data
         }
@@ -2640,6 +2758,7 @@ pub mod media {
 
     impl PiwgFirmwareVolume {
         /// Contents are defined in the UEFI PI Specification.
+        #[must_use]
         pub fn data(&self) -> &[u8] {
             &self.data
         }
@@ -2688,11 +2807,13 @@ pub mod media {
 
     impl RelativeOffsetRange {
         /// Offset of the first byte, relative to the parent device node.
+        #[must_use]
         pub fn starting_offset(&self) -> u64 {
             self.starting_offset
         }
 
         /// Offset of the last byte, relative to the parent device node.
+        #[must_use]
         pub fn ending_offset(&self) -> u64 {
             self.ending_offset
         }
@@ -2733,21 +2854,25 @@ pub mod media {
 
     impl RamDisk {
         /// Starting memory address.
+        #[must_use]
         pub fn starting_address(&self) -> u64 {
             self.starting_address
         }
 
         /// Ending memory address.
+        #[must_use]
         pub fn ending_address(&self) -> u64 {
             self.ending_address
         }
 
         /// Type of RAM disk.
+        #[must_use]
         pub fn disk_type(&self) -> crate::proto::device_path::media::RamDiskType {
             self.disk_type
         }
 
         /// RAM disk instance number if supported, otherwise 0.
+        #[must_use]
         pub fn disk_instance(&self) -> u16 {
             self.disk_instance
         }
@@ -2779,6 +2904,7 @@ pub mod media {
 
     impl HardDrive {
         /// Signature unique to this partition.
+        #[must_use]
         pub fn partition_signature(&self) -> PartitionSignature {
             match self.signature_type {
                 0 => PartitionSignature::None,
@@ -2838,17 +2964,20 @@ pub mod bios_boot_spec {
 
     impl BootSpecification {
         /// Device type as defined by the BIOS Boot Specification.
+        #[must_use]
         pub fn device_type(&self) -> u16 {
             self.device_type
         }
 
         /// Status flags as defined by the BIOS Boot Specification.
+        #[must_use]
         pub fn status_flag(&self) -> u16 {
             self.status_flag
         }
 
         /// Description of the boot device encoded as a null-terminated
         /// ASCII string.
+        #[must_use]
         pub fn description_string(&self) -> &[u8] {
             &self.description_string
         }
@@ -3640,6 +3769,7 @@ pub mod build {
         impl AdrSlice {
             /// Create a new `AdrSlice`. Returns `None` if the input slice
             /// is empty.
+            #[must_use]
             pub fn new(slice: &[u32]) -> Option<&Self> {
                 if slice.is_empty() {
                     None

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -133,6 +133,7 @@ impl DevicePathNode {
     /// The input pointer must point to valid data. That data must
     /// remain valid for the lifetime `'a`, and cannot be mutated during
     /// that lifetime.
+    #[must_use]
     pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a DevicePathNode {
         let header = *ptr.cast::<DevicePathHeader>();
 
@@ -141,32 +142,38 @@ impl DevicePathNode {
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
+    #[must_use]
     pub const fn as_ffi_ptr(&self) -> *const FfiDevicePath {
         let ptr: *const Self = self;
         ptr.cast::<FfiDevicePath>()
     }
 
     /// Type of device
+    #[must_use]
     pub const fn device_type(&self) -> DeviceType {
         self.header.device_type
     }
 
     /// Sub type of device
+    #[must_use]
     pub const fn sub_type(&self) -> DeviceSubType {
         self.header.sub_type
     }
 
     /// Tuple of the node's type and subtype.
+    #[must_use]
     pub const fn full_type(&self) -> (DeviceType, DeviceSubType) {
         (self.header.device_type, self.header.sub_type)
     }
 
     /// Size (in bytes) of the full [`DevicePathNode`], including the header.
+    #[must_use]
     pub const fn length(&self) -> u16 {
         self.header.length
     }
 
     /// True if this node ends an entire [`DevicePath`].
+    #[must_use]
     pub fn is_end_entire(&self) -> bool {
         self.full_type() == (DeviceType::END, DeviceSubType::END_ENTIRE)
     }
@@ -199,6 +206,7 @@ impl DevicePathInstance {
     /// reached.
     ///
     /// [`DevicePathNodes`]: DevicePathNode
+    #[must_use]
     pub const fn node_iter(&self) -> DevicePathNodeIterator {
         DevicePathNodeIterator {
             nodes: &self.data,
@@ -260,17 +268,20 @@ impl DevicePath {
     /// The input pointer must point to valid data. That data must
     /// remain valid for the lifetime `'a`, and cannot be mutated during
     /// that lifetime.
+    #[must_use]
     pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a DevicePath {
         &*Self::ptr_from_ffi(ptr.cast::<c_void>())
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
+    #[must_use]
     pub const fn as_ffi_ptr(&self) -> *const FfiDevicePath {
         let p = self as *const Self;
         p.cast()
     }
 
     /// Get an iterator over the [`DevicePathInstance`]s in this path.
+    #[must_use]
     pub const fn instance_iter(&self) -> DevicePathInstanceIterator {
         DevicePathInstanceIterator {
             remaining_path: Some(self),
@@ -281,6 +292,7 @@ impl DevicePath {
     /// `self`. Iteration ends when a path is reached where
     /// [`is_end_entire`][DevicePathNode::is_end_entire] is true. That ending
     /// path is not returned by the iterator.
+    #[must_use]
     pub const fn node_iter(&self) -> DevicePathNodeIterator {
         DevicePathNodeIterator {
             nodes: &self.data,

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -52,6 +52,7 @@ pub enum LoadOptionsError {
 
 impl LoadedImage {
     /// Returns a handle to the storage device on which the image is located.
+    #[must_use]
     pub const fn device(&self) -> Handle {
         self.device_handle
     }
@@ -60,6 +61,7 @@ impl LoadedImage {
     ///
     /// Return `None` if the pointer to the file path portion specific to
     /// DeviceHandle that the EFI Image was loaded from is null.
+    #[must_use]
     pub fn file_path(&self) -> Option<&DevicePath> {
         if self.file_path.is_null() {
             None
@@ -106,6 +108,7 @@ impl LoadedImage {
     /// Returns `None` if load options are not set.
     ///
     /// [`load_options_as_cstr16`]: `Self::load_options_as_cstr16`
+    #[must_use]
     pub fn load_options_as_bytes(&self) -> Option<&[u8]> {
         if self.load_options.is_null() {
             None
@@ -164,6 +167,7 @@ impl LoadedImage {
     }
 
     /// Returns the base address and the size in bytes of the loaded image.
+    #[must_use]
     pub const fn info(&self) -> (*const c_void, u64) {
         (self.image_base, self.image_size)
     }

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -31,6 +31,7 @@ pub struct BlockIO {
 
 impl BlockIO {
     /// Pointer for block IO media.
+    #[must_use]
     pub const fn media(&self) -> &BlockIOMedia {
         unsafe { &*self.media }
     }
@@ -128,31 +129,37 @@ pub struct BlockIOMedia {
 
 impl BlockIOMedia {
     /// The current media ID.
+    #[must_use]
     pub const fn media_id(&self) -> u32 {
         self.media_id
     }
 
     /// True if the media is removable.
+    #[must_use]
     pub const fn is_removable_media(&self) -> bool {
         self.removable_media
     }
 
     /// True if there is a media currently present in the device.
+    #[must_use]
     pub const fn is_media_present(&self) -> bool {
         self.media_present
     }
 
     /// True if block IO was produced to abstract partition structure.
+    #[must_use]
     pub const fn is_logical_partition(&self) -> bool {
         self.logical_partition
     }
 
     /// True if the media is marked read-only.
+    #[must_use]
     pub const fn is_read_only(&self) -> bool {
         self.read_only
     }
 
     /// True if `writeBlocks` function writes data.
+    #[must_use]
     pub const fn is_write_caching(&self) -> bool {
         self.write_caching
     }
@@ -160,31 +167,37 @@ impl BlockIOMedia {
     /// The intrinsic block size of the device.
     ///
     /// If the media changes, then this field is updated. Returns the number of bytes per logical block.
+    #[must_use]
     pub const fn block_size(&self) -> u32 {
         self.block_size
     }
 
     /// Supplies the alignment requirement for any buffer used in a data transfer.
+    #[must_use]
     pub const fn io_align(&self) -> u32 {
         self.io_align
     }
 
     /// The last LBA on the device. If the media changes, then this field is updated.
+    #[must_use]
     pub const fn last_block(&self) -> Lba {
         self.last_block
     }
 
     /// Returns the first LBA that is aligned to a physical block boundary.
+    #[must_use]
     pub const fn lowest_aligned_lba(&self) -> Lba {
         self.lowest_aligned_lba
     }
 
     /// Returns the number of logical blocks per physical block.
+    #[must_use]
     pub const fn logical_blocks_per_physical_block(&self) -> u32 {
         self.logical_blocks_per_physical_block
     }
 
     /// Returns the optimal transfer length granularity as a number of logical blocks.
+    #[must_use]
     pub const fn optimal_transfer_length_granularity(&self) -> u32 {
         self.optimal_transfer_length_granularity
     }

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -19,6 +19,7 @@ impl Directory {
     /// # Safety
     /// This function should only be called on files which ARE directories,
     /// doing otherwise is unsafe.
+    #[must_use]
     pub unsafe fn new(handle: FileHandle) -> Self {
         Self(RegularFile::new(handle))
     }

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -189,36 +189,43 @@ impl FileInfo {
     }
 
     /// File size (number of bytes stored in the file)
+    #[must_use]
     pub const fn file_size(&self) -> u64 {
         self.file_size
     }
 
     /// Physical space consumed by the file on the file system volume
+    #[must_use]
     pub const fn physical_size(&self) -> u64 {
         self.physical_size
     }
 
     /// Time when the file was created
+    #[must_use]
     pub const fn create_time(&self) -> &Time {
         &self.create_time
     }
 
     /// Time when the file was last accessed
+    #[must_use]
     pub const fn last_access_time(&self) -> &Time {
         &self.last_access_time
     }
 
     /// Time when the file's contents were last modified
+    #[must_use]
     pub const fn modification_time(&self) -> &Time {
         &self.modification_time
     }
 
     /// Attribute bits for the file
+    #[must_use]
     pub const fn attribute(&self) -> FileAttribute {
         self.attribute
     }
 
     /// Name of the file
+    #[must_use]
     pub fn file_name(&self) -> &CStr16 {
         unsafe { CStr16::from_ptr(self.file_name.as_ptr()) }
     }
@@ -286,26 +293,31 @@ impl FileSystemInfo {
     }
 
     /// Truth that the volume only supports read access
+    #[must_use]
     pub const fn read_only(&self) -> bool {
         self.read_only
     }
 
     /// Number of bytes managed by the file system
+    #[must_use]
     pub const fn volume_size(&self) -> u64 {
         self.volume_size
     }
 
     /// Number of available bytes for use by the file system
+    #[must_use]
     pub const fn free_space(&self) -> u64 {
         self.free_space
     }
 
     /// Nominal block size by which files are typically grown
+    #[must_use]
     pub const fn block_size(&self) -> u32 {
         self.block_size
     }
 
     /// Volume label
+    #[must_use]
     pub fn volume_label(&self) -> &CStr16 {
         unsafe { CStr16::from_ptr(self.volume_label.as_ptr()) }
     }
@@ -353,6 +365,7 @@ impl FileSystemVolumeLabel {
     }
 
     /// Volume label
+    #[must_use]
     pub fn volume_label(&self) -> &CStr16 {
         unsafe { CStr16::from_ptr(self.volume_label.as_ptr()) }
     }

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -222,6 +222,7 @@ impl FileHandle {
 
     /// If the handle represents a directory, convert it into a
     /// [`Directory`]. Otherwise returns `None`.
+    #[must_use]
     pub fn into_directory(self) -> Option<Directory> {
         if let Ok(FileType::Dir(dir)) = self.into_type() {
             Some(dir)
@@ -232,6 +233,7 @@ impl FileHandle {
 
     /// If the handle represents a regular file, convert it into a
     /// [`RegularFile`]. Otherwise returns `None`.
+    #[must_use]
     pub fn into_regular_file(self) -> Option<RegularFile> {
         if let Ok(FileType::Regular(regular)) = self.into_type() {
             Some(regular)

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -17,6 +17,7 @@ impl RegularFile {
     /// # Safety
     /// This function should only be called on handles which ARE NOT directories,
     /// doing otherwise is unsafe.
+    #[must_use]
     pub unsafe fn new(handle: FileHandle) -> Self {
         Self(handle)
     }

--- a/uefi/src/proto/media/partition.rs
+++ b/uefi/src/proto/media/partition.rs
@@ -44,6 +44,7 @@ pub struct MbrPartitionRecord {
 
 impl MbrPartitionRecord {
     /// True if the partition is a bootable legacy partition.
+    #[must_use]
     pub const fn is_bootable(&self) -> bool {
         self.boot_indicator == 0x80
     }
@@ -100,6 +101,7 @@ bitflags! {
 impl GptPartitionAttributes {
     /// Get bits `48..=63` as a [`u16`]. The meaning of these bits depends
     /// on the partition's type (see [`GptPartitionEntry::partition_type_guid`]).
+    #[must_use]
     pub const fn type_specific_bits(&self) -> u16 {
         (self.bits >> 48) as u16
     }
@@ -135,6 +137,7 @@ impl GptPartitionEntry {
     /// Get the number of blocks in the partition. Returns `None` if the
     /// end block is before the start block, or if the number doesn't
     /// fit in a `u64`.
+    #[must_use]
     pub fn num_blocks(&self) -> Option<u64> {
         self.ending_lba
             .checked_sub(self.starting_lba)?
@@ -188,12 +191,14 @@ pub struct PartitionInfo {
 
 impl PartitionInfo {
     /// True if the partition is an EFI system partition.
+    #[must_use]
     pub const fn is_system(&self) -> bool {
         self.system == 1
     }
 
     /// Get the MBR partition record. Returns None if the partition
     /// type is not MBR.
+    #[must_use]
     pub fn mbr_partition_record(&self) -> Option<&MbrPartitionRecord> {
         if { self.revision } != PartitionInfoRevision::PROTOCOL_REVISION {
             return None;
@@ -208,6 +213,7 @@ impl PartitionInfo {
 
     /// Get the GPT partition entry. Returns None if the partition
     /// type is not GPT.
+    #[must_use]
     pub fn gpt_partition_entry(&self) -> Option<&GptPartitionEntry> {
         if { self.revision } != PartitionInfoRevision::PROTOCOL_REVISION {
             return None;

--- a/uefi/src/proto/network/mod.rs
+++ b/uefi/src/proto/network/mod.rs
@@ -13,6 +13,7 @@ pub struct IpAddress(pub [u8; 16]);
 
 impl IpAddress {
     /// Construct a new IPv4 address.
+    #[must_use]
     pub const fn new_v4(ip_addr: [u8; 4]) -> Self {
         let mut buffer = [0; 16];
         buffer[0] = ip_addr[0];
@@ -23,6 +24,7 @@ impl IpAddress {
     }
 
     /// Construct a new IPv6 address.
+    #[must_use]
     pub const fn new_v6(ip_addr: [u8; 16]) -> Self {
         Self(ip_addr)
     }

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -611,6 +611,7 @@ impl BaseCode {
     }
 
     /// Returns a reference to the `Mode` struct.
+    #[must_use]
     pub const fn mode(&self) -> &Mode {
         unsafe { &*self.mode }
     }
@@ -664,6 +665,7 @@ pub struct DiscoverInfo<T: ?Sized> {
 
 impl<const N: usize> DiscoverInfo<[Server; N]> {
     /// Create a `DiscoverInfo`.
+    #[must_use]
     pub const fn new(
         use_m_cast: bool,
         use_b_cast: bool,
@@ -742,6 +744,7 @@ impl Server {
     /// Construct a `Server` for a Boot Server reply type. If `ip_addr` is not
     /// `None` only Boot Server replies with matching the IP address will be
     /// accepted.
+    #[must_use]
     pub fn new(ty: u16, ip_addr: Option<IpAddress>) -> Self {
         Self {
             ty,
@@ -753,6 +756,7 @@ impl Server {
 
     /// Returns a `None` if the any response should be accepted or the IP
     /// address of a Boot Server whose responses should be accepted.
+    #[must_use]
     pub const fn ip_addr(&self) -> Option<&IpAddress> {
         if self.accept_any_response {
             None
@@ -837,6 +841,7 @@ impl IpFilter {
     /// # Panics
     ///
     /// Panics if `ip_list` contains more than 8 entries.
+    #[must_use]
     pub fn new(filters: IpFilters, ip_list: &[IpAddress]) -> Self {
         assert!(ip_list.len() <= 8);
 
@@ -854,6 +859,7 @@ impl IpFilter {
 
     /// A list of IP addresses other than the Station Ip that should be
     /// enabled. Maybe be multicast or unicast.
+    #[must_use]
     pub fn ip_list(&self) -> &[IpAddress] {
         &self.ip_list[..usize::from(self.ip_cnt)]
     }
@@ -944,21 +950,25 @@ impl DhcpV4Packet {
     pub const DHCP_MAGIK: u32 = 0x63825363;
 
     /// Transaction ID, a random number, used to match this boot request with the responses it generates.
+    #[must_use]
     pub const fn bootp_ident(&self) -> u32 {
         u32::from_be(self.bootp_ident)
     }
 
     /// Filled in by client, seconds elapsed since client started trying to boot.
+    #[must_use]
     pub const fn bootp_seconds(&self) -> u16 {
         u16::from_be(self.bootp_seconds)
     }
 
     /// The flags.
+    #[must_use]
     pub const fn bootp_flags(&self) -> DhcpV4Flags {
         DhcpV4Flags::from_bits_truncate(u16::from_be(self.bootp_flags))
     }
 
     /// A magic cookie, should be [`Self::DHCP_MAGIK`].
+    #[must_use]
     pub const fn dhcp_magik(&self) -> u32 {
         u32::from_be(self.dhcp_magik)
     }
@@ -988,6 +998,7 @@ pub struct DhcpV6Packet {
 
 impl DhcpV6Packet {
     /// The transaction id.
+    #[must_use]
     pub fn transaction_id(&self) -> u32 {
         u32::from(self.transaction_id[0]) << 16
             | u32::from(self.transaction_id[1]) << 8

--- a/uefi/src/proto/pi/mp.rs
+++ b/uefi/src/proto/pi/mp.rs
@@ -59,16 +59,19 @@ pub struct ProcessorInformation {
 
 impl ProcessorInformation {
     /// Returns `true` if the processor is playing the role of BSP.
+    #[must_use]
     pub const fn is_bsp(&self) -> bool {
         self.status_flag.contains(StatusFlag::PROCESSOR_AS_BSP_BIT)
     }
 
     /// Returns `true` if the processor is enabled.
+    #[must_use]
     pub const fn is_enabled(&self) -> bool {
         self.status_flag.contains(StatusFlag::PROCESSOR_ENABLED_BIT)
     }
 
     /// Returns `true` if the processor is healthy.
+    #[must_use]
     pub const fn is_healthy(&self) -> bool {
         self.status_flag
             .contains(StatusFlag::PROCESSOR_HEALTH_STATUS_BIT)

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -27,6 +27,7 @@ pub struct UnicodeCollation {
 impl UnicodeCollation {
     /// Performs a case insensitive comparison of two
     /// null-terminated strings.
+    #[must_use]
     pub fn stri_coll(&self, s1: &CStr16, s2: &CStr16) -> Ordering {
         let order = (self.stri_coll)(self, s1.as_ptr(), s2.as_ptr());
         order.cmp(&0)
@@ -54,6 +55,7 @@ impl UnicodeCollation {
     /// letter in the alphabet. The pattern "z" will match the letter "z".
     /// The pattern "d?.*" will match the character "D" or "d" followed by
     /// any single character followed by a "." followed by any string.
+    #[must_use]
     pub fn metai_match(&self, s: &CStr16, pattern: &CStr16) -> bool {
         (self.metai_match)(self, s.as_ptr(), pattern.as_ptr())
     }

--- a/uefi/src/result/status.rs
+++ b/uefi/src/result/status.rs
@@ -112,18 +112,21 @@ pub enum Status: usize => {
 impl Status {
     /// Returns true if status code indicates success.
     #[inline]
+    #[must_use]
     pub fn is_success(self) -> bool {
         self == Status::SUCCESS
     }
 
     /// Returns true if status code indicates a warning.
     #[inline]
+    #[must_use]
     pub fn is_warning(self) -> bool {
         (self != Status::SUCCESS) && (self.0 & ERROR_BIT == 0)
     }
 
     /// Returns true if the status code indicates an error.
     #[inline]
+    #[must_use]
     pub const fn is_error(self) -> bool {
         self.0 & ERROR_BIT != 0
     }

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -325,6 +325,7 @@ impl BootServices {
     /// Raising a task's priority level can affect other running tasks and
     /// critical processes run by UEFI. The highest priority level is the
     /// most dangerous, since it disables interrupts.
+    #[must_use]
     pub unsafe fn raise_tpl(&self, tpl: Tpl) -> TplGuard<'_> {
         TplGuard {
             boot_services: self,
@@ -362,6 +363,7 @@ impl BootServices {
     /// Note that the size of the memory map can increase any time an allocation happens,
     /// so when creating a buffer to put the memory map into, it's recommended to allocate a few extra
     /// elements worth of space above the size of the current memory map.
+    #[must_use]
     pub fn memory_map_size(&self) -> MemoryMapSize {
         let mut map_size = 0;
         let mut map_key = MemoryMapKey(0);
@@ -1687,6 +1689,7 @@ pub enum MemoryType: u32 => {
 impl MemoryType {
     /// Construct a custom `MemoryType`. Values in the range `0x80000000..=0xffffffff` are free for use if you are
     /// an OS loader.
+    #[must_use]
     pub const fn custom(value: u32) -> MemoryType {
         assert!(value >= 0x80000000);
         MemoryType(value)
@@ -1849,6 +1852,7 @@ pub enum SearchType<'guid> {
 
 impl<'guid> SearchType<'guid> {
     /// Constructs a new search type for a specified protocol.
+    #[must_use]
     pub const fn from_proto<P: Protocol>() -> Self {
         SearchType::ByProtocol(&P::GUID)
     }
@@ -1926,6 +1930,7 @@ impl<'a> ProtocolsPerHandle<'a> {
     /// Get the protocol interface [`Guids`][Guid] that are installed on the
     /// [`Handle`].
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    #[must_use]
     pub fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.
@@ -1953,6 +1958,7 @@ impl<'a> Drop for HandleBuffer<'a> {
 impl<'a> HandleBuffer<'a> {
     /// Get an array of [`Handles`][Handle] that support the requested protocol.
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    #[must_use]
     pub fn handles(&self) -> &[Handle] {
         // convert raw pointer to slice here so that we can get
         // appropriate lifetime of the slice.

--- a/uefi/src/table/revision.rs
+++ b/uefi/src/table/revision.rs
@@ -56,6 +56,7 @@ impl Revision {
 
 impl Revision {
     /// Creates a new revision.
+    #[must_use]
     pub const fn new(major: u16, minor: u16) -> Self {
         let major = major as u32;
         let minor = minor as u32;
@@ -64,11 +65,13 @@ impl Revision {
     }
 
     /// Returns the major revision.
+    #[must_use]
     pub const fn major(self) -> u16 {
         (self.0 >> 16) as u16
     }
 
     /// Returns the minor revision.
+    #[must_use]
     pub const fn minor(self) -> u16 {
         self.0 as u16
     }

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -405,6 +405,7 @@ impl Time {
     ///
     /// [`FileInfo`]: uefi::proto::media::file::FileInfo
     /// [`File::set_info`]: uefi::proto::media::file::File::set_info
+    #[must_use]
     pub const fn invalid() -> Self {
         Self {
             year: 0,
@@ -422,6 +423,7 @@ impl Time {
     }
 
     /// True if all fields are within valid ranges, false otherwise.
+    #[must_use]
     pub fn is_valid(&self) -> bool {
         (1900..=9999).contains(&self.year)
             && (1..=12).contains(&self.month)
@@ -435,41 +437,49 @@ impl Time {
     }
 
     /// Query the year.
+    #[must_use]
     pub const fn year(&self) -> u16 {
         self.year
     }
 
     /// Query the month.
+    #[must_use]
     pub const fn month(&self) -> u8 {
         self.month
     }
 
     /// Query the day.
+    #[must_use]
     pub const fn day(&self) -> u8 {
         self.day
     }
 
     /// Query the hour.
+    #[must_use]
     pub const fn hour(&self) -> u8 {
         self.hour
     }
 
     /// Query the minute.
+    #[must_use]
     pub const fn minute(&self) -> u8 {
         self.minute
     }
 
     /// Query the second.
+    #[must_use]
     pub const fn second(&self) -> u8 {
         self.second
     }
 
     /// Query the nanosecond.
+    #[must_use]
     pub const fn nanosecond(&self) -> u32 {
         self.nanosecond
     }
 
     /// Query the time offset in minutes from UTC, or None if using local time.
+    #[must_use]
     pub const fn time_zone(&self) -> Option<i16> {
         if self.time_zone == 2047 {
             None
@@ -479,6 +489,7 @@ impl Time {
     }
 
     /// Query the daylight savings time information.
+    #[must_use]
     pub const fn daylight(&self) -> Daylight {
         self.daylight
     }

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -53,17 +53,20 @@ pub struct SystemTable<View: SystemTableView> {
 // These parts of the UEFI System Table interface will always be available
 impl<View: SystemTableView> SystemTable<View> {
     /// Return the firmware vendor string
+    #[must_use]
     pub fn firmware_vendor(&self) -> &CStr16 {
         unsafe { CStr16::from_ptr(self.table.fw_vendor) }
     }
 
     /// Return the firmware revision
+    #[must_use]
     pub const fn firmware_revision(&self) -> u32 {
         self.table.fw_revision
     }
 
     /// Returns the revision of this table, which is defined to be
     /// the revision of the UEFI specification implemented by the firmware.
+    #[must_use]
     pub const fn uefi_revision(&self) -> Revision {
         self.table.header.revision
     }
@@ -71,6 +74,7 @@ impl<View: SystemTableView> SystemTable<View> {
     /// Returns the config table entries, a linear array of structures
     /// pointing to other system-specific tables.
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    #[must_use]
     pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
         unsafe { slice::from_raw_parts(self.table.cfg_table, self.table.nr_cfg) }
     }
@@ -121,11 +125,13 @@ impl SystemTable<Boot> {
     }
 
     /// Access runtime services
+    #[must_use]
     pub const fn runtime_services(&self) -> &RuntimeServices {
         self.table.runtime
     }
 
     /// Access boot services
+    #[must_use]
     pub const fn boot_services(&self) -> &BootServices {
         unsafe { &*self.table.boot }
     }
@@ -246,6 +252,7 @@ impl SystemTable<Runtime> {
     /// This is unsafe because UEFI runtime services require an elaborate
     /// CPU configuration which may not be preserved by OS loaders. See the
     /// "Calling Conventions" chapter of the UEFI specification for details.
+    #[must_use]
     pub const unsafe fn runtime_services(&self) -> &RuntimeServices {
         self.table.runtime
     }
@@ -286,6 +293,7 @@ impl SystemTable<Runtime> {
 
     /// Return the address of the SystemTable that resides in a UEFI runtime services
     /// memory region.
+    #[must_use]
     pub fn get_current_system_table_addr(&self) -> u64 {
         self.table as *const _ as usize as u64
     }

--- a/xtask/src/device_path/field.rs
+++ b/xtask/src/device_path/field.rs
@@ -271,6 +271,7 @@ impl NodeField {
 
         Some(quote!(
             #(#field_docs)*
+            #[must_use]
             pub fn #field_name(&self) -> #ret_type {
                 #ret_val
             }

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -294,6 +294,7 @@ mod acpi {
     impl AdrSlice {
         /// Create a new `AdrSlice`. Returns `None` if the input slice
         /// is empty.
+        #[must_use]
         pub fn new(slice: &[u32]) -> Option<&Self> {
             if slice.is_empty() {
                 None
@@ -896,6 +897,7 @@ mod messaging {
         /// service type is [`VENDOR`], otherwise returns None.
         ///
         /// [`VENDOR`]: uefi::proto::device_path::messaging::RestServiceType
+        #[must_use]
         pub fn vendor_guid_and_data(&self) -> Option<(Guid, &[u8])> {
             if self.service_type == RestServiceType::VENDOR
                 && self.vendor_guid_and_data.len() >= size_of::<Guid>()
@@ -1032,6 +1034,7 @@ mod media {
 
     impl HardDrive {
         /// Signature unique to this partition.
+        #[must_use]
         pub fn partition_signature(&self) -> PartitionSignature {
             match self.signature_type {
                 0 => PartitionSignature::None,


### PR DESCRIPTION
Adds the `clippy::must_use_candiate`-lint. Luckily, this was easy as `cargo clippy --fix` worked like a charm.

I had to do some minor adjustments to the device path code generation functionality.

Closes #565.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
