### PR TITLE
Add Sorted Iterator for the UEFI Memory Map (Issue#661)

### DIFF
--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -91,16 +91,27 @@ fn memory_map(bt: &BootServices) {
     // We will use vectors for convenience.
     let mut buffer = vec![0_u8; buf_sz];
 
-    let (_key, desc_iter) = bt
+    let mut memory_map = bt
         .memory_map(&mut buffer)
         .expect("Failed to retrieve UEFI memory map");
 
+    memory_map.sort();
+
     // Collect the descriptors into a vector
-    let descriptors = desc_iter.copied().collect::<Vec<_>>();
+    let descriptors = memory_map.entries().copied().collect::<Vec<_>>();
 
     // Ensured we have at least one entry.
     // Real memory maps usually have dozens of entries.
     assert!(!descriptors.is_empty(), "Memory map is empty");
+
+    let mut curr_value = descriptors[0];
+
+    for value in descriptors.iter().skip(1) {
+        if value.phys_start <= curr_value.phys_start {
+            panic!("memory map sorting failed");
+        }
+        curr_value = *value;
+    }
 
     // This is pretty much a sanity test to ensure returned memory isn't filled with random values.
     let first_desc = descriptors[0];

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1990,8 +1990,11 @@ pub struct MemoryMapSize {
     pub map_size: usize,
 }
 
-/// An iterator of [`MemoryDescriptor`] which returns elements in sorted order. The underlying memory map is always
-/// associated with the unique [`MemoryMapKey`] contained in the struct.
+/// An iterator of [`MemoryDescriptor`] that is always associated with the
+/// unique [`MemoryMapKey`] contained in the struct.
+///
+/// To iterate over the entries, call [`MemoryMap::entries`]. To get a sorted
+/// map, you manually have to call [`MemoryMap::sort`] first.
 pub struct MemoryMap<'buf> {
     key: MemoryMapKey,
     buf: &'buf mut [u8],
@@ -2007,6 +2010,7 @@ impl<'buf> MemoryMap<'buf> {
     }
 
     /// Sorts the memory map by physical address in place.
+    /// This operation is optional and should be invoked only once.
     pub fn sort(&mut self) {
         unsafe {
             self.qsort(0, self.len - 1);
@@ -2075,8 +2079,9 @@ impl<'buf> MemoryMap<'buf> {
         elem.phys_start
     }
 
+    /// Returns an iterator over the contained memory map. To get a sorted map,
+    /// call [`MemoryMap::sort`] first.
     #[must_use]
-    /// Returns an iterator over the contained memory map
     pub fn entries(&self) -> MemoryMapIter {
         MemoryMapIter {
             buffer: self.buf,
@@ -2356,7 +2361,6 @@ mod tests {
     }
 
     // Added for debug purposes on test failure
-    #[cfg(test)]
     impl core::fmt::Display for MemoryMap<'_> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             writeln!(f)?;


### PR DESCRIPTION
Added a sorted iterator and a method to convert a normal iterator to it.

Should close [issue#661](https://github.com/rust-osdev/uefi-rs/issues/661)