### PR TITLE
Add component name protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## uefi - [Unreleased]
 
+### Added
+
+- Added the `CompnentName1` and `ComponentName2` protocols. The `ComponentName`
+  wrapper will automatically select `ComponentName2` if available, and fall back
+  to `ComponentName1` otherwise.
+
 ### Changed
 
 - `SystemTable::exit_boot_services` now takes no parameters and handles
@@ -16,7 +22,7 @@
 
 ### Added
 
-* Added `table::boot::PAGE_SIZE` constant.
+- Added `table::boot::PAGE_SIZE` constant.
 
 ### Changed
 

--- a/uefi-test-runner/src/proto/driver.rs
+++ b/uefi-test-runner/src/proto/driver.rs
@@ -1,0 +1,150 @@
+use uefi::prelude::*;
+use uefi::proto::driver::{ComponentName, ComponentName2, LanguageError, LanguageIter};
+use uefi::table::boot::{BootServices, ScopedProtocol, SearchType};
+use uefi::{CStr16, Result};
+
+#[allow(deprecated)]
+use uefi::proto::driver::ComponentName1;
+
+/// Generic interface for testing `ComponentName1`, `ComponentName2`, and
+/// `ComponentName`.
+trait ComponentNameInterface<'a>: Sized {
+    fn open(boot_services: &'a BootServices, handle: Handle) -> Result<Self>;
+    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError>;
+    fn driver_name(&self, language: &str) -> Result<&CStr16>;
+    fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16>;
+}
+
+#[allow(deprecated)]
+impl<'a> ComponentNameInterface<'a> for ScopedProtocol<'a, ComponentName1> {
+    fn open(boot_services: &'a BootServices, handle: Handle) -> Result<Self> {
+        boot_services.open_protocol_exclusive::<ComponentName1>(handle)
+    }
+
+    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        (**self).supported_languages()
+    }
+
+    fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        (**self).driver_name(language)
+    }
+
+    fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        (**self).controller_name(controller_handle, child_handle, language)
+    }
+}
+
+impl<'a> ComponentNameInterface<'a> for ScopedProtocol<'a, ComponentName2> {
+    fn open(boot_services: &'a BootServices, handle: Handle) -> Result<Self> {
+        boot_services.open_protocol_exclusive::<ComponentName2>(handle)
+    }
+
+    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        (**self).supported_languages()
+    }
+
+    fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        (**self).driver_name(language)
+    }
+
+    fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        (**self).controller_name(controller_handle, child_handle, language)
+    }
+}
+
+impl<'a> ComponentNameInterface<'a> for ComponentName<'a> {
+    fn open(boot_services: &'a BootServices, handle: Handle) -> Result<Self> {
+        Self::open(boot_services, handle)
+    }
+
+    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        self.supported_languages()
+    }
+
+    fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        self.driver_name(language)
+    }
+
+    fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        self.controller_name(controller_handle, child_handle, language)
+    }
+}
+
+fn test_component_name<'a, C: ComponentNameInterface<'a>>(
+    boot_services: &'a BootServices,
+    english: &str,
+) {
+    let all_handles = boot_services
+        .locate_handle_buffer(SearchType::AllHandles)
+        .unwrap();
+
+    let fat_driver_name = cstr16!("FAT File System Driver");
+    let fat_controller_name = cstr16!("FAT File System");
+
+    // Find the FAT driver by name.
+    let component_name: C = all_handles
+        .handles()
+        .iter()
+        .find_map(|handle| {
+            let component_name = C::open(boot_services, *handle).ok()?;
+
+            assert!(component_name
+                .supported_languages()
+                .ok()?
+                .any(|lang| lang == english));
+
+            let driver_name = component_name.driver_name(english).ok()?;
+            if driver_name == fat_driver_name {
+                Some(component_name)
+            } else {
+                None
+            }
+        })
+        .expect("failed to find FAT driver");
+
+    // Now check that the FAT controller can be found by name.
+    all_handles
+        .handles()
+        .iter()
+        .find(|handle| {
+            let controller_name = if let Ok(controller_name) =
+                component_name.controller_name(**handle, None, english)
+            {
+                controller_name
+            } else {
+                return false;
+            };
+
+            controller_name == fat_controller_name
+        })
+        .expect("failed to find FAT controller");
+}
+
+pub fn test(boot_services: &BootServices) {
+    info!("Running component name test");
+
+    #[allow(deprecated)]
+    test_component_name::<ScopedProtocol<ComponentName1>>(boot_services, "eng");
+    test_component_name::<ScopedProtocol<ComponentName2>>(boot_services, "en");
+    test_component_name::<ComponentName>(boot_services, "en");
+}

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -14,6 +14,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
 
     debug::test(bt);
     device_path::test(image, bt);
