### PR TITLE
Various fixes for tests under Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,11 +141,18 @@ jobs:
     name: Check that the build works on a Windows target
     runs-on: windows-latest
     steps:
+      - name: Install QEMU
+        run: choco install qemu
+
       - name: Checkout sources
         uses: actions/checkout@v3
 
       - name: Build
         run: cargo xtask build
+
+      - name: Run VM tests
+        run: cargo xtask run --target x86_64 --ci
+        timeout-minutes: 2
 
   # Run the build with our current nightly MSRV (specified in
   # ./msrv_toolchain.toml). This serves to check that we don't

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -15,7 +15,11 @@ log = { version = "0.4.17", default-features = false }
 qemu-exit = "3.0.0"
 
 [features]
-# This feature should only be enabled in our CI, it disables some tests
-# which currently fail in that environment (see #103 for discussion).
-ci = []
+# Enable the multiprocessor test. This only works if KVM is enabled.
+multi_processor = []
 
+# Enable the TPM v1 test.
+tpm_v1 = []
+
+# Enable the TPM v2 test.
+tpm_v2 = []

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -9,8 +9,10 @@ use uefi::Status;
 const NUM_CPUS: usize = 4;
 
 pub fn test(bt: &BootServices) {
-    // These tests break CI. See #103.
-    if cfg!(feature = "ci") {
+    // Skip the test if the `multi_processing` feature is not
+    // enabled. This toggle is needed because the test only works with
+    // KVM, which is not available in CI or on Windows.
+    if cfg!(not(feature = "multi_processor")) {
         return;
     }
 

--- a/uefi-test-runner/src/proto/tcg.rs
+++ b/uefi-test-runner/src/proto/tcg.rs
@@ -46,16 +46,16 @@ fn tcg_v1_read_pcr(tcg: &mut v1::Tcg, pcr_index: PcrIndex) -> v1::Sha1Digest {
 }
 
 fn test_tcg_v1(bt: &BootServices) {
+    // Skip the test of the `tpm_v1` feature is not enabled.
+    if cfg!(not(feature = "tpm_v1")) {
+        return;
+    }
+
     info!("Running TCG v1 test");
 
-    let handle = if let Ok(handle) = bt.get_handle_for_protocol::<v1::Tcg>() {
-        handle
-    } else if cfg!(all(feature = "ci", target_arch = "x86_64")) {
-        panic!("TPM v1 is required on x86_64 CI");
-    } else {
-        info!("No TCG handle found");
-        return;
-    };
+    let handle = bt
+        .get_handle_for_protocol::<v1::Tcg>()
+        .expect("no TCG handle found");
 
     let mut tcg = bt
         .open_protocol_exclusive::<v1::Tcg>(handle)
@@ -215,16 +215,16 @@ fn tcg_v2_read_pcr_8(tcg: &mut v2::Tcg) -> v1::Sha1Digest {
 }
 
 pub fn test_tcg_v2(bt: &BootServices) {
+    // Skip the test of the `tpm_v2` feature is not enabled.
+    if cfg!(not(feature = "tpm_v2")) {
+        return;
+    }
+
     info!("Running TCG v2 test");
 
-    let handle = if let Ok(handle) = bt.get_handle_for_protocol::<v2::Tcg>() {
-        handle
-    } else if cfg!(all(feature = "ci", target_arch = "x86")) {
-        panic!("TPM v2 is required on x86 (32-bit) CI");
-    } else {
-        info!("No TCG handle found");
-        return;
-    };
+    let handle = bt
+        .get_handle_for_protocol::<v2::Tcg>()
+        .expect("no TCG handle found");
 
     let mut tcg = bt
         .open_protocol_exclusive::<v2::Tcg>(handle)

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -58,7 +58,9 @@ pub enum Feature {
     ServicesLogger,
 
     // `uefi-test-runner` features.
-    Ci,
+    MultiProcessor,
+    TpmV1,
+    TpmV2,
 }
 
 impl Feature {
@@ -74,7 +76,9 @@ impl Feature {
             Self::Qemu => "uefi-services/qemu",
             Self::ServicesLogger => "uefi-services/logger",
 
-            Self::Ci => "uefi-test-runner/ci",
+            Self::MultiProcessor => "uefi-test-runner/multi_processor",
+            Self::TpmV1 => "uefi-test-runner/tpm_v1",
+            Self::TpmV2 => "uefi-test-runner/tpm_v2",
         }
     }
 
@@ -89,7 +93,7 @@ impl Feature {
                 Self::Unstable,
             ],
             Package::UefiServices => vec![Self::PanicHandler, Self::Qemu, Self::ServicesLogger],
-            Package::UefiTestRunner => vec![Self::Ci],
+            Package::UefiTestRunner => vec![Self::MultiProcessor, Self::TpmV1, Self::TpmV2],
             _ => vec![],
         }
     }


### PR DESCRIPTION
In addition to fixing the tests under Windows, this PR enables adds running the VM tests under Windows to prevent future accidental breakage.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
