### PR TITLE
Implement `Error` and `Display` traits for `FromStrError`

### DIFF
--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -15,6 +15,22 @@ pub enum FromStrError {
     InteriorNul,
 }
 
+impl fmt::Display for FromStrError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "UCS-2 Conversion Error: {}",
+            match self {
+                Self::InvalidChar => "Invalid character",
+                Self::InteriorNul => "Interior null terminator",
+            }
+        )
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for FromStrError {}
+
 /// An owned UCS-2 null-terminated string.
 ///
 /// For convenience, a [CString16] is comparable with `&str` and `String` from the standard library


### PR DESCRIPTION
For issue #594.

I implemented the `Error` trait in the same way that it's implemented for `uefi::Error`.

I'm not sure where the `Error` trait is useful, so I haven't tested it beyond running the unit/qemu tests. :P I'm curious, though, what can this be used for?

Please let me know if this looks like a good solution for #594 and I'll implement these traits for other error types, as well.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
