### PR TITLE
UnalignedSlice: impl Clone and improve Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### Changed
 
+- `UnalignedSlice` now implements `Clone`, and the `Debug` impl now
+  prints the elements instead of the internal fields.
+
 ### Removed
 
 ## uefi-macros - [Unreleased]

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -1,3 +1,4 @@
+use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
@@ -10,7 +11,7 @@ use crate::alloc::vec::Vec;
 /// [`repr(packed)`] struct. The element type must be [`Copy`].
 ///
 /// [`repr(packed)`]: https://doc.rust-lang.org/nomicon/other-reprs.html#reprpacked
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct UnalignedSlice<'a, T: Copy> {
     data: *const T,
     len: usize,
@@ -124,6 +125,12 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
             v.set_len(len);
         }
         v
+    }
+}
+
+impl<'a, T: Copy + Debug> Debug for UnalignedSlice<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 


### PR DESCRIPTION
Slices and containers like `Vec` print their elements when formatted with `Debug`, so make `UnalignedSlice` do the same.

Also implement `Clone`, which just makes a shallow copy.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
