### PR TITLE
Implement `Deref` for `HandleBuffer` and `ProtocolsPerHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   unrecoverable and will cause the system to reset.
 - Re-export the `cstr8`, `cstr16`, and `entry` macros from the root of the
   `uefi` crate.
+- `HandleBuffer` and `ProtocolsPerHandle` now implement `Deref`. The
+  `HandleBuffer::handles` and `ProtocolsPerHandle::protocols` methods have been
+  deprecated.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -37,7 +37,6 @@ fn print_image_path(boot_services: &BootServices) -> Result {
     // ANCHOR: device_path
     let device_path_to_text_handle = *boot_services
         .locate_handle_buffer(SearchType::ByProtocol(&DevicePathToText::GUID))?
-        .handles()
         .first()
         .expect("DevicePathToText is missing");
 

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -120,8 +120,7 @@ fn test_reinstall_protocol_interface(bt: &BootServices) {
     info!("Reinstalling TestProtocol");
     let handle = bt
         .locate_handle_buffer(SearchType::from_proto::<TestProtocol>())
-        .expect("Failed to find protocol to uninstall")
-        .handles()[0];
+        .expect("Failed to find protocol to uninstall")[0];
 
     unsafe {
         let _ = bt.reinstall_protocol_interface(
@@ -137,8 +136,7 @@ fn test_uninstall_protocol_interface(bt: &BootServices) {
     info!("Uninstalling TestProtocol");
     let handle = bt
         .locate_handle_buffer(SearchType::from_proto::<TestProtocol>())
-        .expect("Failed to find protocol to uninstall")
-        .handles()[0];
+        .expect("Failed to find protocol to uninstall")[0];
 
     unsafe {
         bt.uninstall_protocol_interface(handle, &TestProtocol::GUID, ptr::null_mut())

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -20,7 +20,7 @@ fn test_locate_handle_buffer(bt: &BootServices) {
         let handles = bt
             .locate_handle_buffer(SearchType::AllHandles)
             .expect("Failed to locate handle buffer");
-        assert!(!handles.handles().is_empty(), "Could not find any handles");
+        assert!(!handles.is_empty(), "Could not find any handles");
     }
 
     {
@@ -29,7 +29,7 @@ fn test_locate_handle_buffer(bt: &BootServices) {
             .locate_handle_buffer(SearchType::ByProtocol(&Output::GUID))
             .expect("Failed to locate handle buffer");
         assert!(
-            !handles.handles().is_empty(),
+            !handles.is_empty(),
             "Could not find any OUTPUT protocol handles"
         );
     }

--- a/uefi-test-runner/src/proto/driver.rs
+++ b/uefi-test-runner/src/proto/driver.rs
@@ -103,7 +103,6 @@ fn test_component_name<'a, C: ComponentNameInterface<'a>>(
 
     // Find the FAT driver by name.
     let component_name: C = all_handles
-        .handles()
         .iter()
         .find_map(|handle| {
             let component_name = C::open(boot_services, *handle).ok()?;
@@ -124,7 +123,6 @@ fn test_component_name<'a, C: ComponentNameInterface<'a>>(
 
     // Now check that the FAT controller can be found by name.
     all_handles
-        .handles()
         .iter()
         .find(|handle| {
             let controller_name = if let Ok(controller_name) =

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -50,13 +50,10 @@ fn test_protocols_per_handle(image: Handle, bt: &BootServices) {
         .protocols_per_handle(image)
         .expect("Failed to get protocols for image handle");
 
-    info!("Image handle has {} protocols", pph.protocols().len());
+    info!("Image handle has {} protocols", pph.len());
 
     // Check that one of the image's protocols is `LoadedImage`.
-    assert!(pph
-        .protocols()
-        .iter()
-        .any(|guid| **guid == LoadedImage::GUID));
+    assert!(pph.iter().any(|guid| **guid == LoadedImage::GUID));
 }
 
 mod console;

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1013,7 +1013,6 @@ impl BootServices {
 
     fn get_handle_for_protocol_impl(&self, guid: &Guid) -> Result<Handle> {
         self.locate_handle_buffer(SearchType::ByProtocol(guid))?
-            .handles()
             .first()
             .cloned()
             .ok_or_else(|| Status::NOT_FOUND.into())
@@ -2214,10 +2213,19 @@ impl<'a> Drop for ProtocolsPerHandle<'a> {
     }
 }
 
+impl<'a> Deref for ProtocolsPerHandle<'a> {
+    type Target = [&'a Guid];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.protocols, self.count) }
+    }
+}
+
 impl<'a> ProtocolsPerHandle<'a> {
     /// Get the protocol interface [`Guids`][Guid] that are installed on the
     /// [`Handle`].
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    #[deprecated = "use Deref instead"]
     #[must_use]
     pub fn protocols<'b>(&'b self) -> &'b [&'a Guid] {
         // convert raw pointer to slice here so that we can get
@@ -2243,9 +2251,18 @@ impl<'a> Drop for HandleBuffer<'a> {
     }
 }
 
+impl<'a> Deref for HandleBuffer<'a> {
+    type Target = [Handle];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.buffer, self.count) }
+    }
+}
+
 impl<'a> HandleBuffer<'a> {
     /// Get an array of [`Handles`][Handle] that support the requested protocol.
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
+    #[deprecated = "use Deref instead"]
     #[must_use]
     pub fn handles(&self) -> &[Handle] {
         // convert raw pointer to slice here so that we can get


### PR DESCRIPTION
These types are smart pointers, so `Deref` is a good fit.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
