### PR TITLE
uefi: Remove useless padding field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   on the [`ptr_meta`](https://docs.rs/ptr_meta) crate.
 - `pxe::DiscoverInfo` is now a DST. Create with `new_in_buffer` by supplying a
   `MaybeUninit<u8>` slice of appropriate length.
+- Redundant private field used for padding in `MemoryDescriptor` structure was removed. Now all
+  fields of this struct are public.
 
 ### Removed
 

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1979,8 +1979,6 @@ pub const MEMORY_DESCRIPTOR_VERSION: u32 = 1;
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
     pub ty: MemoryType,
-    /// Skip 4 bytes as UEFI declares items in structs should be naturally aligned
-    padding: u32,
     /// Starting physical address.
     pub phys_start: PhysicalAddress,
     /// Starting virtual address.
@@ -1995,7 +1993,6 @@ impl Default for MemoryDescriptor {
     fn default() -> MemoryDescriptor {
         MemoryDescriptor {
             ty: MemoryType::RESERVED,
-            padding: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,


### PR DESCRIPTION
Fixes #628

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
