### PR TITLE
xtask: Add option to skip uefi-macros tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,8 +175,10 @@ jobs:
     - name: Run cargo doc with the `unstable` feature
       run: cargo xtask doc --warnings-as-errors --document-private-items --unstable
 
-    - name: Run tests with the `unstable` feature
-      run: cargo xtask test --unstable
+    - name: Run test with the `unstable` feature
+      # Skip testing uefi-macros on nightly because the tests that check the
+      # compiler error output produce different output on stable vs nightly.
+      run: cargo xtask test --unstable --skip-macro-tests
 
     - name: Run unit tests and doctests under Miri
       run: |

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -177,6 +177,11 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
     };
     run_cmd(cargo.command()?)?;
 
+    let mut packages = vec![Package::Uefi];
+    if !test_opt.skip_macro_tests {
+        packages.push(Package::UefiMacros);
+    }
+
     // Run uefi-rs and uefi-macros tests.
     let cargo = Cargo {
         action: CargoAction::Test,
@@ -187,7 +192,7 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
         features: Feature::more_code(*test_opt.unstable, false),
         // Don't test uefi-services (or the packages that depend on it)
         // as it has lang items that conflict with `std`.
-        packages: vec![Package::Uefi, Package::UefiMacros],
+        packages,
         release: false,
         // Use the host target so that tests can run without a VM.
         target: None,

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -184,6 +184,10 @@ pub struct QemuOpt {
 pub struct TestOpt {
     #[clap(flatten)]
     pub unstable: UnstableOpt,
+
+    /// Skip the uefi-macros tests.
+    #[clap(long, action)]
+    pub skip_macro_tests: bool,
 }
 
 /// Build the template against the crates.io packages.


### PR DESCRIPTION
The uefi-macros tests check that the expected compiler output is produced for errors. The error output is slightly different between stable and nightly, so when we transition to testing on stable we have to handle that somehow. We could potentially have two sets of expected output, one for stable and one for nightly, but that's probably more trouble than it's worth. Instead, add an option to skip the uefi-macros tests, and enable that flag in the CI job for the nightly channel.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
