### PR TITLE
uefi: bug fix found by clippy

### DIFF
--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -164,7 +164,7 @@ pub trait File: Sized {
     /// * [`uefi::Status::BAD_BUFFER_SIZE`]
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
         let info_ptr = (info as *const Info).cast::<c_void>();
-        let info_size = mem::size_of_val(&info);
+        let info_size = mem::size_of_val(info);
         unsafe { (self.imp().set_info)(self.imp(), &Info::GUID, info_size, info_ptr).into() }
     }
 


### PR DESCRIPTION
Clippy found this bug. Apparently, we do not have an integration test for it. We obtained the size of a reference, not of the data structure itself.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
