### PR TITLE
Add (Un)Installing Multiple Protocol Interfaces

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -58,7 +58,7 @@
 //! [`uefi-services`]: https://crates.io/crates/uefi-services
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
-#![feature(abi_efiapi)]
+#![feature(extended_varargs_abi_support)]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -258,11 +258,11 @@ pub struct BootServices {
     install_multiple_protocol_interfaces: extern "efiapi" fn(
         handle: Handle,
         ...
-    ),
+    ) -> Status,
     uninstall_multiple_protocol_interfaces: extern "efiapi" fn(
         handle: Handle,
         ...
-    ),
+    ) -> Status,
 
     // CRC services
     calculate_crc32: usize,
@@ -793,6 +793,19 @@ impl BootServices {
         (self.reinstall_protocol_interface)(handle, protocol, old_interface, new_interface).into()
     }
 
+    /// Installs one or more protocol interfaces to the boot services environment.
+    ///
+    /// # Errors
+    ///
+    /// See section `EFI_BOOT_SERVICES.InstallMultipleProtocolInterfaces()` in the UEFI Specification for more details.
+    ///
+    /// * [`uefi::Status::ALREADY_STARTED`]
+    /// * [`uefi::Status::INVALID_PARAMETER`]
+    /// * [`uefi::Status::OUT_OF_RESOURCES`]
+    pub fn install_multiple_protocol_interfaces(&self, handle: Handle, mut args: ...) -> Result {
+        (self.install_multiple_protocol_interfaces)(handle, args).into()
+    }
+
     /// Removes a protocol interface from a device handle.
     ///
     /// # Safety
@@ -819,6 +832,17 @@ impl BootServices {
         interface: *mut c_void,
     ) -> Result<()> {
         (self.uninstall_protocol_interface)(handle, protocol, interface).into()
+    }
+
+    /// Removes one or more protocol interfaces from the boot services environment.
+    ///
+    /// # Errors
+    ///
+    /// See section `EFI_BOOT_SERVICES.UninstallMultipleProtocolInterfaces()` in the UEFI Specification for more details.
+    ///
+    /// * [`uefi::Status::INVALID_PARAMETER`]
+    pub fn uninstall_multiple_protocol_interfaces(&self, handle: Handle, mut args: ...) -> Result {
+        (self.uninstall_multiple_protocol_interfaces)(handle, args).into()
     }
 
     /// Query a handle for a certain protocol.

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -255,8 +255,14 @@ pub struct BootServices {
         registration: *mut c_void,
         out_proto: &mut *mut c_void,
     ) -> Status,
-    install_multiple_protocol_interfaces: usize,
-    uninstall_multiple_protocol_interfaces: usize,
+    install_multiple_protocol_interfaces: extern "efiapi" fn(
+        handle: Handle,
+        ...
+    ),
+    uninstall_multiple_protocol_interfaces: extern "efiapi" fn(
+        handle: Handle,
+        ...
+    ),
 
     // CRC services
     calculate_crc32: usize,


### PR DESCRIPTION
This (currently draft) PR proposes the addition for support for missing functions `EFI_BOOT_SERVICES.InstallMultipleProtocolInterfaces()` and `EFI_BOOT_SERVICES.UninstallMultipleProtocolInterfaces()`.

This was previously blocked due to lack of support for varargs in EFIAPI. (Still need some assistance on the actual wrapper implementation).

Currently blocked on regular functions not supporting variadics, probably need to find a workaround for this.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
