### PR TITLE
test-runner: Open serial device in exclusive mode

### DIFF
--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -7,7 +7,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
 
     let bt = st.boot_services();
     unsafe {
-        serial::test(image, bt);
+        serial::test(bt);
         gop::test(image, bt);
     }
     pointer::test(bt);


### PR DESCRIPTION
The serial test is occasionally failing in CI. I'm hoping that changing the test to open in exclusive mode will fix it, using the same trick of reconnecting all controllers that we do in `send_request_to_host`. It's hard to be sure though since the test failure doesn't occur all that often.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
