### PR TITLE
Editorconfig: switch to max line width of 80

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+max_line_length = 80
 
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
This commit changes the `max_line_width` to 80 in `.editorconfig`. This is not mandatory nor enforced. However, 80 is also the default for commit messages and some editors guide users to follow this rule. For example, my CLion IDE automatically shows a line at width 80:

![image](https://user-images.githubusercontent.com/5737016/209542055-58c822f6-b9a6-44f5-b6b3-327efc48950d.png)

I think that a line-width of 80 is more suited than 100 from personal experience. However, I also used 100 as default for a long time.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)


PS: @nicholasbishop @GabrielMajeri : Merry Christmas!