### PR TITLE
uefi: Add `ptr_meta` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   `impl Iterator` which simplifies usage.
 - `GraphicsOutput::modes()` now returns `ModesIter` instead of `impl Iterator`
    which simplifies usage.
+- Use of the unstable `ptr_metadata` feature has been replaced with a dependency
+  on the [`ptr_meta`](https://docs.rs/ptr_meta) crate.
 
 ### Removed
 

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -25,6 +25,7 @@ unstable = []
 [dependencies]
 bitflags = "1.3.1"
 log = { version = "0.4.5", default-features = false }
+ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"
 uefi-macros = "0.9.0"
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -60,7 +60,6 @@
 
 #![feature(abi_efiapi)]
 #![feature(maybe_uninit_slice)]
-#![feature(ptr_metadata)]
 #![cfg_attr(feature = "alloc", feature(vec_into_raw_parts))]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -9,7 +9,6 @@ pub use uefi::proto::device_path::device_path_gen::build::*;
 
 use crate::proto::device_path::{DevicePath, DevicePathNode};
 use core::mem::MaybeUninit;
-use core::ptr;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -139,7 +138,7 @@ impl<'a> DevicePathBuilder<'a> {
         };
 
         let ptr: *const () = data.as_ptr().cast();
-        Ok(unsafe { &*ptr::from_raw_parts(ptr, data.len()) })
+        Ok(unsafe { &*ptr_meta::from_raw_parts(ptr, data.len()) })
     }
 }
 

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -14,8 +14,9 @@ use crate::table::boot::MemoryType;
 use crate::{guid, Guid};
 use bitflags::bitflags;
 use core::mem::{size_of, size_of_val};
-use core::ptr::{self, addr_of};
+use core::ptr::addr_of;
 use core::{fmt, slice};
