### PR TITLE
test-runner: Make `unstable` an optional feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
       # At least one unit test, for make_boxed() currently, has different behaviour dependent on
       # the unstable feature.
       - name: Run cargo test (with unstable)
-        run: cargo xtask test --include-unstable
+        run: cargo xtask test --unstable
 
   lints:
     name: Lints
@@ -169,3 +169,19 @@ jobs:
 
     - name: Build
       run: cargo xtask build --feature-permutations
+
+  vm_test_unstable:
+    name: Run uefi-test-runner with `unstable` on x86_64
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+
+    - name: Install qemu and OVMF
+      run: |
+        sudo apt-get update
+        sudo apt-get install qemu-system-x86 ovmf -y
+
+    - name: Run VM tests
+      run: cargo xtask run --target x86_64 --headless --ci --unstable
+      timeout-minutes: 4

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -6,8 +6,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-# TODO we should let the uefi-test-runner run with and without unstable.
-uefi = { path = "../uefi", features = ["alloc", "unstable"] }
+uefi = { path = "../uefi", features = ["alloc"] }
 uefi-services = { path = "../uefi-services" }
 
 log = { version = "0.4.17", default-features = false }
@@ -20,6 +19,9 @@ multi_processor = []
 
 # Enable the PXE test.
 pxe = []
+
+# Enable the `unstable` feature of the `uefi` crate.
+unstable = ["uefi/unstable"]
 
 # Enable the TPM v1 test.
 tpm_v1 = []

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -60,6 +60,7 @@ pub enum Feature {
     // `uefi-test-runner` features.
     MultiProcessor,
     Pxe,
+    TestUnstable,
     TpmV1,
     TpmV2,
 }
@@ -79,6 +80,7 @@ impl Feature {
 
             Self::MultiProcessor => "uefi-test-runner/multi_processor",
             Self::Pxe => "uefi-test-runner/pxe",
+            Self::TestUnstable => "uefi-test-runner/unstable",
             Self::TpmV1 => "uefi-test-runner/tpm_v1",
             Self::TpmV2 => "uefi-test-runner/tpm_v2",
         }
@@ -96,7 +98,13 @@ impl Feature {
             ],
             Package::UefiServices => vec![Self::PanicHandler, Self::Qemu, Self::ServicesLogger],
             Package::UefiTestRunner => {
-                vec![Self::MultiProcessor, Self::Pxe, Self::TpmV1, Self::TpmV2]
+                vec![
+                    Self::MultiProcessor,
+                    Self::Pxe,
+                    Self::TestUnstable,
+                    Self::TpmV1,
+                    Self::TpmV2,
+                ]
             }
             _ => vec![],
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,6 +142,11 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
         features.push(Feature::MultiProcessor);
     }
 
+    // Enable `unstable` if requested.
+    if *opt.unstable {
+        features.push(Feature::TestUnstable);
+    }
+
     // Build uefi-test-runner.
     let cargo = Cargo {
         action: CargoAction::Build,
@@ -180,7 +185,7 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
         // the unstable feature. Because of this, we need to allow to test both variants. Runtime
         // features is set to no as it is not possible as as soon a #[global_allocator] is
         // registered, the Rust runtime executing the tests uses it as well.
-        features: Feature::more_code(test_opt.include_unstable, false),
+        features: Feature::more_code(*test_opt.unstable, false),
         // Don't test uefi-services (or the packages that depend on it)
         // as it has lang items that conflict with `std`.
         packages: vec![Package::Uefi, Package::UefiMacros],

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -35,6 +35,21 @@ pub struct BuildModeOpt {
 }
 
 #[derive(Debug, Parser)]
+pub struct UnstableOpt {
+    /// Enable the `unstable` feature (requires nightly).
+    #[clap(long, action)]
+    pub unstable: bool,
+}
+
+impl Deref for UnstableOpt {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.unstable
+    }
+}
+
+#[derive(Debug, Parser)]
 pub struct WarningOpt {
     /// Treat warnings as errors.
     #[clap(long, action)]
@@ -156,15 +171,16 @@ pub struct QemuOpt {
     /// Run an example instead of the main binary.
     #[clap(long, action)]
     pub example: Option<String>,
+
+    #[clap(flatten)]
+    pub unstable: UnstableOpt,
 }
 
 /// Run unit tests and doctests on the host.
 #[derive(Debug, Parser)]
 pub struct TestOpt {
-    /// Include all features behind the "unstable" gate. uefi-rs must build without unstable
-    /// functionality on stable (eventually) and with it in our nightly MSRV.
-    #[clap(long, action)]
-    pub include_unstable: bool,
+    #[clap(flatten)]
+    pub unstable: UnstableOpt,
 }
 
 /// Build the template against the crates.io packages.


### PR DESCRIPTION
Add an `unstable` option to `uefi-test-runner` that controls whether the `unstable` feature of the `uefi` crate is enabled. Also add a separate CI job so that we test both with and without the unstable feature.

This change is a necessary prereq for testing on stable, since we can't unconditionally enable unstable features there.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
