### PR TITLE
uefi-macros: Fix error tests

### DIFF
--- a/uefi-macros/tests/ui/entry_bad_arg.stderr
+++ b/uefi-macros/tests/ui/entry_bad_arg.stderr
@@ -6,3 +6,4 @@ error[E0308]: mismatched types
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status`
                 found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>, usize) -> uefi::Status {main}`
+  = note: when the arguments and return types match, functions can be coerced to function pointers

--- a/uefi-macros/tests/ui/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/entry_bad_return_type.stderr
@@ -2,7 +2,8 @@ error[E0308]: mismatched types
  --> tests/ui/entry_bad_return_type.rs:8:4
   |
 8 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
-  |    ^^^^ expected struct `Status`, found `bool`
+  |    ^^^^ expected fn pointer, found fn item
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> Status`
                 found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool {main}`
+  = note: when the arguments and return types match, functions can be coerced to function pointers


### PR DESCRIPTION
The new error text is actually not as good, we'll want to make some updates to the `entry` macro to improve that in the future. Filed that as https://github.com/rust-osdev/uefi-rs/issues/649

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