+use ptr_meta::{Pointee, PtrExt};
 /// Device path nodes for [`DeviceType::END`].
 pub mod end {
     use super::*;
@@ -215,6 +216,7 @@ pub mod hardware {
 
     /// Vendor-defined hardware device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Vendor {
         pub(super) header: DevicePathHeader,
         pub(super) vendor_guid: Guid,
@@ -241,7 +243,7 @@ pub mod hardware {
                 .field("vendor_guid", &{ self.vendor_guid })
                 .field("vendor_defined_data", {
                     let ptr = addr_of!(self.vendor_defined_data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -262,7 +264,7 @@ pub mod hardware {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Vendor = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Vendor = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -406,6 +408,7 @@ pub mod acpi {
 
     /// Expanded ACPI device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Expanded {
         pub(super) header: DevicePathHeader,
         pub(super) hid: u32,
@@ -488,13 +491,14 @@ pub mod acpi {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Expanded = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Expanded = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
 
     /// ADR ACPI device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Adr {
         pub(super) header: DevicePathHeader,
         pub(super) adr: [u32],
@@ -507,7 +511,7 @@ pub mod acpi {
         #[must_use]
         pub fn adr(&self) -> UnalignedSlice<u32> {
             let ptr: *const [u32] = addr_of!(self.adr);
-            let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
+            let (ptr, len): (*const (), usize) = PtrExt::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u32>(), len) }
         }
     }
@@ -517,7 +521,7 @@ pub mod acpi {
             f.debug_struct("Adr")
                 .field("adr", {
                     let ptr = addr_of!(self.adr);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u32>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -538,7 +542,7 @@ pub mod acpi {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Adr = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Adr = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -1026,6 +1030,7 @@ pub mod messaging {
 
     /// USB World Wide ID (WWID) messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct UsbWwid {
         pub(super) header: DevicePathHeader,
         pub(super) interface_number: u16,
@@ -1057,7 +1062,7 @@ pub mod messaging {
         #[must_use]
         pub fn serial_number(&self) -> UnalignedSlice<u16> {
             let ptr: *const [u16] = addr_of!(self.serial_number);
-            let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
+            let (ptr, len): (*const (), usize) = PtrExt::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u16>(), len) }
         }
     }
@@ -1070,7 +1075,7 @@ pub mod messaging {
                 .field("device_product_id", &{ self.device_product_id })
                 .field("serial_number", {
                     let ptr = addr_of!(self.serial_number);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u16>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -1091,7 +1096,7 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const UsbWwid = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const UsbWwid = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -1639,6 +1644,7 @@ pub mod messaging {
 
     /// Vendor-defined messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Vendor {
         pub(super) header: DevicePathHeader,
         pub(super) vendor_guid: Guid,
@@ -1665,7 +1671,7 @@ pub mod messaging {
                 .field("vendor_guid", &{ self.vendor_guid })
                 .field("vendor_defined_data", {
                     let ptr = addr_of!(self.vendor_defined_data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -1686,7 +1692,7 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Vendor = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Vendor = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -1753,6 +1759,7 @@ pub mod messaging {
 
     /// iSCSI messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Iscsi {
         pub(super) header: DevicePathHeader,
         pub(super) protocol: crate::proto::device_path::messaging::IscsiProtocol,
@@ -1808,7 +1815,7 @@ pub mod messaging {
                 .field("target_portal_group_tag", &{ self.target_portal_group_tag })
                 .field("iscsi_target_name", {
                     let ptr = addr_of!(self.iscsi_target_name);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -1829,7 +1836,7 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Iscsi = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Iscsi = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -1884,6 +1891,7 @@ pub mod messaging {
 
     /// Uniform Resource Identifier (URI) messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Uri {
         pub(super) header: DevicePathHeader,
         pub(super) value: [u8],
@@ -1902,7 +1910,7 @@ pub mod messaging {
             f.debug_struct("Uri")
                 .field("value", {
                     let ptr = addr_of!(self.value);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -1923,7 +1931,7 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Uri = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Uri = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -2162,6 +2170,7 @@ pub mod messaging {
 
     /// DNS messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Dns {
         pub(super) header: DevicePathHeader,
         pub(super) address_type: crate::proto::device_path::messaging::DnsAddressType,
@@ -2179,7 +2188,7 @@ pub mod messaging {
         #[must_use]
         pub fn addresses(&self) -> UnalignedSlice<IpAddress> {
             let ptr: *const [IpAddress] = addr_of!(self.addresses);
-            let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
+            let (ptr, len): (*const (), usize) = PtrExt::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<IpAddress>(), len) }
         }
     }
@@ -2190,7 +2199,7 @@ pub mod messaging {
                 .field("address_type", &{ self.address_type })
                 .field("addresses", {
                     let ptr = addr_of!(self.addresses);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<IpAddress>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2211,7 +2220,7 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Dns = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Dns = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -2254,6 +2263,7 @@ pub mod messaging {
 
     /// REST service messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct RestService {
         pub(super) header: DevicePathHeader,
         pub(super) service_type: crate::proto::device_path::messaging::RestServiceType,
@@ -2282,7 +2292,7 @@ pub mod messaging {
                 .field("access_mode", &{ self.access_mode })
                 .field("vendor_guid_and_data", {
                     let ptr = addr_of!(self.vendor_guid_and_data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2303,13 +2313,15 @@ pub mod messaging {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const RestService = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const RestService =
+                ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
 
     /// NVME over Fabric (NVMe-oF) namespace messaging device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct NvmeOfNamespace {
         pub(super) header: DevicePathHeader,
         pub(super) nidt: u8,
@@ -2345,7 +2357,7 @@ pub mod messaging {
                 .field("nid", &{ self.nid })
                 .field("subsystem_nqn", {
                     let ptr = addr_of!(self.subsystem_nqn);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2367,7 +2379,7 @@ pub mod messaging {
 
             let node: *const DevicePathNode = node;
             let node: *const NvmeOfNamespace =
-                ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+                ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -2566,6 +2578,7 @@ pub mod media {
 
     /// Vendor-defined media device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct Vendor {
         pub(super) header: DevicePathHeader,
         pub(super) vendor_guid: Guid,
@@ -2592,7 +2605,7 @@ pub mod media {
                 .field("vendor_guid", &{ self.vendor_guid })
                 .field("vendor_defined_data", {
                     let ptr = addr_of!(self.vendor_defined_data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2613,13 +2626,14 @@ pub mod media {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const Vendor = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const Vendor = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
 
     /// File path media device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct FilePath {
         pub(super) header: DevicePathHeader,
         pub(super) path_name: [u16],
@@ -2630,7 +2644,7 @@ pub mod media {
         #[must_use]
         pub fn path_name(&self) -> UnalignedSlice<u16> {
             let ptr: *const [u16] = addr_of!(self.path_name);
-            let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
+            let (ptr, len): (*const (), usize) = PtrExt::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u16>(), len) }
         }
     }
@@ -2640,7 +2654,7 @@ pub mod media {
             f.debug_struct("FilePath")
                 .field("path_name", {
                     let ptr = addr_of!(self.path_name);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u16>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2661,7 +2675,7 @@ pub mod media {
             }
 
             let node: *const DevicePathNode = node;
-            let node: *const FilePath = ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+            let node: *const FilePath = ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -2704,6 +2718,7 @@ pub mod media {
 
     /// PIWG firmware file media device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct PiwgFirmwareFile {
         pub(super) header: DevicePathHeader,
         pub(super) data: [u8],
@@ -2722,7 +2737,7 @@ pub mod media {
             f.debug_struct("PiwgFirmwareFile")
                 .field("data", {
                     let ptr = addr_of!(self.data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2744,13 +2759,14 @@ pub mod media {
 
             let node: *const DevicePathNode = node;
             let node: *const PiwgFirmwareFile =
-                ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+                ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
 
     /// PIWG firmware volume media device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct PiwgFirmwareVolume {
         pub(super) header: DevicePathHeader,
         pub(super) data: [u8],
@@ -2769,7 +2785,7 @@ pub mod media {
             f.debug_struct("PiwgFirmwareVolume")
                 .field("data", {
                     let ptr = addr_of!(self.data);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -2791,7 +2807,7 @@ pub mod media {
 
             let node: *const DevicePathNode = node;
             let node: *const PiwgFirmwareVolume =
-                ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+                ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }
@@ -2955,6 +2971,7 @@ pub mod bios_boot_spec {
     use super::*;
     /// BIOS Boot Specification device path node.
     #[repr(C, packed)]
+    #[derive(Pointee)]
     pub struct BootSpecification {
         pub(super) header: DevicePathHeader,
         pub(super) device_type: u16,
@@ -2990,7 +3007,7 @@ pub mod bios_boot_spec {
                 .field("status_flag", &{ self.status_flag })
                 .field("description_string", {
                     let ptr = addr_of!(self.description_string);
-                    let (ptr, len) = ptr.to_raw_parts();
+                    let (ptr, len) = PtrExt::to_raw_parts(ptr);
                     let byte_len = size_of::<u8>() * len;
                     unsafe { &slice::from_raw_parts(ptr.cast::<u8>(), byte_len) }
                 })
@@ -3012,7 +3029,7 @@ pub mod bios_boot_spec {
 
             let node: *const DevicePathNode = node;
             let node: *const BootSpecification =
-                ptr::from_raw_parts(node.cast(), dst_size / elem_size);
+                ptr_meta::from_raw_parts(node.cast(), dst_size / elem_size);
             Ok(unsafe { &*node })
         }
     }

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -15,6 +15,7 @@ use crate::{Result, Status};
 use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::{mem, ptr};
+use ptr_meta::Pointee;
 
 /// 20-byte SHA-1 digest.
 pub type Sha1Digest = [u8; 20];
@@ -96,6 +97,7 @@ pub struct Version {
 /// field. These two are independent; although the event data _can_ be
 /// what is hashed in the digest field, it doesn't have to be.
 #[repr(C, packed)]
+#[derive(Pointee)]
 pub struct PcrEvent {
     pcr_index: PcrIndex,
     event_type: EventType,
@@ -110,7 +112,7 @@ impl PcrEvent {
         let ptr_u32: *const u32 = ptr.cast();
         let event_size = ptr_u32.add(7).read_unaligned();
         let event_size = usize_from_u32(event_size);
-        unsafe { &*ptr::from_raw_parts(ptr.cast(), event_size) }
+        unsafe { &*ptr_meta::from_raw_parts(ptr.cast(), event_size) }
     }
 
     /// PCR index for the event.

--- a/xtask/src/device_path/field.rs
+++ b/xtask/src/device_path/field.rs
@@ -253,7 +253,7 @@ impl NodeField {
                 ret_type = quote!(UnalignedSlice<#slice_elem>);
                 ret_val = quote!(
                     let ptr: *const [#slice_elem] = addr_of!(self.#field_name);
-                    let (ptr, len): (*const (), usize) = ptr.to_raw_parts();
+                    let (ptr, len): (*const (), usize) = PtrExt::to_raw_parts(ptr);
                     unsafe {
                         UnalignedSlice::new(ptr.cast::<#slice_elem>(), len)
                     }

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -30,8 +30,9 @@ fn gen_code_as_string(groups: &[NodeGroup]) -> Result<String> {
         use crate::proto::network::IpAddress;
         use crate::table::boot::MemoryType;
         use core::mem::{size_of, size_of_val};
-        use core::ptr::{self, addr_of};
+        use core::ptr::addr_of;
         use core::{fmt, slice};
+        use ptr_meta::{Pointee, PtrExt};
 
         #(#packed_modules)*
 


### PR DESCRIPTION
The `ptr_meta` crate (https://docs.rs/ptr_meta) is a polyfill for the unstable [`ptr_metadata`](https://github.com/rust-lang/rust/issues/81513) feature on stable Rust. This allows us to drop use of an unstable feature with fairly minimal code changes; mostly just adding a derive for the `Pointee` type on some DST structs.

https://github.com/rust-osdev/uefi-rs/issues/452

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
