### PR TITLE
uefi-macros: Improve entry macro errors

### DIFF
--- a/uefi-macros/tests/ui/entry_bad_arg.stderr
+++ b/uefi-macros/tests/ui/entry_bad_arg.stderr
@@ -1,9 +1,8 @@
 error[E0308]: mismatched types
- --> tests/ui/entry_bad_arg.rs:8:4
+ --> tests/ui/entry_bad_arg.rs:8:1
   |
 8 | fn main(_handle: Handle, _st: SystemTable<Boot>, _x: usize) -> Status {
-  |    ^^^^ incorrect number of function parameters
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status`
-                found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>, usize) -> uefi::Status {main}`
-  = note: when the arguments and return types match, functions can be coerced to function pointers
+             found fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>, usize) -> uefi::Status`

--- a/uefi-macros/tests/ui/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/entry_bad_return_type.stderr
@@ -1,9 +1,8 @@
 error[E0308]: mismatched types
- --> tests/ui/entry_bad_return_type.rs:8:4
+ --> tests/ui/entry_bad_return_type.rs:8:1
   |
 8 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
-  |    ^^^^ expected fn pointer, found fn item
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Status`, found `bool`
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> Status`
-                found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool {main}`
-  = note: when the arguments and return types match, functions can be coerced to function pointers
+             found fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool`


### PR DESCRIPTION
In Rust 1.69, the error output of our function typecheck will become less clear. Fix by doing an intermediate cast from the fn item to a fn pointer, and then checking the signature of that pointer.

Also improved the error span to point at the whole function signature rather than just the ident.

Fixes https://github.com/rust-osdev/uefi-rs/issues/649

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
