### PR TITLE
Shortened error documentation for all methods in `BootServices`

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -344,9 +344,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.AllocatePages()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.2 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.2 for more information on each
+    /// error type.
     ///
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
@@ -372,8 +371,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.FreePages()`.
     ///
-    /// See the function definition in the UEFI Specification, Chapter 7.2 for
-    /// more information on each error type.
+    /// See the UEFI Specification, Chapter 7.2 for more information on each error type.
     ///
     /// * [`uefi::Status::NOT_FOUND`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
@@ -429,9 +427,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.GetMemoryMap()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.2 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.2 for more information on each error
+    /// type.
     ///
     /// * [`uefi::Status::BUFFER_TOO_SMALL`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
@@ -483,9 +480,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.AllocatePool()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.2 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.2 for more information on each error type.
     ///
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
@@ -501,8 +496,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.FreePool()`.
     ///
-    /// See the function definition in the UEFI Specification, Chapter 7.2 for
-    /// more information on this error type.
+    /// See the UEFI Specification, Chapter 7.2 for more details.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     pub fn free_pool(&self, addr: *mut u8) -> Result {
@@ -530,9 +524,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.CreateEvent()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.1 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.1 for more information on each
+    /// error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
@@ -595,9 +588,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.CreateEventEx()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.1 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.1 for more information on each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
@@ -633,8 +624,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.SetTimer()`.
     ///
-    /// See the function definition in the UEFI Specification, Chapter 7.1 for more
-    /// information on this error type.
+    /// See the UEFI Specification, Chapter 7.1 for more details.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     pub fn set_timer(&self, event: &Event, trigger_time: TimerTrigger) -> Result {
@@ -679,9 +669,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.WaitForEvent()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.1 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.1 for more information on each
+    /// error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::UNSUPPORTED`]
@@ -718,7 +707,7 @@ impl BootServices {
     /// This function directly calls the UEFI function `EFI_BOOT_SERVICES.SignalEvent()`.
     ///
     /// Currently, (as of UEFI Spec v2.9) this only returns `EFI_SUCCESS`.
-    /// See the function definition in the UEFI Specification, Chapter 7.1 for more details.
+    /// See the UEFI Specification, Chapter 7.1 for more details.
     pub fn signal_event(&self, event: &Event) -> Result {
         // Safety: cloning this event should be safe, as we're directly passing it to firmware
         // and not keeping the clone around.
@@ -737,7 +726,7 @@ impl BootServices {
     /// at least for application based on EDK2 (such as OVMF), it may also return `EFI_INVALID_PARAMETER`.
     /// To be safe, ensure that error codes are handled properly.
     ///
-    /// See the function definition in the UEFI Specification, Chapter 7.1 for more details.
+    /// See the UEFI Specification, Chapter 7.1 for more details.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     pub fn close_event(&self, event: Event) -> Result {
@@ -756,7 +745,7 @@ impl BootServices {
     /// Note: Instead of returning the `EFI_NOT_READY` error from `EFI_BOOT_SERVICES.CheckEvent()`,
     /// as listed in the UEFI Specification, this function will return `false`.
     ///
-    /// See the function definition in the UEFI Specification, Chapter 7.1 for more details.
+    /// See the UEFI Specification, Chapter 7.1 for more details.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     pub fn check_event(&self, event: Event) -> Result<bool> {
@@ -950,8 +939,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.LocateDevicePath()`.
     ///
-    /// Some errors have multiple different causes. See the function definition in the UEFI
-    /// Specification, Chapter 7.3 for more information on possible causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information on each error type.
     ///
     /// * [`uefi::Status::NOT_FOUND`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
@@ -1252,9 +1240,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.OpenProtocol()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.3 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information on
+    /// each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::UNSUPPORTED`]
@@ -1298,9 +1285,8 @@ impl BootServices {
     /// This function returns errors from the UEFI function
     /// `EFI_BOOT_SERVICES.OpenProtocol()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.3 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more
+    /// information on each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::UNSUPPORTED`]
@@ -1332,9 +1318,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.OpenProtocol()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.3 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information
+    /// on each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::UNSUPPORTED`]
@@ -1362,9 +1347,8 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.ProtocolsPerHandle()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.3 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information on each
+    /// error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
@@ -1402,9 +1386,7 @@ impl BootServices {
     /// This function returns errors directly from the UEFI function
     /// `EFI_BOOT_SERVICES.LocateHandleBuffer()`.
     ///
-    /// Some errors have multiple different causes. See the function definition
-    /// in the UEFI Specification, Chapter 7.3 for more information on possible
-    /// causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information on each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::NOT_FOUND`]
@@ -1512,8 +1494,7 @@ impl BootServices {
     /// This function returns errors from the UEFI functions `EFI_BOOT_SERVICES.OpenProtocol()`
     /// and `EFI_BOOT_SERVICES.LocateDevicePath()`.
     ///
-    /// Some errors have multiple different causes. See the function definitions in the UEFI
-    /// Specification, Chapter 7.3 for more information on possible causes for each error type.
+    /// See the UEFI Specification, Chapter 7.3 for more information on each error type.
     ///
     /// * [`uefi::Status::INVALID_PARAMETER`]
     /// * [`uefi::Status::UNSUPPORTED`]


### PR DESCRIPTION
I'm feeling like I made parts of the documentation more verbose than necessary. :P

This commit cuts back on words that I felt were unnecessary for the documentation. I like this shortened version better, but please let me know if you think the previous version was better.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
