### PR TITLE
PXE: Fix BaseCode::discover optional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
    which simplifies usage.
 - Use of the unstable `ptr_metadata` feature has been replaced with a dependency
   on the [`ptr_meta`](https://docs.rs/ptr_meta) crate.
+- `pxe::DiscoverInfo` is now generic over the number of Servers it specifies instead
+  of `[Server]` and `[Server; N]` (of which only the later is FFI safe).
+- `BaseCode::discover` is now generic over the number of Servers in `DiscoverInfo`,
+  but the source-level interface should remain compatible with existing correct code.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,8 @@
    which simplifies usage.
 - Use of the unstable `ptr_metadata` feature has been replaced with a dependency
   on the [`ptr_meta`](https://docs.rs/ptr_meta) crate.
-- `pxe::DiscoverInfo` is now generic over the number of Servers it specifies instead
-  of `[Server]` and `[Server; N]` (of which only the later is FFI safe).
-- `BaseCode::discover` is now generic over the number of Servers in `DiscoverInfo`,
-  but the source-level interface should remain compatible with existing correct code.
+- `pxe::DiscoverInfo` is now a DST. Create with `new_in_buffer` by supplying a
+  `MaybeUninit<u8>` slice of appropriate length.
 
 ### Removed
 


### PR DESCRIPTION
NOTE: This commit changes the API for `BaseCode::discover`, but should continue to be source-compatible. Edit: `DiscoverInfo` will break in cases where the generic can't be inferred, or where it's explicitly declared (eg, `DiscoverInfo<[Server; 4]>` needs to be changed to `DiscoverInfo<4>`).

The `info` parameter in `BaseCode::discover` is an optional pointer argument (it may be NULL), but is incorrectly specified in the Rust extern definition as `Option<*const T>`. This type is (at least) one byte larger than a Pointer on all platforms, making it incompatible with the Optional Pointers in EFI. Two possible fixes:

1. Remove `Option` wrapper (this is what the PR contains)
2. Convert to `Option<&T>` (chose not to use this since converting references requires unsafe)

The `DiscoverInfo` struct had odd bounds associated with it, and being generic over `T: ?Sized` doesn't make sense when the server list has to be a fixed size. This could be removed or broken out into a separate commit if needed.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
