### PR TITLE
test-runner: Make some tests stricter

### DIFF
--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -3,25 +3,24 @@ use uefi::table::boot::BootServices;
 
 pub fn test(bt: &BootServices) {
     info!("Running pointer protocol test");
-    if let Ok(handle) = bt.get_handle_for_protocol::<Pointer>() {
-        let mut pointer = bt
-            .open_protocol_exclusive::<Pointer>(handle)
-            .expect("failed to open pointer protocol");
+    let handle = bt
+        .get_handle_for_protocol::<Pointer>()
+        .expect("missing Pointer protocol");
+    let mut pointer = bt
+        .open_protocol_exclusive::<Pointer>(handle)
+        .expect("failed to open pointer protocol");
 
-        pointer
-            .reset(false)
-            .expect("Failed to reset pointer device");
+    pointer
+        .reset(false)
+        .expect("Failed to reset pointer device");
 
-        let state = pointer
-            .read_state()
-            .expect("Failed to retrieve pointer state");
+    let state = pointer
+        .read_state()
+        .expect("Failed to retrieve pointer state");
 
-        if let Some(state) = state {
-            info!("New pointer State: {:#?}", state);
-        } else {
-            info!("Pointer state has not changed since the last query");
-        }
+    if let Some(state) = state {
+        info!("New pointer State: {:#?}", state);
     } else {
-        warn!("No pointer device found");
+        info!("Pointer state has not changed since the last query");
     }
 }

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -4,62 +4,61 @@ use uefi::Handle;
 
 pub unsafe fn test(image: Handle, bt: &BootServices) {
     info!("Running serial protocol test");
-    if let Ok(handle) = bt.get_handle_for_protocol::<Serial>() {
-        let mut serial = bt
-            .open_protocol::<Serial>(
-                OpenProtocolParams {
-                    handle,
-                    agent: image,
-                    controller: None,
-                },
-                // For this test, don't open in exclusive mode. That
-                // would break the connection between stdout and the
-                // serial device.
-                OpenProtocolAttributes::GetProtocol,
-            )
-            .expect("failed to open serial protocol");
-        // BUG: there are multiple failures in the serial tests on AArch64
-        if cfg!(target_arch = "aarch64") {
-            return;
-        }
-
-        let old_ctrl_bits = serial
-            .get_control_bits()
-            .expect("Failed to get device control bits");
-        let mut ctrl_bits = ControlBits::empty();
-
-        // For the purposes of testing, we're _not_ going to implement
-        // software flow control.
-        ctrl_bits |= ControlBits::HARDWARE_FLOW_CONTROL_ENABLE;
-
-        // Use a loop back device for testing.
-        ctrl_bits |= ControlBits::SOFTWARE_LOOPBACK_ENABLE;
-
-        serial
-            .set_control_bits(ctrl_bits)
-            .expect("Failed to set device control bits");
-
-        // Keep this message short, we need it to fit in the FIFO.
-        const OUTPUT: &[u8] = b"Hello world!";
-        const MSG_LEN: usize = OUTPUT.len();
-
-        serial
-            .write(OUTPUT)
-            .expect("Failed to write to serial port");
-
-        let mut input = [0u8; MSG_LEN];
-        serial
-            .read(&mut input)
-            .expect("Failed to read from serial port");
-
-        assert_eq!(OUTPUT, &input[..]);
-
-        // Clean up after ourselves
-        serial.reset().expect("Could not reset the serial device");
-        serial
-            .set_control_bits(old_ctrl_bits & ControlBits::SETTABLE)
-            .expect("Could not restore the serial device state");
-    } else {
-        warn!("No serial device found");
+    let handle = bt
+        .get_handle_for_protocol::<Serial>()
+        .expect("missing Serial protocol");
+    let mut serial = bt
+        .open_protocol::<Serial>(
+            OpenProtocolParams {
+                handle,
+                agent: image,
+                controller: None,
+            },
+            // For this test, don't open in exclusive mode. That
+            // would break the connection between stdout and the
+            // serial device.
+            OpenProtocolAttributes::GetProtocol,
+        )
+        .expect("failed to open serial protocol");
+    // BUG: there are multiple failures in the serial tests on AArch64
+    if cfg!(target_arch = "aarch64") {
+        return;
     }
+
+    let old_ctrl_bits = serial
+        .get_control_bits()
+        .expect("Failed to get device control bits");
+    let mut ctrl_bits = ControlBits::empty();
+
+    // For the purposes of testing, we're _not_ going to implement
+    // software flow control.
+    ctrl_bits |= ControlBits::HARDWARE_FLOW_CONTROL_ENABLE;
+
+    // Use a loop back device for testing.
+    ctrl_bits |= ControlBits::SOFTWARE_LOOPBACK_ENABLE;
+
+    serial
+        .set_control_bits(ctrl_bits)
+        .expect("Failed to set device control bits");
+
+    // Keep this message short, we need it to fit in the FIFO.
+    const OUTPUT: &[u8] = b"Hello world!";
+    const MSG_LEN: usize = OUTPUT.len();
+
+    serial
+        .write(OUTPUT)
+        .expect("Failed to write to serial port");
+
+    let mut input = [0u8; MSG_LEN];
+    serial
+        .read(&mut input)
+        .expect("Failed to read from serial port");
+
+    assert_eq!(OUTPUT, &input[..]);
+
+    // Clean up after ourselves
+    serial.reset().expect("Could not reset the serial device");
+    serial
+        .set_control_bits(old_ctrl_bits & ControlBits::SETTABLE)
+        .expect("Could not restore the serial device state");
 }

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -4,91 +4,86 @@ use uefi::table::boot::BootServices;
 
 pub fn test(bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
-    if let Ok(handles) = bt.find_handles::<DebugSupport>() {
-        for handle in handles {
-            if let Ok(mut debug_support) = bt.open_protocol_exclusive::<DebugSupport>(handle) {
-                // make sure that the max processor index is a sane value, i.e. it works
-                let maximum_processor_index = debug_support.get_maximum_processor_index();
-                assert_ne!(
+    let handles = bt
+        .find_handles::<DebugSupport>()
+        .expect("missing DebugSupport protocol");
+    for handle in handles {
+        if let Ok(mut debug_support) = bt.open_protocol_exclusive::<DebugSupport>(handle) {
+            // make sure that the max processor index is a sane value, i.e. it works
+            let maximum_processor_index = debug_support.get_maximum_processor_index();
+            assert_ne!(
                     maximum_processor_index,
                     usize::MAX,
                     "get_maximum_processor_index() returning garbage, unless you really have 18,446,744,073,709,551,615 processors"
                 );
 
-                info!("- Architecture: {:?}", debug_support.arch());
-                info!("- Maximum Processor Index: {:?}", maximum_processor_index);
+            info!("- Architecture: {:?}", debug_support.arch());
+            info!("- Maximum Processor Index: {:?}", maximum_processor_index);
 
-                match debug_support.arch() {
-                    // This arm is the only match when testing on QEMU w/ OVMF, regardless of the machine arch.
-                    // The released OVMF builds don't implement the Debug Support Protocol Interface for the
-                    // machine arch, only EBC.
-                    ProcessorArch::EBC => unsafe {
-                        info!("Registering periodic callback");
-                        debug_support
-                            .register_periodic_callback(0, Some(periodic_callback))
-                            .expect("Error while registering periodic callback");
-                        info!("Deregistering periodic callback");
-                        debug_support
-                            .register_periodic_callback(0, None)
-                            .expect("Error while deregistering periodic callback");
-                        // for the EBC virtual CPU, there are already exception callbacks registered
-                        info!("Deregistering exception callback");
-                        debug_support
-                            .register_exception_callback(0, None, ExceptionType::EXCEPT_EBC_DEBUG)
-                            .expect("Error while deregistering exception callback");
-                        info!("Registering exception callback");
-                        debug_support
-                            .register_exception_callback(
-                                0,
-                                Some(exception_callback),
-                                ExceptionType::EXCEPT_EBC_DEBUG,
-                            )
-                            .expect("Error while registering exception callback");
-                    },
-                    #[cfg(target_arch = "x86_64")]
-                    ProcessorArch::X86_64 => unsafe {
-                        info!("Registering exception callback");
-                        debug_support
-                            .register_exception_callback(
-                                0,
-                                Some(exception_callback),
-                                ExceptionType::EXCEPT_X64_DEBUG,
-                            )
-                            .expect("Error while registering exception callback");
-                        info!("Deregistering exception callback");
-                        debug_support
-                            .register_exception_callback(0, None, ExceptionType::EXCEPT_X64_DEBUG)
-                            .expect("Error while deregistering exception callback");
-                    },
-                    #[cfg(target_arch = "aarch64")]
-                    ProcessorArch::AARCH_64 => unsafe {
-                        info!("Registering exception callback");
-                        debug_support
-                            .register_exception_callback(
-                                0,
-                                Some(exception_callback),
-                                ExceptionType::EXCEPT_AARCH64_SERROR,
-                            )
-                            .expect("Error while registering exception callback");
-                        info!("Deregistering exception callback");
-                        debug_support
-                            .register_exception_callback(
-                                0,
-                                None,
-                                ExceptionType::EXCEPT_AARCH64_SERROR,
-                            )
-                            .expect("Error while deregistering exception callback");
-                    },
-                    // if we reach this, we're running on an arch that `cargo xtask run` doesn't support
-                    // TODO: Add match arms as we support testing on more archs
-                    _ => unreachable!(),
-                }
-
-                test_invalidate_instruction_cache(&mut debug_support);
+            match debug_support.arch() {
+                // This arm is the only match when testing on QEMU w/ OVMF, regardless of the machine arch.
+                // The released OVMF builds don't implement the Debug Support Protocol Interface for the
+                // machine arch, only EBC.
+                ProcessorArch::EBC => unsafe {
+                    info!("Registering periodic callback");
+                    debug_support
+                        .register_periodic_callback(0, Some(periodic_callback))
+                        .expect("Error while registering periodic callback");
+                    info!("Deregistering periodic callback");
+                    debug_support
+                        .register_periodic_callback(0, None)
+                        .expect("Error while deregistering periodic callback");
+                    // for the EBC virtual CPU, there are already exception callbacks registered
+                    info!("Deregistering exception callback");
+                    debug_support
+                        .register_exception_callback(0, None, ExceptionType::EXCEPT_EBC_DEBUG)
+                        .expect("Error while deregistering exception callback");
+                    info!("Registering exception callback");
+                    debug_support
+                        .register_exception_callback(
+                            0,
+                            Some(exception_callback),
+                            ExceptionType::EXCEPT_EBC_DEBUG,
+                        )
+                        .expect("Error while registering exception callback");
+                },
+                #[cfg(target_arch = "x86_64")]
+                ProcessorArch::X86_64 => unsafe {
+                    info!("Registering exception callback");
+                    debug_support
+                        .register_exception_callback(
+                            0,
+                            Some(exception_callback),
+                            ExceptionType::EXCEPT_X64_DEBUG,
+                        )
+                        .expect("Error while registering exception callback");
+                    info!("Deregistering exception callback");
+                    debug_support
+                        .register_exception_callback(0, None, ExceptionType::EXCEPT_X64_DEBUG)
+                        .expect("Error while deregistering exception callback");
+                },
+                #[cfg(target_arch = "aarch64")]
+                ProcessorArch::AARCH_64 => unsafe {
+                    info!("Registering exception callback");
+                    debug_support
+                        .register_exception_callback(
+                            0,
+                            Some(exception_callback),
+                            ExceptionType::EXCEPT_AARCH64_SERROR,
+                        )
+                        .expect("Error while registering exception callback");
+                    info!("Deregistering exception callback");
+                    debug_support
+                        .register_exception_callback(0, None, ExceptionType::EXCEPT_AARCH64_SERROR)
+                        .expect("Error while deregistering exception callback");
+                },
+                // if we reach this, we're running on an arch that `cargo xtask run` doesn't support
+                // TODO: Add match arms as we support testing on more archs
+                _ => unreachable!(),
             }
+
+            test_invalidate_instruction_cache(&mut debug_support);
         }
-    } else {
-        warn!("Debug protocol is not supported");
     }
 }
 

--- a/uefi-test-runner/src/proto/string/unicode_collation.rs
+++ b/uefi-test-runner/src/proto/string/unicode_collation.rs
@@ -6,94 +6,93 @@ use uefi::{CStr16, CStr8};
 pub fn test(bt: &BootServices) {
     info!("Testing the Unicode Collation protocol");
 
-    if let Ok(handles) = bt.find_handles::<UnicodeCollation>() {
-        for handle in handles {
-            let uc = bt
-                .open_protocol_exclusive::<UnicodeCollation>(handle)
-                .unwrap();
+    let handles = bt
+        .find_handles::<UnicodeCollation>()
+        .expect("missing UnicodeCollation protocol");
+    for handle in handles {
+        let uc = bt
+            .open_protocol_exclusive::<UnicodeCollation>(handle)
+            .unwrap();
 
-            let mut buf1 = [0; 30];
-            let mut buf2 = [0; 30];
+        let mut buf1 = [0; 30];
+        let mut buf2 = [0; 30];
 
-            macro_rules! strings {
-                ($s1:expr, $s2:expr) => {{
-                    let s1 = CStr16::from_str_with_buf($s1, &mut buf1).unwrap();
-                    let s2 = CStr16::from_str_with_buf($s2, &mut buf2).unwrap();
-                    (s1, s2)
-                }};
-            }
-
-            let (s1, s2) = strings!("aab", "aaa");
-            // "aab" is lexically greater than "aaa"
-            assert_eq!(uc.stri_coll(s1, s2), Ordering::Greater);
-
-            let (s1, s2) = strings!("{}", "{}");
-            assert_eq!(uc.stri_coll(s1, s2), Ordering::Equal);
-
-            let (s1, s2) = strings!("\t", "-");
-            // Tab comes before dash in the unicode table
-            assert_eq!(uc.stri_coll(s1, s2), Ordering::Less);
-
-            let (s, pattern) = strings!("haaaaaaaaarderr", "h*a*r*derr");
-            assert!(uc.metai_match(s, pattern));
-
-            let (s, pattern) = strings!("haaaaaaaaarder0r", "h*a*r*derr");
-            assert!(!uc.metai_match(s, pattern));
-
-            let mut buf1 = [0; 13];
-            let s = CStr16::from_str_with_buf("HeLlO World!", &mut buf1).unwrap();
-
-            let mut buf2 = [0; 12];
-            assert_eq!(
-                uc.str_lwr(s, &mut buf2),
-                Err(StrConversionError::BufferTooSmall)
-            );
-
-            let mut buf2 = [0; 13];
-            let lower_s = uc.str_lwr(s, &mut buf2).unwrap();
-            assert_eq!(
-                lower_s,
-                CStr16::from_str_with_buf("hello world!", &mut [0; 13]).unwrap()
-            );
-
-            let mut buf = [0; 12];
-            assert_eq!(
-                uc.str_upr(s, &mut buf),
-                Err(StrConversionError::BufferTooSmall)
-            );
-
-            let mut buf = [0; 13];
-            let upper_s = uc.str_upr(s, &mut buf).unwrap();
-            assert_eq!(
-                upper_s,
-                CStr16::from_str_with_buf("HELLO WORLD!", &mut [0; 13]).unwrap()
-            );
-
-            let s = CStr8::from_bytes_with_nul(b"Hello World!\0").unwrap();
-            assert_eq!(
-                uc.fat_to_str(s, &mut [0; 12]),
-                Err(StrConversionError::BufferTooSmall)
-            );
-
-            assert_eq!(
-                uc.fat_to_str(s, &mut [0; 13]).unwrap(),
-                CStr16::from_str_with_buf("Hello World!", &mut [0; 13]).unwrap()
-            );
-
-            let mut buf = [0; 13];
-            let s = CStr16::from_str_with_buf("Hello World!", &mut buf).unwrap();
-            let mut buf = [0; 12];
-            assert_eq!(
-                uc.str_to_fat(s, &mut buf),
-                Err(StrConversionError::BufferTooSmall)
-            );
-            let mut buf = [0; 13];
-            assert_eq!(
-                uc.str_to_fat(s, &mut buf).unwrap(),
-                CStr8::from_bytes_with_nul(b"HELLOWORLD!\0").unwrap()
-            );
+        macro_rules! strings {
+            ($s1:expr, $s2:expr) => {{
+                let s1 = CStr16::from_str_with_buf($s1, &mut buf1).unwrap();
+                let s2 = CStr16::from_str_with_buf($s2, &mut buf2).unwrap();
+                (s1, s2)
+            }};
         }
-    } else {
-        warn!("The Unicode Collation protocol is not supported");
+
+        let (s1, s2) = strings!("aab", "aaa");
+        // "aab" is lexically greater than "aaa"
+        assert_eq!(uc.stri_coll(s1, s2), Ordering::Greater);
+
+        let (s1, s2) = strings!("{}", "{}");
+        assert_eq!(uc.stri_coll(s1, s2), Ordering::Equal);
+
+        let (s1, s2) = strings!("\t", "-");
+        // Tab comes before dash in the unicode table
+        assert_eq!(uc.stri_coll(s1, s2), Ordering::Less);
+
+        let (s, pattern) = strings!("haaaaaaaaarderr", "h*a*r*derr");
+        assert!(uc.metai_match(s, pattern));
+
+        let (s, pattern) = strings!("haaaaaaaaarder0r", "h*a*r*derr");
+        assert!(!uc.metai_match(s, pattern));
+
+        let mut buf1 = [0; 13];
+        let s = CStr16::from_str_with_buf("HeLlO World!", &mut buf1).unwrap();
+
+        let mut buf2 = [0; 12];
+        assert_eq!(
+            uc.str_lwr(s, &mut buf2),
+            Err(StrConversionError::BufferTooSmall)
+        );
+
+        let mut buf2 = [0; 13];
+        let lower_s = uc.str_lwr(s, &mut buf2).unwrap();
+        assert_eq!(
+            lower_s,
+            CStr16::from_str_with_buf("hello world!", &mut [0; 13]).unwrap()
+        );
+
+        let mut buf = [0; 12];
+        assert_eq!(
+            uc.str_upr(s, &mut buf),
+            Err(StrConversionError::BufferTooSmall)
+        );
+
+        let mut buf = [0; 13];
+        let upper_s = uc.str_upr(s, &mut buf).unwrap();
+        assert_eq!(
+            upper_s,
+            CStr16::from_str_with_buf("HELLO WORLD!", &mut [0; 13]).unwrap()
+        );
+
+        let s = CStr8::from_bytes_with_nul(b"Hello World!\0").unwrap();
+        assert_eq!(
+            uc.fat_to_str(s, &mut [0; 12]),
+            Err(StrConversionError::BufferTooSmall)
+        );
+
+        assert_eq!(
+            uc.fat_to_str(s, &mut [0; 13]).unwrap(),
+            CStr16::from_str_with_buf("Hello World!", &mut [0; 13]).unwrap()
+        );
+
+        let mut buf = [0; 13];
+        let s = CStr16::from_str_with_buf("Hello World!", &mut buf).unwrap();
+        let mut buf = [0; 12];
+        assert_eq!(
+            uc.str_to_fat(s, &mut buf),
+            Err(StrConversionError::BufferTooSmall)
+        );
+        let mut buf = [0; 13];
+        assert_eq!(
+            uc.str_to_fat(s, &mut buf).unwrap(),
+            CStr8::from_bytes_with_nul(b"HELLOWORLD!\0").unwrap()
+        );
     }
 }


### PR DESCRIPTION
We now assume that tests are running in the special QEMU env, so change some of the tests to `expect` that a protocol is present rather than just `log::warn` if missing.

This change looks big due to removing `if` blocks creating big whitespace changes; `git show -w` will make it easier to see what's really changed.

https://github.com/rust-osdev/uefi-rs/issues/553

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
