### PR TITLE
xtask: Enable strict provenance checks in Miri

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -269,6 +269,7 @@ impl Cargo {
             CargoAction::Miri => {
                 action = "miri";
                 sub_action = Some("test");
+                cmd.env("MIRIFLAGS", "-Zmiri-strict-provenance");
             }
             CargoAction::Test => {
                 action = "test";


### PR DESCRIPTION
I noticed while testing https://github.com/rust-osdev/uefi-rs/pull/662 that Miri is printing some useful warnings about pointer/integer casts. Enabling the `-Zmiri-strict-provenance` flag turns these warnings into errors so that they'll fail CI, otherwise it's easy to miss them.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
