### PR TITLE
Initial support for TCG TPM protocols

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,13 +42,13 @@ jobs:
     - name: Install qemu and OVMF
       run: |
         sudo apt-get update
-        sudo apt-get install qemu-system-x86 ovmf -y
+        sudo apt-get install qemu-system-x86 ovmf swtpm -y
 
     - name: Build (without unstable)
       run: cargo xtask build --target x86_64
 
     - name: Run VM tests
-      run: cargo xtask run --target x86_64 --headless --ci
+      run: cargo xtask run --target x86_64 --headless --ci --tpm=v1
       timeout-minutes: 2
 
   test_ia32:
@@ -61,13 +61,13 @@ jobs:
     - name: Install qemu and OVMF
       run: |
         sudo apt-get update
-        sudo apt-get install qemu-system-x86 ovmf-ia32 -y
+        sudo apt-get install qemu-system-x86 ovmf-ia32 swtpm -y
 
     - name: Build
       run: cargo xtask build --target ia32
 
     - name: Run VM tests
-      run: cargo xtask run --target ia32 --headless --ci
+      run: cargo xtask run --target ia32 --headless --ci --tpm=v2
       timeout-minutes: 2
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   feature. (requires the **unstable** and **alloc** features)
 - Added an `core::error::Error` implementation for `Error` to ease
   integration with error-handling crates. (requires the **unstable** feature)
+- Added partial support for the TCG protocols for TPM devices under `uefi::proto::tcg`.
 
 ### Changed
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -28,6 +28,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
         target_arch = "aarch64"
     ))]
     shim::test(bt);
+    tcg::test(bt);
 }
 
 fn find_protocol(bt: &BootServices) {
@@ -73,3 +74,4 @@ mod rng;
 ))]
 mod shim;
 mod string;
+mod tcg;

--- a/uefi-test-runner/src/proto/tcg.rs
+++ b/uefi-test-runner/src/proto/tcg.rs
@@ -1,0 +1,65 @@
+use uefi::proto::tcg::{v1, v2};
+use uefi::table::boot::BootServices;
+
+// Environmental note:
+//
+// QEMU does not support attaching multiple TPM devices at once, so we
+// can't test TPM v1 and v2 at the same time. To ensure that the CI
+// tests both v1 and v2, we arbitrarily choose x86_64 to test TPM v1 and
+// x86 32-bit to test TPM v2.
+//
+// This is enforced in the tests here; if the `ci` feature is enabled
+// but the TPM device of the appropriate type isn't available, the test
+// panics. If the `ci` feature is not enabled then you can freely enable
+// v1, v2, or no TPM.
+
+pub fn test_tcg_v1(bt: &BootServices) {
+    info!("Running TCG v1 test");
+
+    let handle = if let Ok(handle) = bt.get_handle_for_protocol::<v1::Tcg>() {
+        handle
+    } else if cfg!(all(feature = "ci", target_arch = "x86_64")) {
+        panic!("TPM v1 is required on x86_64 CI");
+    } else {
+        info!("No TCG handle found");
+        return;
+    };
+
+    let mut tcg = bt
+        .open_protocol_exclusive::<v1::Tcg>(handle)
+        .expect("failed to open TCG protocol");
+
+    let status = tcg.status_check().expect("failed to call status_check");
+    info!(
+        "tcg status: {:?} {}",
+        status.protocol_capability, status.feature_flags
+    );
+    for event in status.event_log.iter() {
+        info!("PCR {}: {:?}", event.pcr_index().0, event.event_type());
+    }
+}
+
+pub fn test_tcg_v2(bt: &BootServices) {
+    info!("Running TCG v2 test");
+
+    let handle = if let Ok(handle) = bt.get_handle_for_protocol::<v2::Tcg>() {
+        handle
+    } else if cfg!(all(feature = "ci", target_arch = "x86")) {
+        panic!("TPM v2 is required on x86 (32-bit) CI");
+    } else {
+        info!("No TCG handle found");
+        return;
+    };
+
+    let mut tcg = bt
+        .open_protocol_exclusive::<v2::Tcg>(handle)
+        .expect("failed to open TCG protocol");
+
+    let capability = tcg.get_capability().expect("failed to call get_capability");
+    info!("capability: {:?}", capability);
+}
+
+pub fn test(bt: &BootServices) {
+    test_tcg_v1(bt);
+    test_tcg_v2(bt);
+}

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -75,3 +75,4 @@ pub mod rng;
 pub mod security;
 pub mod shim;
 pub mod string;
