### PR TITLE
ci: Increase Windows job timeout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run VM tests
         run: cargo xtask run --target x86_64 --ci
-        timeout-minutes: 4
+        timeout-minutes: 6
 
   # Run the build with our current nightly MSRV (specified in
   # ./msrv_toolchain.toml). This serves to check that we don't


### PR DESCRIPTION
The Windows job is sometimes hitting the four minute timeout, so bump it up by a couple minutes to avoid unnecessary flakes.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
