### PR TITLE
Make more tests fail if protocol is missing

### DIFF
--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -18,6 +18,9 @@ qemu-exit = "3.0.0"
 # Enable the multiprocessor test. This only works if KVM is enabled.
 multi_processor = []
 
+# Enable the PXE test.
+pxe = []
+
 # Enable the TPM v1 test.
 tpm_v1 = []
 

--- a/uefi-test-runner/src/proto/network/pxe.rs
+++ b/uefi-test-runner/src/proto/network/pxe.rs
@@ -8,97 +8,101 @@ use uefi::{
 };
 
 pub fn test(bt: &BootServices) {
+    // Skip the test if the `pxe` feature is not enabled.
+    if cfg!(not(feature = "pxe")) {
+        return;
+    }
+
     info!("Testing The PXE base code protocol");
 
-    if let Ok(handles) = bt.find_handles::<BaseCode>() {
-        for handle in handles {
-            let mut base_code = bt.open_protocol_exclusive::<BaseCode>(handle).unwrap();
+    let handles = bt
+        .find_handles::<BaseCode>()
+        .expect("failed to get PXE base code handles");
+    for handle in handles {
+        let mut base_code = bt.open_protocol_exclusive::<BaseCode>(handle).unwrap();
 
-            info!("Starting PXE Base Code");
-            base_code
-                .start(false)
-                .expect("failed to start PXE Base Code");
-            base_code
-                .dhcp(false)
-                .expect("failed to complete a dhcpv4 handshake");
+        info!("Starting PXE Base Code");
+        base_code
+            .start(false)
+            .expect("failed to start PXE Base Code");
+        base_code
+            .dhcp(false)
+            .expect("failed to complete a dhcpv4 handshake");
 
-            assert!(base_code.mode().dhcp_ack_received);
-            let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack.as_ref();
-            let server_ip = dhcp_ack.bootp_si_addr;
-            let server_ip = IpAddress::new_v4(server_ip);
+        assert!(base_code.mode().dhcp_ack_received);
+        let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack.as_ref();
+        let server_ip = dhcp_ack.bootp_si_addr;
+        let server_ip = IpAddress::new_v4(server_ip);
 
-            const EXAMPLE_FILE_NAME: &[u8] = b"example-file.txt\0";
-            const EXAMPLE_FILE_CONTENT: &[u8] = b"Hello world!";
-            let example_file_name = CStr8::from_bytes_with_nul(EXAMPLE_FILE_NAME).unwrap();
+        const EXAMPLE_FILE_NAME: &[u8] = b"example-file.txt\0";
+        const EXAMPLE_FILE_CONTENT: &[u8] = b"Hello world!";
+        let example_file_name = CStr8::from_bytes_with_nul(EXAMPLE_FILE_NAME).unwrap();
 
-            info!("Getting remote file size");
-            let file_size = base_code
-                .tftp_get_file_size(&server_ip, example_file_name)
-                .expect("failed to query file size");
-            assert_eq!(file_size, EXAMPLE_FILE_CONTENT.len() as u64);
+        info!("Getting remote file size");
+        let file_size = base_code
+            .tftp_get_file_size(&server_ip, example_file_name)
+            .expect("failed to query file size");
+        assert_eq!(file_size, EXAMPLE_FILE_CONTENT.len() as u64);
 
-            info!("Reading remote file");
-            let mut buffer = [0; 512];
-            let len = base_code
-                .tftp_read_file(&server_ip, example_file_name, Some(&mut buffer))
-                .expect("failed to read file");
-            let len = usize::try_from(len).unwrap();
-            assert_eq!(EXAMPLE_FILE_CONTENT, &buffer[..len]);
+        info!("Reading remote file");
+        let mut buffer = [0; 512];
+        let len = base_code
+            .tftp_read_file(&server_ip, example_file_name, Some(&mut buffer))
+            .expect("failed to read file");
+        let len = usize::try_from(len).unwrap();
+        assert_eq!(EXAMPLE_FILE_CONTENT, &buffer[..len]);
 
-            base_code
-                .set_ip_filter(&IpFilter::new(IpFilters::STATION_IP, &[]))
-                .expect("failed to set IP filter");
+        base_code
+            .set_ip_filter(&IpFilter::new(IpFilters::STATION_IP, &[]))
+            .expect("failed to set IP filter");
 
-            const EXAMPLE_SERVICE_PORT: u16 = 21572;
+        const EXAMPLE_SERVICE_PORT: u16 = 21572;
 
-            info!("Writing UDP packet to example service");
+        info!("Writing UDP packet to example service");
 
-            let payload = [1, 2, 3, 4];
-            let header = [payload.len() as u8];
-            let mut write_src_port = 0;
-            base_code
-                .udp_write(
-                    UdpOpFlags::ANY_SRC_PORT,
-                    &server_ip,
-                    EXAMPLE_SERVICE_PORT,
-                    None,
-                    None,
-                    Some(&mut write_src_port),
-                    Some(&header),
-                    &payload,
-                )
-                .expect("failed to write UDP packet");
+        let payload = [1, 2, 3, 4];
+        let header = [payload.len() as u8];
+        let mut write_src_port = 0;
+        base_code
+            .udp_write(
+                UdpOpFlags::ANY_SRC_PORT,
+                &server_ip,
+                EXAMPLE_SERVICE_PORT,
+                None,
+                None,
+                Some(&mut write_src_port),
+                Some(&header),
+                &payload,
+            )
+            .expect("failed to write UDP packet");
 
-            info!("Reading UDP packet from example service");
+        info!("Reading UDP packet from example service");
 
-            let mut src_ip = server_ip;
-            let mut src_port = EXAMPLE_SERVICE_PORT;
-            let mut dest_ip = base_code.mode().station_ip;
-            let mut dest_port = write_src_port;
-            let mut header = [0; 1];
-            let mut received = [0; 4];
-            base_code
-                .udp_read(
-                    UdpOpFlags::USE_FILTER,
-                    Some(&mut dest_ip),
-                    Some(&mut dest_port),
-                    Some(&mut src_ip),
-                    Some(&mut src_port),
-                    Some(&mut header),
-                    &mut received,
-                )
-                .unwrap();
+        let mut src_ip = server_ip;
+        let mut src_port = EXAMPLE_SERVICE_PORT;
+        let mut dest_ip = base_code.mode().station_ip;
+        let mut dest_port = write_src_port;
+        let mut header = [0; 1];
+        let mut received = [0; 4];
+        base_code
+            .udp_read(
+                UdpOpFlags::USE_FILTER,
+                Some(&mut dest_ip),
+                Some(&mut dest_port),
+                Some(&mut src_ip),
+                Some(&mut src_port),
+                Some(&mut header),
+                &mut received,
+            )
+            .unwrap();
 
-            // Check the header.
-            assert_eq!(header[0] as usize, payload.len());
-            // Check that we receive the reversed payload.
-            received.reverse();
-            assert_eq!(payload, received);
+        // Check the header.
+        assert_eq!(header[0] as usize, payload.len());
+        // Check that we receive the reversed payload.
+        received.reverse();
+        assert_eq!(payload, received);
 
-            info!("Stopping PXE Base Code");
-            base_code.stop().expect("failed to stop PXE Base Code");
-        }
-    } else {
-        warn!("PXE Base Code protocol is not supported");
+        info!("Stopping PXE Base Code");
+        base_code.stop().expect("failed to stop PXE Base Code");
     }
 }

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -17,20 +17,19 @@ pub fn test(bt: &BootServices) {
     }
 
     info!("Running UEFI multi-processor services protocol test");
-    if let Ok(handle) = bt.get_handle_for_protocol::<MpServices>() {
-        let mp_support = &bt
-            .open_protocol_exclusive::<MpServices>(handle)
-            .expect("failed to open multi-processor services protocol");
+    let handle = bt
+        .get_handle_for_protocol::<MpServices>()
+        .expect("failed to get multi-processor services handle");
+    let mp_support = &bt
+        .open_protocol_exclusive::<MpServices>(handle)
+        .expect("failed to open multi-processor services protocol");
 
-        test_get_number_of_processors(mp_support);
-        test_get_processor_info(mp_support);
-        test_startup_all_aps(mp_support, bt);
-        test_startup_this_ap(mp_support, bt);
-        test_enable_disable_ap(mp_support);
-        test_switch_bsp_and_who_am_i(mp_support);
-    } else {
-        warn!("Multi-processor services protocol is not supported");
-    }
+    test_get_number_of_processors(mp_support);
+    test_get_processor_info(mp_support);
+    test_startup_all_aps(mp_support, bt);
+    test_startup_this_ap(mp_support, bt);
+    test_enable_disable_ap(mp_support);
+    test_switch_bsp_and_who_am_i(mp_support);
 }
 
 fn test_get_number_of_processors(mps: &MpServices) {

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -59,6 +59,7 @@ pub enum Feature {
 
     // `uefi-test-runner` features.
     MultiProcessor,
+    Pxe,
     TpmV1,
     TpmV2,
 }
@@ -77,6 +78,7 @@ impl Feature {
             Self::ServicesLogger => "uefi-services/logger",
 
             Self::MultiProcessor => "uefi-test-runner/multi_processor",
+            Self::Pxe => "uefi-test-runner/pxe",
             Self::TpmV1 => "uefi-test-runner/tpm_v1",
             Self::TpmV2 => "uefi-test-runner/tpm_v2",
         }
@@ -93,7 +95,9 @@ impl Feature {
                 Self::Unstable,
             ],
             Package::UefiServices => vec![Self::PanicHandler, Self::Qemu, Self::ServicesLogger],
-            Package::UefiTestRunner => vec![Self::MultiProcessor, Self::TpmV1, Self::TpmV2],
+            Package::UefiTestRunner => {
+                vec![Self::MultiProcessor, Self::Pxe, Self::TpmV1, Self::TpmV2]
+            }
             _ => vec![],
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod util;
 
 use crate::opt::TestOpt;
 use anyhow::Result;
+use arch::UefiArch;
 use cargo::{fix_nested_cargo_env, Cargo, CargoAction, Feature, Package, TargetTypes};
 use clap::Parser;
 use itertools::Itertools;
@@ -121,6 +122,12 @@ fn run_miri() -> Result<()> {
 /// Build uefi-test-runner and run it in QEMU.
 fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
     let mut features = vec![];
+
+    // Enable the PXE test unless networking is disabled or the arch doesn't
+    // support it.
+    if *opt.target == UefiArch::X86_64 && !opt.disable_network {
+        features.push(Feature::Pxe);
+    }
 
     // Enable TPM tests if a TPM device is present.
     match opt.tpm {


### PR DESCRIPTION
Make the MP and PXE tests fail if the protocol isn't present. If the tests aren't supposed to pass then they are disabled by feature flag. This makes it easier to catch accidental breakage, since the tests will actually fail with an error instead of just printing a warning.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
