### PR TITLE
Fix warnings from `abi_efiapi` stabilization

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_efiapi)]
+#![allow(stable_features)]
 
 use uefi::prelude::*;
 

--- a/uefi-macros/tests/ui/entry_bad_abi.rs
+++ b/uefi-macros/tests/ui/entry_bad_abi.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_abi.stderr
+++ b/uefi-macros/tests/ui/entry_bad_abi.stderr
@@ -1,5 +1,5 @@
 error: Entry method must have no ABI modifier
- --> tests/ui/entry_bad_abi.rs:9:1
+ --> tests/ui/entry_bad_abi.rs:8:1
   |
-9 | extern "C" fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+8 | extern "C" fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
   | ^^^^^^^^^^

--- a/uefi-macros/tests/ui/entry_bad_arg.rs
+++ b/uefi-macros/tests/ui/entry_bad_arg.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_arg.stderr
+++ b/uefi-macros/tests/ui/entry_bad_arg.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
- --> tests/ui/entry_bad_arg.rs:9:4
+ --> tests/ui/entry_bad_arg.rs:8:4
   |
-9 | fn main(_handle: Handle, _st: SystemTable<Boot>, _x: usize) -> Status {
+8 | fn main(_handle: Handle, _st: SystemTable<Boot>, _x: usize) -> Status {
   |    ^^^^ incorrect number of function parameters
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status`

--- a/uefi-macros/tests/ui/entry_bad_async.rs
+++ b/uefi-macros/tests/ui/entry_bad_async.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_async.stderr
+++ b/uefi-macros/tests/ui/entry_bad_async.stderr
@@ -1,5 +1,5 @@
 error: Entry method should not be async
- --> tests/ui/entry_bad_async.rs:9:1
+ --> tests/ui/entry_bad_async.rs:8:1
   |
-9 | async fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+8 | async fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
   | ^^^^^

--- a/uefi-macros/tests/ui/entry_bad_attr_arg.rs
+++ b/uefi-macros/tests/ui/entry_bad_attr_arg.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_attr_arg.stderr
+++ b/uefi-macros/tests/ui/entry_bad_attr_arg.stderr
@@ -1,5 +1,5 @@
 error: Entry attribute accepts no arguments
- --> tests/ui/entry_bad_attr_arg.rs:8:9
+ --> tests/ui/entry_bad_attr_arg.rs:7:9
   |
-8 | #[entry(some_arg)]
+7 | #[entry(some_arg)]
   |         ^^^^^^^^

--- a/uefi-macros/tests/ui/entry_bad_const.rs
+++ b/uefi-macros/tests/ui/entry_bad_const.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_const.stderr
+++ b/uefi-macros/tests/ui/entry_bad_const.stderr
@@ -1,5 +1,5 @@
 error: Entry method should not be const
- --> tests/ui/entry_bad_const.rs:9:1
+ --> tests/ui/entry_bad_const.rs:8:1
   |
-9 | const fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+8 | const fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
   | ^^^^^

--- a/uefi-macros/tests/ui/entry_bad_generic.rs
+++ b/uefi-macros/tests/ui/entry_bad_generic.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_generic.stderr
+++ b/uefi-macros/tests/ui/entry_bad_generic.stderr
@@ -1,5 +1,5 @@
 error: Entry method should not be generic
- --> tests/ui/entry_bad_generic.rs:9:9
+ --> tests/ui/entry_bad_generic.rs:8:9
   |
-9 | fn main<T>(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+8 | fn main<T>(_handle: Handle, _st: SystemTable<Boot>) -> Status {
   |         ^

--- a/uefi-macros/tests/ui/entry_bad_return_type.rs
+++ b/uefi-macros/tests/ui/entry_bad_return_type.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/entry_bad_return_type.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
- --> tests/ui/entry_bad_return_type.rs:9:4
+ --> tests/ui/entry_bad_return_type.rs:8:4
   |
-9 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
+8 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
   |    ^^^^ expected struct `Status`, found `bool`
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> Status`

--- a/uefi-macros/tests/ui/entry_unnamed_image_arg.rs
+++ b/uefi-macros/tests/ui/entry_unnamed_image_arg.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
@@ -1,5 +1,5 @@
 error: Entry method's arguments must be named
- --> tests/ui/entry_unnamed_image_arg.rs:9:22
+ --> tests/ui/entry_unnamed_image_arg.rs:8:22
   |
-9 | fn unnamed_image_arg(_: Handle, _st: SystemTable<Boot>) -> Status {
+8 | fn unnamed_image_arg(_: Handle, _st: SystemTable<Boot>) -> Status {
   |                      ^^^^^^^^^

--- a/uefi-macros/tests/ui/entry_unnamed_table_arg.rs
+++ b/uefi-macros/tests/ui/entry_unnamed_table_arg.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 #![no_main]
-#![feature(abi_efiapi)]
 
 use uefi::prelude::*;
 use uefi_macros::entry;

--- a/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
@@ -1,5 +1,5 @@
 error: Entry method's arguments must be named
- --> tests/ui/entry_unnamed_table_arg.rs:9:38
+ --> tests/ui/entry_unnamed_table_arg.rs:8:38
   |
-9 | fn unnamed_table_arg(_image: Handle, _: SystemTable<Boot>) -> Status {
+8 | fn unnamed_table_arg(_image: Handle, _: SystemTable<Boot>) -> Status {
   |                                      ^^^^^^^^^^^^^^^^^^^^

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
 #![deny(clippy::must_use_candidate)]
+#![allow(stable_features)]
 
 extern crate log;
 // Core types.

--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -3,6 +3,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_efiapi)]
+#![allow(stable_features)]
 // ANCHOR_END: features
 
 // ANCHOR: use

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_efiapi)]
+#![allow(stable_features)]
 
 use log::info;
 use uefi::prelude::*;

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![no_std]
 #![feature(abi_efiapi)]
+#![allow(stable_features)]
 
 extern crate alloc;
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 #![feature(abi_efiapi)]
+#![allow(stable_features)]
 
 #[macro_use]
 extern crate log;

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -67,6 +67,7 @@
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
 #![deny(clippy::must_use_candidate)]
+#![allow(stable_features)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
The `abi_efiapi` feature has been stabilized, so in the very latest nightlies we get this warning from enabling it:

    the feature `abi_efiapi` has been stable since 1.68.0-nightly and no longer requires an attribute to enable

We don't want to stop using `#![feature(abi_efiapi)]` just yet though, because that would require raising our nightly MSRV to 2023-01-13. So for now, to get the CI passing again, turn off the `stable_features` warning.

In the `uefi-macros` tests, just remove `#![feature(abi_efiapi)]` since that code is only run when developing uefi-rs, not when using it.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
