### PR TITLE
uefi: Rework `exit_boot_services` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## uefi - [Unreleased]
 
+### Changed
+
+- `SystemTable::exit_boot_services` now takes no parameters and handles
+  the memory map allocation itself. Errors are now treated as
+  unrecoverable and will cause the system to reset.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -61,7 +61,7 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
 
     runtime::test(st.runtime_services());
 
-    shutdown(image, st);
+    shutdown(st);
 }
 
 fn check_revision(rev: uefi::table::Revision) {
@@ -152,7 +152,7 @@ fn send_request_to_host(bt: &BootServices, request: HostRequest) {
     }
 }
 
-fn shutdown(image: uefi::Handle, mut st: SystemTable<Boot>) -> ! {
+fn shutdown(mut st: SystemTable<Boot>) -> ! {
     // Get our text output back.
     st.stdout().reset(false).unwrap();
 
@@ -164,12 +164,7 @@ fn shutdown(image: uefi::Handle, mut st: SystemTable<Boot>) -> ! {
     send_request_to_host(st.boot_services(), HostRequest::TestsComplete);
 
     // Exit boot services as a proof that it works :)
-    let sizes = st.boot_services().memory_map_size();
-    let max_mmap_size = sizes.map_size + 2 * sizes.entry_size;
-    let mut mmap_storage = vec![0; max_mmap_size].into_boxed_slice();
-    let (st, _iter) = st
-        .exit_boot_services(image, &mut mmap_storage[..])
-        .expect("Failed to exit boot services");
+    let (st, _iter) = st.exit_boot_services();
 
     #[cfg(target_arch = "x86_64")]
     {


### PR DESCRIPTION
Exiting boot services is a one-way operation, which is why `exit_boot_services`
takes `self` rather than a reference. If it succeeds then you get back a
`SystemTable<Runtime>`, but even if it fails you can't continue to use boot
services except for a very limited subset. Specifically, in UEFI 2.8 and
earlier, only `get_memory_map` and `exit_boot_services` are allowed. Starting in
UEFI 2.9 other memory allocation functions may also be called.

To properly support pre-2.9 firmware then, the right thing to do is to
make sure that the initial buffer allocated to hold the memory map has
sufficient extra room in case the first attempt to get the memory map
and exit boot services fails. We now add room for 8 extra entries if
that occurs, matching the behavior of the Linux kernel:
https://github.com/torvalds/linux/blob/e544a07438/drivers/firmware/efi/libstub/efistub.h#L173

If something unexpected happens and exiting boot services still fails
after two attempts, the system is in an undefined state that we can't
reasonably recover from. The best thing we can do then is to simply
reset the system, essentially a strong panic.

Closes https://github.com/rust-osdev/uefi-rs/issues/523

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
