### PR TITLE
Drop explicit enabling of `abi_efiapi` feature

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-08-25"
+channel = "nightly-2023-01-14"
 components = ["rust-src"]

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -41,9 +41,7 @@ This is some boilerplate that all Rust UEFI applications will
 need. `no_main` is needed because the UEFI application entry point is
 different from the standard Rust `main` function. `no_std` is needed to
 turn off the `std` library; the `core` and `alloc` crates can still be
-used. And `feature(abi_efiapi)` is needed because UEFI applications have
-a special calling convention that is not yet stabilized in the Rust
-compiler.
+used.
 
 Next up are some `use` lines. Nothing too exciting here; the
 `uefi::prelude` module is intended to be glob-imported, and exports a

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -1,7 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 use uefi::prelude::*;
 

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -222,7 +222,6 @@ fn get_function_arg_name(f: &ItemFn, arg_index: usize, errors: &mut TokenStream2
 /// ```no_run
 /// #![no_main]
 /// #![no_std]
-/// #![feature(abi_efiapi)]
 /// # // A bit of boilerplate needed to make the example compile in the
 /// # // context of `cargo test`.
 /// # #![feature(lang_items)]

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -28,9 +28,7 @@
 
 #![no_std]
 #![feature(alloc_error_handler)]
-#![feature(abi_efiapi)]
 #![deny(clippy::must_use_candidate)]
-#![allow(stable_features)]
 
 extern crate log;
 // Core types.

--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -2,8 +2,6 @@
 // ANCHOR: features
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 // ANCHOR_END: features
 
 // ANCHOR: use

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -1,8 +1,6 @@
 // ANCHOR: all
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 use log::info;
 use uefi::prelude::*;

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -1,8 +1,6 @@
 // ANCHOR: all
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 extern crate alloc;
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 #[macro_use]
 extern crate log;

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -58,7 +58,6 @@
 //! [`uefi-services`]: https://crates.io/crates/uefi-services
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
-#![feature(abi_efiapi)]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -67,7 +66,6 @@
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
 #![deny(clippy::must_use_candidate)]
-#![allow(stable_features)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
The feature has been stabilized so we don't need to enable it anymore.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
