### PR TITLE
Add docs to `BootServices` functions describing error cases

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -717,12 +717,7 @@ impl BootServices {
     ///
     /// This function directly calls the UEFI function `EFI_BOOT_SERVICES.SignalEvent()`.
     ///
-    /// Note: The UEFI Specification v2.9 states that this may only return `EFI_SUCCESS`, but,
-    /// depending on the UEFI implementation, it is possible that this may return an error.
-    /// More research should be done to determine if any UEFI implementations (specifically EDK2)
-    /// return error codes for this function. To be safe, ensure that error codes are handled
-    /// properly.
-    ///
+    /// Currently, (as of UEFI Spec v2.9) this only returns `EFI_SUCCESS`.
     /// See the function definition in the UEFI Specification, Chapter 7.1 for more details.
     pub fn signal_event(&self, event: &Event) -> Result {
         // Safety: cloning this event should be safe, as we're directly passing it to firmware


### PR DESCRIPTION
Hello,

I added some more documentation to functions in `BootServices`.

I also rewrote some documentation in `BootServices::signal_event` to detail the possibility that some UEFI implementations might return an error, even though the UEFI Specification does not list any returned errors. I figured the documentation probably should not say that the function won't return any errors, since it returns a `Result`.

Does anyone else have advice for writing documentation on UEFI functions with errors that are not listed in the UEFI spec? It seems like this problem comes up a lot in UEFI. :)

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
