### PR TITLE
Add list of possible errors to `BootServices::open_protocol` docs

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1105,6 +1105,19 @@ impl BootServices {
     ///
     /// [`handle_protocol`]: BootServices::handle_protocol
     /// [`open_protocol_exclusive`]: BootServices::open_protocol_exclusive
+    ///
+    /// # Errors
+    ///
+    /// This function returns errors directly from the UEFI function
+    /// `EFI_BOOT_SERVICES.OpenProtocol()`. Some errors have multiple
+    /// different causes. See the function definition in the UEFI
+    /// Specification, Chapter 7.3 for more information on possible causes
+    /// for each error type.
+    ///
+    /// * [`uefi::Status::INVALID_PARAMETER`]
+    /// * [`uefi::Status::UNSUPPORTED`]
+    /// * [`uefi::Status::ACCESS_DENIED`]
+    /// * [`uefi::Status::ALREADY_STARTED`]
     pub unsafe fn open_protocol<P: ProtocolPointer + ?Sized>(
         &self,
         params: OpenProtocolParams,


### PR DESCRIPTION
I added a list of possible errors that `BootServices::open_protocol` can return into the function's documentation.

Since each error could have multiple possible causes, I listed which chapter of the UEFI Specification this function can be found in. I figured that this would be better than copying every possible cause for every error of each function from the specification.

Please let me know if you think there might be a better way to list the types of errors returned from functions. I hope to add the possible returned error types for other `BootServices` functions in the future. :)

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
