### PR TITLE
uefi: Export cstr8, cstr16, and entry macros from the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `SystemTable::exit_boot_services` now takes no parameters and handles
   the memory map allocation itself. Errors are now treated as
   unrecoverable and will cause the system to reset.
+- Re-export the `cstr8`, `cstr16`, and `entry` macros from the root of the
+  `uefi` crate.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -82,7 +82,7 @@ pub mod data_types;
 pub use self::data_types::CString16;
 pub use self::data_types::Identify;
 pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
-pub use uefi_macros::guid;
+pub use uefi_macros::{cstr16, cstr8, entry, guid};
 
 mod result;
 pub use self::result::{Error, Result, ResultExt, Status};


### PR DESCRIPTION
Previously these macros were only exported from the `prelude` module, but that's intended for glob imports which not everyone likes to use.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