+pub mod tcg;

--- a/uefi/src/proto/tcg/enums.rs
+++ b/uefi/src/proto/tcg/enums.rs
@@ -1,0 +1,85 @@
+// Providing docstrings for each constant would be a lot of work, so
+// allow missing docs. Each type-level doc links to the relevant spec to
+// provide more info.
+//
+// Setting this at the module level so that we don't have to write it
+// above each constant. That's also why these enums are in a separate
+// module instead of `super`, since we don't want to allow missing docs
+// too broadly.
+#![allow(missing_docs)]
+
+newtype_enum! {
+    /// Algorithm identifiers.
+    ///
+    /// These values are defined in the [TCG Algorithm Registry].
+    ///
+    /// [TCG Algorithm Registry]: https://trustedcomputinggroup.org/resource/tcg-algorithm-registry/
+    pub enum AlgorithmId: u16 => {
+        ERROR = 0x0000,
+        RSA = 0x0001,
+        TDES = 0x0003,
+        SHA1 = 0x0004,
+        HMAC = 0x0005,
+        AES = 0x0006,
+        MGF1 = 0x0007,
+        KEYED_HASH = 0x0008,
+        XOR = 0x000a,
+        SHA256 = 0x000b,
+        SHA384 = 0x000c,
+        SHA512 = 0x000d,
+        NULL = 0x0010,
+        SM3_256 = 0x0012,
+        SM4 = 0x0013,
+        // TODO: there are a bunch more, but the above list is probably
+        // more than sufficient for real devices.
+    }
+}
+
+newtype_enum! {
+    /// Event types stored in the TPM event log. The event type defines
+    /// which structure type is stored in the event data.
+    ///
+    /// For details of each variant, see the [TCG PC Client Platform
+    /// Firmware Protocol Specification][spec], in particular the Events
+    /// table in the Event Logging chapter.
+    ///
+    /// [spec]: https://trustedcomputinggroup.org/resource/pc-client-specific-platform-firmware-profile-specification/
+    pub enum EventType: u32 => {
+        PREBOOT_CERT = 0x0000_0000,
+        POST_CODE = 0x0000_0001,
+        UNUSED = 0x0000_0002,
+        NO_ACTION = 0x0000_0003,
+        SEPARATOR = 0x0000_0004,
+        ACTION = 0x0000_0005,
+        EVENT_TAG = 0x0000_0006,
+        CRTM_CONTENTS = 0x0000_0007,
+        CRTM_VERSION = 0x0000_0008,
+        CPU_MICROCODE = 0x0000_0009,
+        PLATFORM_CONFIG_FLAGS = 0x0000_000a,
+        TABLE_OF_DEVICES = 0x0000_000b,
+        COMPACT_HASH = 0x0000_000c,
+        IPL = 0x0000_000d,
+        IPL_PARTITION_DATA = 0x0000_000e,
+        NONHOST_CODE = 0x0000_000f,
+        NONHOST_CONFIG = 0x0000_0010,
+        NONHOST_INFO = 0x0000_0011,
+        OMIT_BOOT_DEVICE_EVENTS = 0x0000_0012,
+        EFI_EVENT_BASE = 0x8000_0000,
+        EFI_VARIABLE_DRIVER_CONFIG = 0x8000_0001,
+        EFI_VARIABLE_BOOT = 0x8000_0002,
+        EFI_BOOT_SERVICES_APPLICATION = 0x8000_0003,
+        EFI_BOOT_SERVICES_DRIVER = 0x8000_0004,
+        EFI_RUNTIME_SERVICES_DRIVER = 0x8000_0005,
+        EFI_GPT_EVENT = 0x8000_0006,
+        EFI_ACTION = 0x8000_0007,
+        EFI_PLATFORM_FIRMWARE_BLOB = 0x8000_0008,
+        EFI_HANDOFF_TABLES = 0x8000_0009,
+        EFI_PLATFORM_FIRMWARE_BLOB2 = 0x8000_000a,
+        EFI_HANDOFF_TABLES2 = 0x8000_000b,
+        EFI_VARIABLE_BOOT2 = 0x8000_000c,
+        EFI_HCRTM_EVENT = 0x8000_0010,
+        EFI_VARIABLE_AUTHORITY = 0x8000_00e0,
+        EFI_SPDM_FIRMWARE_BLOB = 0x8000_00e1,
+        EFI_SPDM_FIRMWARE_CONFIG = 0x8000_00e2,
+    }
+}

