### PR TITLE
uefi: Fix the DevicePathToText example to actually compile

### DIFF
--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -37,7 +37,7 @@ fn print_image_path(boot_services: &BootServices) -> Result {
     // ANCHOR: device_path
     let device_path_to_text_handle = *boot_services
         .locate_handle_buffer(SearchType::ByProtocol(&DevicePathToText::GUID))?
-        .first()
+        .handles().first()
         .expect("DevicePathToText is missing");
 
     let device_path_to_text = boot_services


### PR DESCRIPTION
I've just started my Rust journey, and I noticed the example didn't compile. I've included the trivial fix, I hope that's okay.

## Checklist
- [X] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