+    driver::test(bt);
     loaded_image::test(image, bt);
     media::test(bt);
     network::test(bt);
@@ -61,6 +62,7 @@ fn test_protocols_per_handle(image: Handle, bt: &BootServices) {
 mod console;
 mod debug;
 mod device_path;
+mod driver;
 mod loaded_image;
 mod media;
 mod network;

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -1,0 +1,428 @@
+// This module defines the `ComponentName1` type and marks it deprecated. That
+// causes warnings for uses within this module (e.g. the `impl ComponentName1`
+// block), so turn off deprecated warnings. It's not yet possible to make this
+// allow more fine-grained, see https://github.com/rust-lang/rust/issues/62398.
+#![allow(deprecated)]
+
+use crate::proto::unsafe_protocol;
+use crate::table::boot::{BootServices, ScopedProtocol};
+use crate::{CStr16, Error, Handle, Result, Status};
+use core::{ptr, slice};
+
+/// Protocol that provides human-readable names for a driver and for each of the
+/// controllers that the driver is managing.
+///
+/// This protocol was deprecated in UEFI 2.1 in favor of the new
+/// [`ComponentName2`] protocol. The two protocols are identical except the
+/// encoding of supported languages changed from [ISO 639-2] to [RFC 4646]. The
+/// [`ComponentName`] wrapper can be used to automatically select
+/// [`ComponentName2`] if available, and otherwise fall back to
+/// [`ComponentName1`].
+///
+/// The corresponding C type is `EFI_COMPONENT_NAME_PROTOCOL`.
+///
+/// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+/// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
+#[deprecated = "deprecated in UEFI 2.1; use ComponentName2 where possible"]
+#[unsafe_protocol("107a772c-d5e1-11d4-9a46-0090273fc14d")]
+#[repr(C)]
+pub struct ComponentName1 {
+    get_driver_name: unsafe extern "efiapi" fn(
+        this: *const Self,
+        language: *const u8,
+        driver_name: *mut *const u16,
+    ) -> Status,
+    get_controller_name: unsafe extern "efiapi" fn(
+        this: *const Self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: *const u8,
+        controller_name: *mut *const u16,
+    ) -> Status,
+    supported_languages: *const u8,
+}
+
+impl ComponentName1 {
+    /// Get an iterator over supported languages. Each language is identified by
+    /// a three-letter ASCII string specified in [ISO 639-2]. For example,
+    /// English is encoded as "eng".
+    ///
+    /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        LanguageIter::new(self.supported_languages, LanguageIterKind::V1)
+    }
+
+    /// Get the human-readable name of the driver in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        let language = language_to_cstr(language)?;
+        let mut driver_name = ptr::null();
+        unsafe { (self.get_driver_name)(self, language.as_ptr(), &mut driver_name) }
+            .into_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
+    }
+
+    /// Get the human-readable name of a controller in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        let language = language_to_cstr(language)?;
+        let mut driver_name = ptr::null();
+        unsafe {
+            (self.get_controller_name)(
+                self,
+                controller_handle,
+                child_handle,
+                language.as_ptr(),
+                &mut driver_name,
+            )
+        }
+        .into_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
+    }
+}
+
+/// Protocol that provides human-readable names for a driver and for each of the
+/// controllers that the driver is managing.
+///
+/// This protocol was introduced in UEFI 2.1 to replace the now-deprecated
+/// [`ComponentName1`] protocol. The two protocols are identical except the
+/// encoding of supported languages changed from [ISO 639-2] to [RFC 4646]. The
+/// [`ComponentName`] wrapper can be used to automatically select
+/// [`ComponentName2`] if available, and otherwise fall back to
+/// [`ComponentName1`].
+///
+/// The corresponding C type is `EFI_COMPONENT_NAME2_PROTOCOL`.
+///
+/// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+/// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
+#[unsafe_protocol("6a7a5cff-e8d9-4f70-bada-75ab3025ce14")]
+#[repr(C)]
+pub struct ComponentName2 {
+    get_driver_name: unsafe extern "efiapi" fn(
+        this: *const Self,
+        language: *const u8,
+        driver_name: *mut *const u16,
+    ) -> Status,
+    get_controller_name: unsafe extern "efiapi" fn(
+        this: *const Self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: *const u8,
+        controller_name: *mut *const u16,
+    ) -> Status,
+    supported_languages: *const u8,
+}
+
+impl ComponentName2 {
+    /// Get an iterator over supported languages. Each language is identified by
+    /// an ASCII string specified in [RFC 4646]. For example, English is encoded
+    /// as "en".
+    ///
+    /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
+    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        LanguageIter::new(self.supported_languages, LanguageIterKind::V2)
+    }
+
+    /// Get the human-readable name of the driver in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        let language = language_to_cstr(language)?;
+        let mut driver_name = ptr::null();
+        unsafe { (self.get_driver_name)(self, language.as_ptr(), &mut driver_name) }
+            .into_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
+    }
+
+    /// Get the human-readable name of a controller in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        let language = language_to_cstr(language)?;
+        let mut driver_name = ptr::null();
+        unsafe {
+            (self.get_controller_name)(
+                self,
+                controller_handle,
+                child_handle,
+                language.as_ptr(),
+                &mut driver_name,
+            )
+        }
+        .into_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
+    }
+}
+
+/// Wrapper around [`ComponentName1`] and [`ComponentName2`]. This will use
+/// [`ComponentName2`] if available, otherwise it will back to
+/// [`ComponentName1`].
+pub enum ComponentName<'a> {
+    /// Opened [`ComponentName1`] protocol.
+    V1(ScopedProtocol<'a, ComponentName1>),
+
+    /// Opened [`ComponentName2`] protocol.
+    V2(ScopedProtocol<'a, ComponentName2>),
+}
+
+impl<'a> ComponentName<'a> {
+    /// Open the [`ComponentName2`] protocol if available, otherwise fall back to
+    /// [`ComponentName1`].
+    pub fn open(boot_services: &'a BootServices, handle: Handle) -> Result<Self> {
+        if let Ok(cn2) = boot_services.open_protocol_exclusive::<ComponentName2>(handle) {
+            Ok(Self::V2(cn2))
+        } else {
+            Ok(Self::V1(
+                boot_services.open_protocol_exclusive::<ComponentName1>(handle)?,
+            ))
+        }
+    }
+
+    /// Get an iterator over supported languages. Each language is identified by
+    /// an ASCII string. If the opened protocol is [`ComponentName1`] this will
+    /// be an [ISO 639-2] string. If the opened protocol is [`ComponentName2`]
+    /// it will be an [RFC 4646] string. For example, English is encoded as
+    /// "eng" in ISO 639-2, and "en" in RFC 4646.
+    ///
+    /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+    /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
+    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+        match self {
+            Self::V1(cn1) => cn1.supported_languages(),
+            Self::V2(cn2) => cn2.supported_languages(),
+        }
+    }
+
+    /// Get the human-readable name of the driver in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn driver_name(&self, language: &str) -> Result<&CStr16> {
+        match self {
+            Self::V1(cn1) => cn1.driver_name(language),
+            Self::V2(cn2) => cn2.driver_name(language),
+        }
+    }
+
+    /// Get the human-readable name of a controller in the given language.
+    ///
+    /// `language` must be one of the languages returned by [`supported_languages`].
+    ///
+    /// [`supported_languages`]: Self::supported_languages
+    pub fn controller_name(
+        &self,
+        controller_handle: Handle,
+        child_handle: Option<Handle>,
+        language: &str,
+    ) -> Result<&CStr16> {
+        match self {
+            Self::V1(cn1) => cn1.controller_name(controller_handle, child_handle, language),
+            Self::V2(cn2) => cn2.controller_name(controller_handle, child_handle, language),
+        }
+    }
+}
+
+/// Error returned by [`ComponentName1::supported_languages`] and
+/// [`ComponentName2::supported_languages`].
+#[derive(Debug, Eq, PartialEq)]
+pub enum LanguageError {
+    /// The supported languages list contains a non-ASCII character at the
+    /// specified index.
+    Ascii {
+        /// Index of the invalid character.
+        index: usize,
+    },
+}
+
+#[derive(PartialEq)]
+enum LanguageIterKind {
+    V1,
+    V2,
+}
+
+/// Iterator returned by [`ComponentName1::supported_languages`] and
+/// [`ComponentName2::supported_languages`].
+pub struct LanguageIter<'a> {
+    languages: &'a [u8],
+    kind: LanguageIterKind,
+}
+
+impl<'a> LanguageIter<'a> {
+    fn new(
+        languages: *const u8,
+        kind: LanguageIterKind,
+    ) -> core::result::Result<Self, LanguageError> {
+        let mut index = 0;
+        loop {
+            let c = unsafe { languages.add(index).read() };
+            if c == 0 {
+                break;
+            } else if !c.is_ascii() {
+                return Err(LanguageError::Ascii { index });
+            } else {
+                index += 1;
+            }
+        }
+
+        Ok(Self {
+            languages: unsafe { slice::from_raw_parts(languages, index) },
+            kind,
+        })
+    }
+}
+
+impl<'a> Iterator for LanguageIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.languages.is_empty() {
+            return None;
+        }
+
+        let lang;
+        match self.kind {
+            LanguageIterKind::V1 => {
+                if self.languages.len() <= 3 {
+                    lang = self.languages;
+                    self.languages = &[];
+                } else {
+                    lang = &self.languages[..3];
+                    self.languages = &self.languages[3..];
+                }
+            }
+            LanguageIterKind::V2 => {
+                if let Some(index) = self.languages.iter().position(|c| *c == b';') {
+                    lang = &self.languages[..index];
+                    self.languages = &self.languages[index + 1..];
+                } else {
+                    lang = self.languages;
+                    self.languages = &[];
+                }
+            }
+        }
+
+        // OK to unwrap because we already checked the string is ASCII.
+        Some(core::str::from_utf8(lang).unwrap())
+    }
+}
+
+/// Statically-sized buffer used to convert a `str` to a null-terminated C
+/// string. The buffer should be at least 42 characters per
+/// <https://www.rfc-editor.org/rfc/rfc4646#section-4.3.1>, plus one for the
+/// null terminator. Round up to 64 bytes just for aesthetics.
+type LanguageCStr = [u8; 64];
+
+fn language_to_cstr(language: &str) -> Result<LanguageCStr> {
+    let mut lang_cstr: LanguageCStr = [0; 64];
+    // Ensure there's room for a null-terminator.
+    if language.len() >= lang_cstr.len() - 1 {
+        return Err(Error::from(Status::BUFFER_TOO_SMALL));
+    }
+    lang_cstr[..language.len()].copy_from_slice(language.as_bytes());
+    // Assert that it's null-terminated.
+    assert_eq!(*lang_cstr.last().unwrap(), 0);
+    Ok(lang_cstr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use LanguageIterKind::{V1, V2};
+
+    #[test]
+    fn test_language_iter_v1() {
+        // Empty string.
+        let data = "\0";
+        assert!(LanguageIter::new(data.as_ptr(), V1)
+            .unwrap()
+            .next()
+            .is_none());
+
+        // Two languages.
+        let data = "engfra\0";
+        assert_eq!(
+            LanguageIter::new(data.as_ptr(), V1)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            ["eng", "fra"]
+        );
+
+        // Truncated data.
+        let data = "en\0";
+        assert_eq!(
+            LanguageIter::new(data.as_ptr(), V1)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            ["en"]
+        );
+
+        // Non-ASCII.
+        let data = "engæ\0";
+        assert_eq!(
+            LanguageIter::new(data.as_ptr(), V1).err().unwrap(),
+            LanguageError::Ascii { index: 3 },
+        );
+    }
+
+    #[test]
+    fn test_language_iter_v2() {
+        // Empty string.
+        let data = "\0";
+        assert!(LanguageIter::new(data.as_ptr(), V2)
+            .unwrap()
+            .next()
+            .is_none());
+
+        // Two languages.
+        let data = "en;fr\0";
+        assert_eq!(
+            LanguageIter::new(data.as_ptr(), V2)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            ["en", "fr"]
+        );
+
+        // Non-ASCII.
+        let data = "engæ\0";
+        assert_eq!(
+            LanguageIter::new(data.as_ptr(), V2).err().unwrap(),
+            LanguageError::Ascii { index: 3 },
+        );
+    }
+
+    #[test]
+    fn test_language_to_cstr() {
+        let mut expected = [0; 64];
+        expected[0] = b'e';
+        expected[1] = b'n';
+        assert_eq!(language_to_cstr("en"), Ok(expected));
+
+        assert_eq!(
+            language_to_cstr(
+                "0123456789012345678901234567890123456789012345678901234567890123456789"
+            )
+            .err()
+            .unwrap()
+            .status(),
+            Status::BUFFER_TOO_SMALL
+        );
+    }
+}

--- a/uefi/src/proto/driver/mod.rs
+++ b/uefi/src/proto/driver/mod.rs
@@ -1,0 +1,5 @@
+//! UEFI driver model protocols.
+
+mod component_name;
+
+pub use component_name::*;

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -71,6 +71,7 @@ pub use uefi_macros::unsafe_protocol;
 pub mod console;
 pub mod debug;
 pub mod device_path;
+pub mod driver;
 pub mod loaded_image;
 pub mod media;
 pub mod network;


### PR DESCRIPTION
Add support for `EFI_COMPONENT_NAME_PROTOCOL` and
`EFI_COMPONENT_NAME2_PROTOCOL`. The former protocol has been deprecated since UEFI 2.1, but there are still some old devices (like some Macbooks) that don't support `EFI_COMPONENT_NAME2_PROTOCOL`.

The `ComponentName` wrapper type makes it easy to automatically use the V2 protocol if available, but fall back to V1 otherwise.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
