### PR TITLE
ci: fix book/deploy in forks

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -8,6 +8,7 @@ on:
 # https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions#github-pages-deploy
 jobs:
   deploy:
+    if: github.repository == 'rust-osdev/uefi-rs'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Forks regularly fail as the book/deploy step fails there.


## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
