### PR TITLE
xtask: Update to mbrman 0.5.1

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,8 +12,7 @@ fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", rev = "87fc1ed5074a3
 fs-err = "2.6.0"
 heck = "0.4.0"
 itertools = "0.10.5"
-# Use git as a temporary workaround for https://github.com/rust-osdev/uefi-rs/issues/573.
-mbrman = { git = "https://github.com/cecton/mbrman.git", rev = "78565860e55c272488d94480e72a4e2cd159ad8e" }
+mbrman = "0.5.1"
 nix = "0.26.1"
 proc-macro2 = "1.0.46"
 quote = "1.0.21"


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/uefi-rs/issues/573

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
