### PR TITLE
Expose MemoryMapIter in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - `UnalignedSlice` now implements `Clone`, and the `Debug` impl now
   prints the elements instead of the internal fields.
 - The unstable `negative_impls` feature is no longer required to use this library.
+- `BootServices::memory_map` and `SystemTable::exit_boot_services` now return `MemoryMapIter`
+  instead of generic `ExactSizeIterator<Item = &'a MemoryDescriptor> + Clone`.
 
 ### Removed
 

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -426,7 +426,7 @@ impl BootServices {
         buffer: &'buf mut [u8],
     ) -> Result<(
         MemoryMapKey,
-        impl ExactSizeIterator<Item = &'buf MemoryDescriptor> + Clone,
+        MemoryMapIter<'buf>
     )> {
         let mut map_size = buffer.len();
         MemoryDescriptor::assert_aligned(buffer);
@@ -2079,7 +2079,7 @@ pub struct MemoryMapSize {
 
 /// An iterator of memory descriptors
 #[derive(Debug, Clone)]
-struct MemoryMapIter<'buf> {
+pub struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],
     entry_size: usize,
     index: usize,

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -7,7 +7,7 @@ use core::{ptr, slice};
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};
 
-use super::boot::{BootServices, MemoryDescriptor};
+use super::boot::{BootServices, MemoryDescriptor, MemoryMapIter};
 use super::runtime::RuntimeServices;
 use super::{cfg, Header, Revision};
 
@@ -184,7 +184,7 @@ impl SystemTable<Boot> {
         mmap_buf: &mut [u8],
     ) -> Result<(
         SystemTable<Runtime>,
-        impl ExactSizeIterator<Item = &MemoryDescriptor> + Clone,
+        MemoryMapIter,
     )> {
         unsafe {
             let boot_services = self.boot_services();


### PR DESCRIPTION
There's no reason to keep it private. Also using generic type here makes it hard to transfer ownership since it's impossible to use Box<T> without a heap allocator. It makes implementing frame allocator much harder.

Fixes #616

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
