### PR TITLE
Drop unstable `maybe_uninit_slice` and `vec_into_raw_parts` features

### DIFF
--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -3,6 +3,7 @@ use super::strs::{CStr16, FromSliceWithNulError};
 use crate::alloc::vec::Vec;
 use crate::data_types::strs::EqStrUntilNul;
 use crate::data_types::UnalignedSlice;
+use crate::polyfill::vec_into_raw_parts;
 use core::fmt;
 use core::ops;
 
@@ -92,7 +93,7 @@ impl TryFrom<Vec<u16>> for CString16 {
         // Safety: `Char16` is a transparent struct wrapping `u16`, so
         // the types are compatible. The pattern used here matches the
         // example in the docs for `into_raw_parts`.
-        let (ptr, len, cap) = input.into_raw_parts();
+        let (ptr, len, cap) = vec_into_raw_parts(input);
         let rebuilt = unsafe {
             let ptr = ptr.cast::<Char16>();
             Vec::from_raw_parts(ptr, len, cap)

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -1,5 +1,6 @@
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
 use super::UnalignedSlice;
+use crate::polyfill::maybe_uninit_slice_assume_init_ref;
 use core::ffi::CStr;
 use core::fmt;
 use core::iter::Iterator;
@@ -300,7 +301,7 @@ impl CStr16 {
         src.copy_to_maybe_uninit(buf);
         let buf = unsafe {
             // Safety: `copy_buf` fully initializes the slice.
-            MaybeUninit::slice_assume_init_ref(buf)
+            maybe_uninit_slice_assume_init_ref(buf)
         };
         CStr16::from_u16_with_nul(buf).map_err(|e| match e {
             FromSliceWithNulError::InvalidChar(v) => UnalignedCStr16Error::InvalidChar(v),

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -59,8 +59,6 @@
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
 #![feature(abi_efiapi)]
-#![feature(maybe_uninit_slice)]
-#![cfg_attr(feature = "alloc", feature(vec_into_raw_parts))]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -105,3 +103,5 @@ pub mod logger;
 // As long as this is behind "alloc", we can simplify cfg-feature attributes in this module.
 #[cfg(feature = "alloc")]
 pub(crate) mod mem;
+
+pub(crate) mod polyfill;

--- a/uefi/src/polyfill.rs
+++ b/uefi/src/polyfill.rs
@@ -1,0 +1,29 @@
+//! Polyfills for functions in the standard library that are currently gated
+//! behind unstable features.
+
+use core::mem::MaybeUninit;
+#[cfg(feature = "alloc")]
+use {alloc::vec::Vec, core::mem::ManuallyDrop};
+
+/// Polyfill for the unstable `MaybeUninit::slice_assume_init_ref` function.
+///
+/// See <https://github.com/rust-lang/rust/issues/63569>.
+pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(s: &[MaybeUninit<T>]) -> &[T] {
+    unsafe { &*(s as *const [MaybeUninit<T>] as *const [T]) }
+}
+
+/// Polyfill for the unstable `MaybeUninit::slice_as_mut_ptr` function.
+///
+/// See <https://github.com/rust-lang/rust/issues/63569>.
+pub fn maybe_uninit_slice_as_mut_ptr<T>(s: &mut [MaybeUninit<T>]) -> *mut T {
+    s.as_mut_ptr().cast::<T>()
+}
+
+/// Polyfill for the unstable `Vec::into_raw_parts` function.
+///
+/// See <https://github.com/rust-lang/rust/issues/65816>.
+#[cfg(feature = "alloc")]
+pub fn vec_into_raw_parts<T>(v: Vec<T>) -> (*mut T, usize, usize) {
+    let mut v = ManuallyDrop::new(v);
+    (v.as_mut_ptr(), v.len(), v.capacity())
+}

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -7,6 +7,7 @@
 
 pub use uefi::proto::device_path::device_path_gen::build::*;
 
+use crate::polyfill::{maybe_uninit_slice_as_mut_ptr, maybe_uninit_slice_assume_init_ref};
 use crate::proto::device_path::{DevicePath, DevicePathNode};
 use core::mem::MaybeUninit;
 
@@ -131,7 +132,7 @@ impl<'a> DevicePathBuilder<'a> {
 
         let data: &[u8] = match &this.storage {
             BuilderStorage::Buf { buf, offset } => unsafe {
-                MaybeUninit::slice_assume_init_ref(&buf[..*offset])
+                maybe_uninit_slice_assume_init_ref(&buf[..*offset])
             },
             #[cfg(feature = "alloc")]
             BuilderStorage::Vec(vec) => vec,
@@ -206,7 +207,7 @@ unsafe impl BuildNode for &DevicePathNode {
     fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
         let src: *const u8 = self.as_ffi_ptr().cast();
 
-        let dst: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+        let dst: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
         unsafe {
             dst.copy_from_nonoverlapping(src, out.len());
         }

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -6,6 +6,7 @@
 // See `/xtask/src/device_path/README.md` for more details.
 
 use crate::data_types::UnalignedSlice;
+use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
 use crate::proto::device_path::{
     DevicePathHeader, DevicePathNode, DeviceSubType, DeviceType, NodeConversionError,
 };
@@ -3333,7 +3334,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3359,7 +3360,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3393,7 +3394,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3429,7 +3430,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3465,7 +3466,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3507,7 +3508,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3546,7 +3547,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3583,7 +3584,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3627,7 +3628,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3682,7 +3683,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3730,7 +3731,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3762,7 +3763,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3824,7 +3825,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3866,7 +3867,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3904,7 +3905,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3943,7 +3944,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -3981,7 +3982,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4016,7 +4017,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4059,7 +4060,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4105,7 +4106,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4152,7 +4153,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4192,7 +4193,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4240,7 +4241,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4275,7 +4276,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4326,7 +4327,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4401,7 +4402,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4461,7 +4462,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4503,7 +4504,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4557,7 +4558,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4604,7 +4605,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4649,7 +4650,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4706,7 +4707,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4761,7 +4762,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4797,7 +4798,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4831,7 +4832,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4867,7 +4868,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4899,7 +4900,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4931,7 +4932,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4963,7 +4964,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -4997,7 +4998,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5035,7 +5036,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5071,7 +5072,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5109,7 +5110,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5151,7 +5152,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5206,12 +5207,12 @@ pub mod build {
                             == crate::proto::device_path::messaging::RestServiceType::VENDOR
                     );
                     let (guid_out, data_out) = out.split_at_mut(size_of::<Guid>());
-                    let guid_out_ptr: *mut Guid = MaybeUninit::slice_as_mut_ptr(guid_out).cast();
+                    let guid_out_ptr: *mut Guid = maybe_uninit_slice_as_mut_ptr(guid_out).cast();
                     unsafe {
                         guid_out_ptr.write_unaligned(src.vendor_guid);
                     }
 
-                    let data_out_ptr = MaybeUninit::slice_as_mut_ptr(data_out);
+                    let data_out_ptr = maybe_uninit_slice_as_mut_ptr(data_out);
                     unsafe {
                         src.vendor_defined_data
                             .as_ptr()
@@ -5248,7 +5249,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5305,7 +5306,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5347,7 +5348,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5386,7 +5387,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5418,7 +5419,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5450,7 +5451,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5482,7 +5483,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5516,7 +5517,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5559,7 +5560,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()
@@ -5639,7 +5640,7 @@ pub mod build {
             fn write_data(&self, out: &mut [MaybeUninit<u8>]) {
                 let size = usize::from(self.size_in_bytes().unwrap());
                 assert_eq!(size, out.len());
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr
                         .cast::<DevicePathHeader>()

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -23,6 +23,7 @@ fn gen_code_as_string(groups: &[NodeGroup]) -> Result<String> {
         use bitflags::bitflags;
         use crate::data_types::UnalignedSlice;
         use crate::{guid, Guid};
+        use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
         use crate::proto::device_path::{
             DevicePathHeader, DevicePathNode, DeviceSubType, DeviceType,
             NodeConversionError,

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -429,7 +429,7 @@ impl Node {
                 // the length of `out` matches the node's size.
                 assert_eq!(size, out.len());
 
-                let out_ptr: *mut u8 = MaybeUninit::slice_as_mut_ptr(out);
+                let out_ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(out);
                 unsafe {
                     out_ptr.cast::<DevicePathHeader>().write_unaligned(DevicePathHeader {
                         device_type: DeviceType::#device_type,

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -973,12 +973,12 @@ mod messaging {
 
                 let (guid_out, data_out) = out.split_at_mut(size_of::<Guid>());
 
-                let guid_out_ptr: *mut Guid = MaybeUninit::slice_as_mut_ptr(guid_out).cast();
+                let guid_out_ptr: *mut Guid = maybe_uninit_slice_as_mut_ptr(guid_out).cast();
                 unsafe {
                     guid_out_ptr.write_unaligned(src.vendor_guid);
                 }
 
-                let data_out_ptr = MaybeUninit::slice_as_mut_ptr(data_out);
+                let data_out_ptr = maybe_uninit_slice_as_mut_ptr(data_out);
                 unsafe {
                     src.vendor_defined_data
                         .as_ptr()


### PR DESCRIPTION
The functionality we need from those features can be provided with a few pretty simple one-liner functions. Add those functions to the uefi crate in a new polyfill module.

https://github.com/rust-osdev/uefi-rs/issues/452

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
