### PR TITLE
Move some util code from TCG to a new top-level module

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -104,3 +104,5 @@ pub mod logger;
 pub(crate) mod mem;
 
 pub(crate) mod polyfill;
+
+mod util;

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -55,6 +55,7 @@
 //! avoid tearing with animations.
 
 use crate::proto::unsafe_protocol;
+use crate::util::usize_from_u32;
 use crate::{Result, Status};
 use core::marker::PhantomData;
 use core::mem;
@@ -409,7 +410,7 @@ impl ModeInfo {
     /// On desktop monitors, this usually means (width, height).
     #[must_use]
     pub const fn resolution(&self) -> (usize, usize) {
-        (self.hor_res as usize, self.ver_res as usize)
+        (usize_from_u32(self.hor_res), usize_from_u32(self.ver_res))
     }
 
     /// Returns the format of the frame buffer.
@@ -433,7 +434,7 @@ impl ModeInfo {
     /// instead the stride might be bigger for better alignment.
     #[must_use]
     pub const fn stride(&self) -> usize {
-        self.stride as usize
+        usize_from_u32(self.stride)
     }
 }
 

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -5,6 +5,7 @@ use crate::{
     proto::device_path::{DevicePath, FfiDevicePath},
     proto::unsafe_protocol,
     table::boot::MemoryType,
+    util::usize_from_u32,
     CStr16, Handle, Status,
 };
 use core::{ffi::c_void, mem, slice};
@@ -78,7 +79,7 @@ impl LoadedImage {
     /// [`&CStr16`]: `CStr16`
     /// [`load_options_as_bytes`]: `Self::load_options_as_bytes`
     pub fn load_options_as_cstr16(&self) -> Result<&CStr16, LoadOptionsError> {
-        let load_options_size = usize::try_from(self.load_options_size).unwrap();
+        let load_options_size = usize_from_u32(self.load_options_size);
 
         if self.load_options.is_null() {
             Err(LoadOptionsError::NotSet)
@@ -115,7 +116,7 @@ impl LoadedImage {
             unsafe {
                 Some(slice::from_raw_parts(
                     self.load_options,
-                    usize::try_from(self.load_options_size).unwrap(),
+                    usize_from_u32(self.load_options_size),
                 ))
             }
         }

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -8,6 +8,7 @@ use core::{
     ptr::{null, null_mut},
 };
 
+use crate::util::ptr_write_unaligned_and_add;
 use crate::{polyfill::maybe_uninit_slice_as_mut_ptr, proto::unsafe_protocol};
 use bitflags::bitflags;
 use ptr_meta::Pointee;
@@ -698,12 +699,6 @@ impl DiscoverInfo {
 
         if buffer.len() < required_size {
             return Err(Status::BUFFER_TOO_SMALL.into());
-        }
-
-        /// Write `value` to `ptr` unaligned, then advance `ptr` by `sizeof(value)`.
-        unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
-            ptr.cast::<T>().write_unaligned(val);
-            *ptr = ptr.add(core::mem::size_of::<T>());
         }
 
         let mut ptr: *mut u8 = maybe_uninit_slice_as_mut_ptr(buffer);

--- a/uefi/src/proto/tcg/mod.rs
+++ b/uefi/src/proto/tcg/mod.rs
@@ -18,7 +18,6 @@ mod enums;
 pub use enums::*;
 
 use bitflags::bitflags;
-use core::mem;
 
 /// Platform Configuration Register (PCR) index.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -55,11 +54,4 @@ bitflags! {
 /// infallable on supported targets.
 fn usize_from_u32(val: u32) -> usize {
     val.try_into().expect("`u32` does not fit in `usize`")
-}
-
-/// Copy the bytes of `val` to `ptr`, then advance pointer to just after the
-/// newly-copied bytes.
-unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
-    ptr.cast::<T>().write_unaligned(val);
-    *ptr = ptr.add(mem::size_of::<T>());
 }

--- a/uefi/src/proto/tcg/mod.rs
+++ b/uefi/src/proto/tcg/mod.rs
@@ -47,11 +47,3 @@ bitflags! {
         const SM3_256 = 0x0000_0010;
     }
 }
-
-/// Convenience function for converting from a `u32` to a `usize`
-/// without using `as` or unwrapping everywhere. This particular
-/// conversion comes up a lot in the TPM API, and it should be
-/// infallable on supported targets.
-fn usize_from_u32(val: u32) -> usize {
-    val.try_into().expect("`u32` does not fit in `usize`")
-}

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -8,12 +8,11 @@
 //! [TCG]: https://trustedcomputinggroup.org/
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
-use super::{
-    ptr_write_unaligned_and_add, usize_from_u32, AlgorithmId, EventType, HashAlgorithm, PcrIndex,
-};
+use super::{usize_from_u32, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
 use crate::data_types::PhysicalAddress;
 use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
 use crate::proto::unsafe_protocol;
+use crate::util::ptr_write_unaligned_and_add;
 use crate::{Error, Result, Status};
 use core::fmt::{self, Debug, Formatter};
 use core::marker::{PhantomData, PhantomPinned};

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -8,11 +8,11 @@
 //! [TCG]: https://trustedcomputinggroup.org/
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
-use super::{usize_from_u32, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
+use super::{AlgorithmId, EventType, HashAlgorithm, PcrIndex};
 use crate::data_types::PhysicalAddress;
 use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
 use crate::proto::unsafe_protocol;
-use crate::util::ptr_write_unaligned_and_add;
+use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
 use crate::{Error, Result, Status};
 use core::fmt::{self, Debug, Formatter};
 use core::marker::{PhantomData, PhantomPinned};

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -10,12 +10,10 @@
 //! [TCG]: https://trustedcomputinggroup.org/
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
-use super::{
-    ptr_write_unaligned_and_add, usize_from_u32, v1, AlgorithmId, EventType, HashAlgorithm,
-    PcrIndex,
-};
+use super::{usize_from_u32, v1, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
 use crate::data_types::{PhysicalAddress, UnalignedSlice};
 use crate::proto::unsafe_protocol;
+use crate::util::ptr_write_unaligned_and_add;
 use crate::{Error, Result, Status};
 use bitflags::bitflags;
 use core::fmt::{self, Debug, Formatter};

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -10,10 +10,10 @@
 //! [TCG]: https://trustedcomputinggroup.org/
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
-use super::{usize_from_u32, v1, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
+use super::{v1, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
 use crate::data_types::{PhysicalAddress, UnalignedSlice};
 use crate::proto::unsafe_protocol;
-use crate::util::ptr_write_unaligned_and_add;
+use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
 use crate::{Error, Result, Status};
 use bitflags::bitflags;
 use core::fmt::{self, Debug, Formatter};

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -6,3 +6,31 @@ pub unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
     ptr.cast::<T>().write_unaligned(val);
     *ptr = ptr.add(mem::size_of::<T>());
 }
+
+/// Convert from a `u32` to a `usize`. Panic if the input does fit. On typical
+/// targets `usize` is at least as big as `u32`, so this should never panic
+/// except on unusual targets.
+///
+/// Comparison to alternatives:
+/// * `val as usize` doesn't check that `val` actually fits in a `usize`.
+/// * `usize::try_from(val).unwrap()` doesn't work in a const context.
+pub const fn usize_from_u32(val: u32) -> usize {
+    // This is essentially the same as `usize::try_from(val).unwrap()`, but
+    // works in a `const` context on stable.
+    if mem::size_of::<usize>() < mem::size_of::<u32>() && val < (usize::MAX as u32) {
+        panic!("value does not fit in a usize");
+    } else {
+        val as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_usize_from_u32() {
+        assert_eq!(usize_from_u32(0), 0usize);
+        assert_eq!(usize_from_u32(u32::MAX), 4294967295usize);
+    }
+}

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -1,0 +1,8 @@
+use core::mem;
+
+/// Copy the bytes of `val` to `ptr`, then advance pointer to just after the
+/// newly-copied bytes.
+pub unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
+    ptr.cast::<T>().write_unaligned(val);
+    *ptr = ptr.add(mem::size_of::<T>());
+}


### PR DESCRIPTION
Add `uefi::util`, an internal module (not part of the public API) with some useful functions, and change some existing code to use those functions.

Just code cleanup, should be no real functional changes.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
