### PR TITLE
uefi: Fix protocol functions to work with unsized protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## uefi - [Unreleased]
 
+### Changed
+
+- Fixed several protocol functions so that they work with unsized protocols
+  (like `DevicePath`): `BootServices::locate_device_path`,
+  `BootServices::get_handle_for_protocol`, `BootServices::test_protocol`,
+  `BootServices::find_handles`, and `SearchType::from_proto`.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -949,7 +949,10 @@ impl BootServices {
     ///
     /// * [`uefi::Status::NOT_FOUND`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
-    pub fn locate_device_path<P: Protocol>(&self, device_path: &mut &DevicePath) -> Result<Handle> {
+    pub fn locate_device_path<P: ProtocolPointer + ?Sized>(
+        &self,
+        device_path: &mut &DevicePath,
+    ) -> Result<Handle> {
         let mut handle = MaybeUninit::uninit();
         let mut device_path_ptr = device_path.as_ffi_ptr();
         unsafe {
@@ -997,7 +1000,7 @@ impl BootServices {
     /// # Errors
     ///
     /// Returns [`NOT_FOUND`] if no handles support the requested protocol.
-    pub fn get_handle_for_protocol<P: Protocol>(&self) -> Result<Handle> {
+    pub fn get_handle_for_protocol<P: ProtocolPointer + ?Sized>(&self) -> Result<Handle> {
         // Delegate to a non-generic function to potentially reduce code size.
         self.get_handle_for_protocol_impl(&P::GUID)
     }
@@ -1389,7 +1392,10 @@ impl BootServices {
     /// * [`uefi::Status::UNSUPPORTED`]
     /// * [`uefi::Status::ACCESS_DENIED`]
     /// * [`uefi::Status::ALREADY_STARTED`]
-    pub fn test_protocol<P: Protocol>(&self, params: OpenProtocolParams) -> Result<()> {
+    pub fn test_protocol<P: ProtocolPointer + ?Sized>(
+        &self,
+        params: OpenProtocolParams,
+    ) -> Result<()> {
         const TEST_PROTOCOL: u32 = 0x04;
         let mut interface = ptr::null_mut();
         (self.open_protocol)(
@@ -1530,7 +1536,7 @@ impl BootServices {
     /// All errors come from calls to [`locate_handle`].
     ///
     /// [`locate_handle`]: Self::locate_handle
-    pub fn find_handles<P: Protocol>(&self) -> Result<Vec<Handle>> {
+    pub fn find_handles<P: ProtocolPointer + ?Sized>(&self) -> Result<Vec<Handle>> {
         // Search by protocol.
         let search_type = SearchType::from_proto::<P>();
 
@@ -2129,7 +2135,7 @@ pub enum SearchType<'guid> {
 impl<'guid> SearchType<'guid> {
     /// Constructs a new search type for a specified protocol.
     #[must_use]
-    pub const fn from_proto<P: Protocol>() -> Self {
+    pub const fn from_proto<P: ProtocolPointer + ?Sized>() -> Self {
         SearchType::ByProtocol(&P::GUID)
     }
 }


### PR DESCRIPTION
A while ago we changed `DevicePath` to be an unsized type, which necessitated some trait bound changes elsewhere. For example, `open_protocol_exclusive` changed from `P: Protocol` to `P: ProtocolPointer + ?Sized`. However, there are a number of other functions in boot services that take a generic protocol, and they weren't updated so they don't work with unsized protocols. This commit fixes all of those functions.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
