### PR TITLE
uefi-macros: Make `entry` example more compatible with stable

### DIFF
--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -221,17 +221,7 @@ fn get_function_arg_name(f: &ItemFn, arg_index: usize, errors: &mut TokenStream2
 ///
 /// ```no_run
 /// #![no_main]
-/// #![no_std]
 /// #![feature(abi_efiapi)]
-/// # // A bit of boilerplate needed to make the example compile in the
-/// # // context of `cargo test`.
-/// # #![feature(lang_items)]
-/// # #[lang = "eh_personality"]
-/// # fn eh_personality() {}
-/// # #[panic_handler]
-/// # fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-/// #     loop {}
-/// # }
 ///
 /// use uefi::prelude::*;
 ///


### PR DESCRIPTION
The `entry` macro's example code had `#![no_std]` in it to make it look like how you'd normally use it with the uefi targets. In the context that the example code is compiled in though, the target is the host's target. To get the example compiling there, we had to add some hidden hacks for `eh_personality` and a panic handler. Those hacks don't work on the stable channel though, so drop them along with `no_std`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