--- a/uefi/src/proto/tcg/mod.rs
+++ b/uefi/src/proto/tcg/mod.rs
@@ -1,0 +1,56 @@
+//! [TCG] (Trusted Computing Group) protocols.
+//!
+//! These protocols provide access to the [TPM][tpm] (Trusted Platform Module).
+//!
+//! There are two versions of the protocol. The original protocol is in
+//! the [`v1`] module. It is used with TPM 1.1 and 1.2 devices. The
+//! newer protocol in the [`v2`] module is generally provided for TPM
+//! 2.0 devices, although the spec indicates it can be used for older
+//! TPM versions as well.
+//!
+//! [TCG]: https://trustedcomputinggroup.org/
+//! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
+
+pub mod v1;
+pub mod v2;
+
+mod enums;
+pub use enums::*;
+
+use bitflags::bitflags;
+
+/// Platform Configuration Register (PCR) index.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PcrIndex(pub u32);
+
+bitflags! {
+    /// Hash algorithms the protocol can provide.
+    ///
+    /// The [`v1`] protocol only supports SHA1.
+    #[derive(Default)]
+    #[repr(transparent)]
+    pub struct HashAlgorithm: u32 {
+        /// SHA-1 hash.
+        const SHA1 = 0x0000_0001;
+
+        /// SHA-256 hash.
+        const SHA256 = 0x0000_0002;
+
+        /// SHA-384 hash.
+        const SHA384 = 0x0000_0004;
+
+        /// SHA-512 hash.
+        const SHA512 = 0x0000_0008;
+
+        /// SM3-256 hash.
+        const SM3_256 = 0x0000_0010;
+    }
+}
+
+/// Convenience function for converting from a `u32` to a `usize`
+/// without using `as` or unwrapping everywhere. This particular
+/// conversion comes up a lot in the TPM API, and it should be
+/// infallable on supported targets.
+fn usize_from_u32(val: u32) -> usize {
+    val.try_into().expect("`u32` does not fit in `usize`")
+}

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -1,0 +1,401 @@
+//! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
+//! Module) 1.1 and 1.2.
+//!
+//! This protocol is defined in the [TCG EFI Protocol Specification _for
+//! TPM Family 1.1 or 1.2_][spec].
+//!
+//! [spec]: https://trustedcomputinggroup.org/resource/tcg-efi-protocol-specification/
+//! [TCG]: https://trustedcomputinggroup.org/
+//! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
+
+use super::{usize_from_u32, EventType, HashAlgorithm, PcrIndex};
+use crate::data_types::PhysicalAddress;
+use crate::proto::Protocol;
+use crate::{unsafe_guid, Result, Status};
+use core::fmt::{self, Debug, Formatter};
+use core::marker::PhantomData;
+use core::{mem, ptr};
+
+/// 20-byte SHA-1 digest.
+pub type Sha1Digest = [u8; 20];
+
+/// Information about the protocol and the TPM device.
+///
+/// Layout compatible with the C type `TCG_EFI_BOOT_SERVICE_CAPABILITY`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BootServiceCapability {
+    size: u8,
+    structure_version: Version,
+    protocol_spec_version: Version,
+    hash_algorithm_bitmap: u8,
+    tpm_present_flag: u8,
+    tpm_deactivated_flag: u8,
+}
+
+impl BootServiceCapability {
+    /// Version of the `BootServiceCapability` structure.
+    #[must_use]
+    pub fn structure_version(&self) -> Version {
+        self.structure_version
+    }
+
+    /// Version of the `Tcg` protocol.
+    #[must_use]
+    pub fn protocol_spec_version(&self) -> Version {
+        self.protocol_spec_version
+    }
+
+    /// Supported hash algorithms.
+    #[must_use]
+    pub fn hash_algorithm(&self) -> HashAlgorithm {
+        // Safety: the value should always be 0x1 (indicating SHA-1), but
+        // we don't care if it's some unexpected value.
+        unsafe { HashAlgorithm::from_bits_unchecked(u32::from(self.hash_algorithm_bitmap)) }
+    }
+
+    /// Whether the TPM device is present.
+    #[must_use]
+    pub fn tpm_present(&self) -> bool {
+        self.tpm_present_flag != 0
+    }
+
+    /// Whether the TPM device is deactivated.
+    #[must_use]
+    pub fn tpm_deactivated(&self) -> bool {
+        self.tpm_deactivated_flag != 0
+    }
+}
+
+/// Version information.
+///
+/// Layout compatible with the C type `TCG_VERSION`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Version {
+    /// Major version.
+    pub major: u8,
+    /// Minor version.
+    pub minor: u8,
+
+    // Leave these two fields undocumented since it's not clear what
+    // they are for. The spec doesn't say, and they were removed in the
+    // v2 spec.
+    #[allow(missing_docs)]
+    pub rev_major: u8,
+    #[allow(missing_docs)]
+    pub rev_minor: u8,
+}
+
+/// Entry in the [`EventLog`].
+///
+/// Layout compatible with the C type `TCG_PCR_EVENT`.
+///
+/// Naming note: the spec refers to "event data" in two conflicting
+/// ways: the `event_data` field and the data hashed in the digest
+/// field. These two are independent; although the event data _can_ be
+/// what is hashed in the digest field, it doesn't have to be.
+#[repr(C, packed)]
+pub struct PcrEvent {
+    pcr_index: PcrIndex,
+    event_type: EventType,
+    digest: Sha1Digest,
+    event_data_size: u32,
+    event_data: [u8],
+}
+
+impl PcrEvent {
+    pub(super) unsafe fn from_ptr<'a>(ptr: *const u8) -> &'a Self {
+        // Get the `event_size` field.
+        let ptr_u32: *const u32 = ptr.cast();
+        let event_size = ptr_u32.add(7).read_unaligned();
+        let event_size = usize_from_u32(event_size);
+        unsafe { &*ptr::from_raw_parts(ptr.cast(), event_size) }
+    }
+
+    /// PCR index for the event.
+    #[must_use]
+    pub fn pcr_index(&self) -> PcrIndex {
+        self.pcr_index
+    }
+
+    /// Type of event, indicating what type of data is stored in [`event_data`].
+    ///
+    /// [`event_data`]: Self::event_data
+    #[must_use]
+    pub fn event_type(&self) -> EventType {
+        self.event_type
+    }
+
+    /// Raw event data. The meaning of this data can be determined from
+    /// the [`event_type`].
+    ///
+    /// Note that this data is independent of what is hashed [`digest`].
+    ///
+    /// [`digest`]: Self::digest
+    /// [`event_type`]: Self::event_type
+    #[must_use]
+    pub fn event_data(&self) -> &[u8] {
+        &self.event_data
+    }
+
+    /// SHA-1 digest of the data hashed for this event.
+    #[must_use]
+    pub fn digest(&self) -> Sha1Digest {
+        self.digest
+    }
+}
+
+// Manual `Debug` implementation since it can't be derived for a packed DST.
+impl Debug for PcrEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PcrEvent")
+            .field("pcr_index", &{ self.pcr_index })
+            .field("event_type", &{ self.event_type })
+            .field("digest", &self.digest)
+            .field("event_data_size", &{ self.event_data_size })
+            .field("event_data", &&self.event_data)
+            .finish()
+    }
+}
+
+/// TPM event log.
+///
+/// This type of event log always uses SHA-1 hashes.
+///
+/// [`v1::Tcg`]: Tcg
+/// [`v2::Tcg`]: super::v2::Tcg
+pub struct EventLog<'a> {
+    // Tie the lifetime to the protocol, and by extension, boot services.
+    _lifetime: PhantomData<&'a Tcg>,
+
+    location: *const u8,
+    last_entry: *const u8,
+
+    is_truncated: bool,
+}
+
+impl<'a> EventLog<'a> {
+    pub(super) unsafe fn new(
+        location: *const u8,
+        last_entry: *const u8,
+        is_truncated: bool,
+    ) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            location,
+            last_entry,
+            is_truncated,
+        }
+    }
+
+    /// Iterator of events in the log.
+    #[must_use]
+    pub fn iter(&self) -> EventLogIter {
+        EventLogIter {
+            log: self,
+            location: self.location,
+        }
+    }
+
+    /// If true, the event log is missing one or more entries because
+    /// additional events would have exceeded the space allocated for
+    /// the log.
+    ///
+    /// This value is not reported for the [`v1::Tcg`] protocol, so it
+    /// is always `false` in that case.
+    ///
+    /// [`v1::Tcg`]: Tcg
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        self.is_truncated
+    }
+}
+
+/// Iterator for events in [`EventLog`].
+pub struct EventLogIter<'a> {
+    log: &'a EventLog<'a>,
+    location: *const u8,
+}
+
+impl<'a> Iterator for EventLogIter<'a> {
+    type Item = &'a PcrEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // The spec says that `last_entry` will be null if there are no
+        // events. Presumably `location` will be null as well, but check
+        // both just to be safe.
+        if self.location.is_null() || self.log.last_entry.is_null() {
+            return None;
+        }
+
+        // Safety: we trust that the protocol has given us a valid range
+        // of memory to read from.
+        let event = unsafe { PcrEvent::from_ptr(self.location) };
+
+        // If this is the last entry, set the location to null so that
+        // future calls to `next()` return `None`.
+        if self.location == self.log.last_entry {
+            self.location = ptr::null();
+        } else {
+            self.location = unsafe { self.location.add(mem::size_of_val(event)) };
+        }
+
+        Some(event)
+    }
+}
+
+/// Protocol for interacting with TPM 1.1 and 1.2 devices.
+///
+/// The corresponding C type is `EFI_TCG_PROTOCOL`.
+#[repr(C)]
+#[unsafe_guid("f541796d-a62e-4954-a775-9584f61b9cdd")]
+#[derive(Protocol)]
+pub struct Tcg {
+    status_check: unsafe extern "efiapi" fn(
+        this: *mut Tcg,
+        protocol_capability: *mut BootServiceCapability,
+        feature_flags: *mut u32,
+        event_log_location: *mut PhysicalAddress,
+        event_log_last_entry: *mut PhysicalAddress,
+    ) -> Status,
+
+    // TODO: fill these in and provide a public interface.
+    hash_all: unsafe extern "efiapi" fn() -> Status,
+    log_event: unsafe extern "efiapi" fn() -> Status,
+    pass_through_to_tpm: unsafe extern "efiapi" fn() -> Status,
+    hash_log_extend_event: unsafe extern "efiapi" fn() -> Status,
+}
+
+/// Return type of [`Tcg::status_check`].
+pub struct StatusCheck<'a> {
+    /// Information about the protocol and the TPM device.
+    pub protocol_capability: BootServiceCapability,
+
+    /// Feature flags. The spec does not define any feature flags, so
+    /// this is always expected to be zero.
+    pub feature_flags: u32,
+
+    /// TPM event log.
+    pub event_log: EventLog<'a>,
+}
+
+impl Tcg {
+    /// Get information about the protocol and TPM device, as well as
+    /// the TPM event log.
+    pub fn status_check(&mut self) -> Result<StatusCheck> {
+        let mut protocol_capability = BootServiceCapability::default();
+        let mut feature_flags = 0;
+        let mut event_log_location = 0;
+        let mut event_log_last_entry = 0;
+
+        let status = unsafe {
+            (self.status_check)(
+                self,
+                &mut protocol_capability,
+                &mut feature_flags,
+                &mut event_log_location,
+                &mut event_log_last_entry,
+            )
+        };
+
+        if status.is_success() {
+            // The truncated field is just there for the v2 protocol;
+            // always set it to false for v1.
+            let truncated = false;
+            let event_log = unsafe {
+                EventLog::new(
+                    event_log_location as *const u8,
+                    event_log_last_entry as *const u8,
+                    truncated,
+                )
+            };
+
+            Ok(StatusCheck {
+                protocol_capability,
+                feature_flags,
+                event_log,
+            })
+        } else {
+            Err(status.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_log_v1() {
+        // This data comes from dumping the TPM event log in a VM
+        // (truncated to just two entries).
+        #[rustfmt::skip]
+        let bytes = [
+            // Event 1
+            // PCR index
+            0x00, 0x00, 0x00, 0x00,
+            // Event type
+            0x08, 0x00, 0x00, 0x00,
+            // SHA1 digest
+            0x14, 0x89, 0xf9, 0x23, 0xc4, 0xdc, 0xa7, 0x29, 0x17, 0x8b,
+            0x3e, 0x32, 0x33, 0x45, 0x85, 0x50, 0xd8, 0xdd, 0xdf, 0x29,
+            // Event data size
+            0x02, 0x00, 0x00, 0x00,
+            // Event data
+            0x00, 0x00,
+
+            // Event 2
+            // PCR index
+            0x00, 0x00, 0x00, 0x00,
+            // Event type
+            0x08, 0x00, 0x00, 0x80,
+            // SHA1 digest
+            0xc7, 0x06, 0xe7, 0xdd, 0x36, 0x39, 0x29, 0x84, 0xeb, 0x06,
+            0xaa, 0xa0, 0x8f, 0xf3, 0x36, 0x84, 0x40, 0x77, 0xb3, 0xed,
+            // Event data size
+            0x10, 0x00, 0x00, 0x00,
+            // Event data
+            0x00, 0x00, 0x82, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let log = unsafe { EventLog::new(bytes.as_ptr(), bytes.as_ptr().add(34), false) };
+        let mut iter = log.iter();
+
+        // Entry 1
+        let entry = iter.next().unwrap();
+        assert_eq!(entry.pcr_index(), PcrIndex(0));
+        assert_eq!(entry.event_type(), EventType::CRTM_VERSION);
+        #[rustfmt::skip]
+        assert_eq!(
+            entry.digest(),
+            [
+                0x14, 0x89, 0xf9, 0x23, 0xc4, 0xdc, 0xa7, 0x29, 0x17, 0x8b,
+                0x3e, 0x32, 0x33, 0x45, 0x85, 0x50, 0xd8, 0xdd, 0xdf, 0x29,
+            ]
+        );
+        assert_eq!(entry.event_data(), [0x00, 0x00]);
+
+        // Entry 2
+        let entry = iter.next().unwrap();
+        assert_eq!(entry.pcr_index(), PcrIndex(0));
+        assert_eq!(entry.event_type(), EventType::EFI_PLATFORM_FIRMWARE_BLOB);
+        #[rustfmt::skip]
+        assert_eq!(
+            entry.digest(),
+            [
+                0xc7, 0x06, 0xe7, 0xdd, 0x36, 0x39, 0x29, 0x84, 0xeb, 0x06,
+                0xaa, 0xa0, 0x8f, 0xf3, 0x36, 0x84, 0x40, 0x77, 0xb3, 0xed,
+            ]
+        );
+        #[rustfmt::skip]
+        assert_eq!(
+            entry.event_data(),
+            [
+                0x00, 0x00, 0x82, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ]
+        );
+    }
+}

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -1,0 +1,150 @@
+//! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
+//! Module) 2.0.
+//!
+//! This protocol is defined in the [TCG EFI Protocol Specification _TPM
+//! Family 2.0_][spec]. It is generally implemented only for TPM 2.0
+//! devices, but the spec indicates it can also be used for older TPM
+//! devices.
+//!
+//! [spec]: https://trustedcomputinggroup.org/resource/tcg-efi-protocol-specification/
+//! [TCG]: https://trustedcomputinggroup.org/
+//! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
+
+use super::HashAlgorithm;
+use crate::proto::Protocol;
+use crate::{unsafe_guid, Result, Status};
+use bitflags::bitflags;
+use core::mem;
+
+/// Version information.
+///
+/// Layout compatible with the C type `EFI_TG2_VERSION`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Version {
+    /// Major version.
+    pub major: u8,
+    /// Minor version.
+    pub minor: u8,
+}
+
+bitflags! {
+    /// Event log formats supported by the firmware.
+    ///
+    /// Corresponds to the C typedef `EFI_TCG2_EVENT_ALGORITHM_BITMAP`.
+    #[derive(Default)]
+    #[repr(transparent)]
+    pub struct EventLogFormat: u32 {
+        /// Firmware supports the SHA-1 log format.
+        const TCG_1_2 = 0x0000_0001;
+
+        /// Firmware supports the crypto-agile log format.
+        const TCG_2 = 0x0000_0002;
+    }
+}
+
+/// Information about the protocol and the TPM device.
+///
+/// Layout compatible with the C type `EFI_TCG2_BOOT_SERVICE_CAPABILITY`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BootServiceCapability {
+    size: u8,
+
+    /// Version of the EFI TCG2 protocol.
+    pub structure_version: Version,
+
+    /// Version of the EFI TCG2 protocol.
+    pub protocol_version: Version,
+
+    /// Bitmap of supported hash algorithms.
+    pub hash_algorithm_bitmap: HashAlgorithm,
+
+    /// Event log formats supported by the firmware.
+    pub supported_event_logs: EventLogFormat,
+
+    present_flag: u8,
+
+    /// Maximum size (in bytes) of a command that can be sent to the TPM.
+    pub max_command_size: u16,
+
+    /// Maximum size (in bytes) of a response that can be provided by the TPM.
+    pub max_response_size: u16,
+
+    /// Manufacturer ID.
+    ///
+    /// See the [TCG Vendor ID registry].
+    ///
+    /// [TCG Vendor ID registry]: https://trustedcomputinggroup.org/resource/vendor-id-registry/
+    pub manufacturer_id: u32,
+
+    /// Maximum number of supported PCR banks (hashing algorithms).
+    pub number_of_pcr_banks: u32,
+
+    /// Bitmap of currently-active PCR banks (hashing algorithms). This
+    /// is a subset of the supported algorithms in [`hash_algorithm_bitmap`].
+    ///
+    /// [`hash_algorithm_bitmap`]: Self::hash_algorithm_bitmap
+    pub active_pcr_banks: HashAlgorithm,
+}
+
+impl Default for BootServiceCapability {
+    fn default() -> Self {
+        // OK to unwrap, the size is less than u8.
+        let struct_size = u8::try_from(mem::size_of::<BootServiceCapability>()).unwrap();
+
+        Self {
+            size: struct_size,
+            structure_version: Version::default(),
+            protocol_version: Version::default(),
+            hash_algorithm_bitmap: HashAlgorithm::default(),
+            supported_event_logs: EventLogFormat::default(),
+            present_flag: 0,
+            max_command_size: 0,
+            max_response_size: 0,
+            manufacturer_id: 0,
+            number_of_pcr_banks: 0,
+            active_pcr_banks: HashAlgorithm::default(),
+        }
+    }
+}
+
+impl BootServiceCapability {
+    /// Whether the TPM device is present.
+    #[must_use]
+    pub fn tpm_present(&self) -> bool {
+        self.present_flag != 0
+    }
+}
+
+/// Protocol for interacting with TPM devices.
+///
+/// This protocol can be used for interacting with older TPM 1.1/1.2
+/// devices, but most firmware only uses it for TPM 2.0.
+///
+/// The corresponding C type is `EFI_TCG2_PROTOCOL`.
+#[repr(C)]
+#[unsafe_guid("607f766c-7455-42be-930b-e4d76db2720f")]
+#[derive(Protocol)]
+pub struct Tcg {
+    get_capability: unsafe extern "efiapi" fn(
+        this: *mut Tcg,
+        protocol_capability: *mut BootServiceCapability,
+    ) -> Status,
+
+    // TODO: fill these in and provide a public interface.
+    get_event_log: unsafe extern "efiapi" fn() -> Status,
+    hash_log_extend_event: unsafe extern "efiapi" fn() -> Status,
+    submit_command: unsafe extern "efiapi" fn() -> Status,
+    get_active_pcr_banks: unsafe extern "efiapi" fn() -> Status,
+    set_active_pcr_banks: unsafe extern "efiapi" fn() -> Status,
+    get_result_of_set_active_pcr_banks: unsafe extern "efiapi" fn() -> Status,
+}
+
+impl Tcg {
+    /// Get information about the protocol and TPM device.
+    pub fn get_capability(&mut self) -> Result<BootServiceCapability> {
+        let mut capability = BootServiceCapability::default();
+        unsafe { (self.get_capability)(self, &mut capability).into_with_val(|| capability) }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ mod opt;
 mod pipe;
 mod platform;
 mod qemu;
+mod tpm;
 mod util;
 
 use crate::opt::TestOpt;

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -1,7 +1,13 @@
 use crate::arch::UefiArch;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::ops::Deref;
 use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, PartialEq, ValueEnum)]
+pub enum TpmVersion {
+    V1,
+    V2,
+}
 
 // Define some common options so that the doc strings don't have to be
 // copy-pasted.
@@ -134,6 +140,10 @@ pub struct QemuOpt {
     /// Run QEMU without a GUI.
     #[clap(long, action)]
     pub headless: bool,
+
+    /// Attach a software TPM to QEMU.
+    #[clap(long, action)]
+    pub tpm: Option<TpmVersion>,
 
     /// Path of an OVMF code file.
     #[clap(long, action)]

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -2,6 +2,7 @@ use crate::arch::UefiArch;
 use crate::disk::{check_mbr_test_disk, create_mbr_test_disk};
 use crate::opt::QemuOpt;
 use crate::pipe::Pipe;
+use crate::tpm::Swtpm;
 use crate::util::command_to_string;
 use crate::{net, platform};
 use anyhow::{bail, Context, Result};
@@ -535,6 +536,15 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
             "user,model=e1000,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",
         ]);
         Some(net::EchoService::start())
+    } else {
+        None
+    };
+
+    // Set up a software TPM if requested.
+    let _tpm = if let Some(tpm_version) = opt.tpm {
+        let tpm = Swtpm::spawn(tpm_version)?;
+        cmd.args(tpm.qemu_args());
+        Some(tpm)
     } else {
         None
     };

