### PR TITLE
Simplification: No longer return "impl Iterator"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   `impl Iterator` which simplifies usage.
 - `BootServices::exit_boot_services()` now returns `MemoryMapIter` instead of
   `impl Iterator` which simplifies usage.
+- `GraphicsOutput::modes()` now returns `ModesIter` instead of `impl Iterator`
+   which simplifies usage.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - `UnalignedSlice` now implements `Clone`, and the `Debug` impl now
   prints the elements instead of the internal fields.
 - The unstable `negative_impls` feature is no longer required to use this library.
+- `BootServices::memory_map()` now returns `MemoryMapIter` instead of
+  `impl Iterator` which simplifies usage.
+- `BootServices::exit_boot_services()` now returns `MemoryMapIter` instead of
+  `impl Iterator` which simplifies usage.
 
 ### Removed
 

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -109,7 +109,7 @@ impl<'boot> GraphicsOutput<'boot> {
 
     /// Returns information about all available graphics modes.
     #[must_use]
-    pub fn modes(&'_ self) -> impl ExactSizeIterator<Item = Mode> + '_ {
+    pub fn modes(&self) -> ModeIter {
         ModeIter {
             gop: self,
             current: 0,
@@ -437,8 +437,8 @@ impl ModeInfo {
     }
 }
 
-/// Iterator for graphics modes.
-struct ModeIter<'gop> {
+/// Iterator for [`Mode`]s of the [`GraphicsOutput`] protocol.
+pub struct ModeIter<'gop> {
     gop: &'gop GraphicsOutput<'gop>,
     current: u32,
     max: u32,

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -424,10 +424,7 @@ impl BootServices {
     pub fn memory_map<'buf>(
         &self,
         buffer: &'buf mut [u8],
-    ) -> Result<(
-        MemoryMapKey,
-        impl ExactSizeIterator<Item = &'buf MemoryDescriptor> + Clone,
-    )> {
+    ) -> Result<(MemoryMapKey, MemoryMapIter<'buf>)> {
         let mut map_size = buffer.len();
         MemoryDescriptor::assert_aligned(buffer);
         let map_buffer = buffer.as_mut_ptr().cast::<MemoryDescriptor>();
@@ -2077,9 +2074,10 @@ pub struct MemoryMapSize {
     pub map_size: usize,
 }
 
-/// An iterator of memory descriptors
+/// An iterator of [`MemoryDescriptor`]. The underlying memory map is always
+/// associated with a unique [`MemoryMapKey`].
 #[derive(Debug, Clone)]
-struct MemoryMapIter<'buf> {
+pub struct MemoryMapIter<'buf> {
     buffer: &'buf [u8],
     entry_size: usize,
     index: usize,

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -2108,7 +2108,11 @@ impl<'buf> Iterator for MemoryMapIter<'buf> {
     }
 }
 
-impl ExactSizeIterator for MemoryMapIter<'_> {}
+impl ExactSizeIterator for MemoryMapIter<'_> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
 
 /// The type of handle search to perform.
 #[derive(Debug, Copy, Clone)]

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -7,7 +7,7 @@ use core::{ptr, slice};
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle, Result, ResultExt, Status};
 
-use super::boot::{BootServices, MemoryDescriptor};
+use super::boot::{BootServices, MemoryDescriptor, MemoryMapIter};
 use super::runtime::RuntimeServices;
 use super::{cfg, Header, Revision};
 
@@ -182,10 +182,7 @@ impl SystemTable<Boot> {
         self,
         image: Handle,
         mmap_buf: &mut [u8],
-    ) -> Result<(
-        SystemTable<Runtime>,
-        impl ExactSizeIterator<Item = &MemoryDescriptor> + Clone,
-    )> {
+    ) -> Result<(SystemTable<Runtime>, MemoryMapIter<'_>)> {
         unsafe {
             let boot_services = self.boot_services();
 


### PR DESCRIPTION
This commit addresses #616 and replaces three occurrences of `impl Iterator` with a specific type. I do not see a benefit in the `impl Iterator` design pattern in our code base. Using a specific, public type is simpler for end-users, as discussed in #616.

`impl Something` only makes sense, I think, in use-cases where users specify code, such as in [`actix-web`](https://actix.rs/):

```
async fn greet(req: HttpRequest) -> impl Responder {
    let name = req.match_info().get("name").unwrap_or("World");
    format!("Hello {}!", &name)
}
``` 

Or in situations where the return type is complex and nested with many generics.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
