### PR TITLE
uefi-services: Drop use of unstable `alloc_error_handler` feature

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-08-25"
+channel = "nightly-2022-12-18"
 components = ["rust-src"]

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -27,7 +27,6 @@
 //! [`exit_boot_services`]: uefi::table::SystemTable::exit_boot_services
 
 #![no_std]
-#![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
 #![deny(clippy::must_use_candidate)]
 
@@ -255,12 +254,4 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             }
         }
     }
-}
-
-#[alloc_error_handler]
-fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!(
-        "Ran out of free memory while trying to allocate {:#?}",
-        layout
-    );
 }


### PR DESCRIPTION
As of 2022-12-18, we can rely on the `default_alloc_error_handler` feature which was stabilized in https://github.com/rust-lang/rust/pull/102318. The behavior of the default handler is to panic, essentially the same as our current custom one.

This needs an MSRV bump, so we can expect to merge this around March 18.

https://github.com/rust-osdev/uefi-rs/issues/452

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