--- a/xtask/src/tpm.rs
+++ b/xtask/src/tpm.rs
@@ -23,7 +23,7 @@ impl Swtpm {
         let tmp_path = tmp_dir.path().to_str().unwrap();
 
         let mut cmd = Command::new("swtpm");
-        cmd.args(&[
+        cmd.args([
             "socket",
             "--tpmstate",
             &format!("dir={tmp_path}"),

--- a/xtask/src/tpm.rs
+++ b/xtask/src/tpm.rs
@@ -1,0 +1,69 @@
+use crate::opt::TpmVersion;
+use crate::util::command_to_string;
+use anyhow::Result;
+use std::process::{Child, Command};
+use tempfile::TempDir;
+
+// Adapted from https://qemu.readthedocs.io/en/latest/specs/tpm.html
+
+/// Wrapper for running `swtpm`, a software TPM emulator.
+///
+/// <https://github.com/stefanberger/swtpm>
+///
+/// The process is killed on drop.
+pub struct Swtpm {
+    tmp_dir: TempDir,
+    child: Child,
+}
+
+impl Swtpm {
+    /// Run `swtpm` in a new process.
+    pub fn spawn(version: TpmVersion) -> Result<Self> {
+        let tmp_dir = TempDir::new()?;
+        let tmp_path = tmp_dir.path().to_str().unwrap();
+
+        let mut cmd = Command::new("swtpm");
+        cmd.args(&[
+            "socket",
+            "--tpmstate",
+            &format!("dir={tmp_path}"),
+            "--ctrl",
+            &format!("type=unixio,path={tmp_path}/swtpm-sock"),
+            // Terminate when the connection drops. If for any reason
+            // this fails, the process will be killed on drop.
+            "--terminate",
+            // Hide some log spam.
+            "--log",
+            "file=-",
+        ]);
+
+        if version == TpmVersion::V2 {
+            cmd.arg("--tpm2");
+        }
+
+        println!("{}", command_to_string(&cmd));
+        let child = cmd.spawn()?;
+
+        Ok(Self { tmp_dir, child })
+    }
+
+    /// Get the QEMU args needed to connect to the TPM emulator.
+    pub fn qemu_args(&self) -> Vec<String> {
+        let socket_path = self.tmp_dir.path().join("swtpm-sock");
+        vec![
+            "-chardev".into(),
+            format!("socket,id=chrtpm0,path={}", socket_path.to_str().unwrap()),
+            "-tpmdev".into(),
+            "emulator,id=tpm0,chardev=chrtpm0".into(),
+            "-device".into(),
+            "tpm-tis,tpmdev=tpm0".into(),
+        ]
+    }
+}
+
+impl Drop for Swtpm {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}


### PR DESCRIPTION
This adds basic support for TPM v1 and v2 devices. Currently you can just query some information from the protocols; I'll be adding support for more active operations like extending PCRs in a future PR, but I didn't want to put too much in one PR.

`uefi-test-runner/src/proto/tcg.rs` has a basic example of how to use the current functionality.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
