### PR TITLE
uefi-macros: Use a more precise error span

### DIFF
--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -190,7 +190,10 @@ fn get_function_arg_name(f: &ItemFn, arg_index: usize, errors: &mut TokenStream2
             Some(pat_ident.ident.clone())
         } else {
             // The argument is unnamed, i.e. `_`.
-            errors.append_all(err!(arg.span(), "Entry method's arguments must be named"));
+            errors.append_all(err!(
+                arg.pat.span(),
+                "Entry method's arguments must be named"
+            ));
             None
         }
     } else {

--- a/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_image_arg.stderr
@@ -2,4 +2,4 @@ error: Entry method's arguments must be named
  --> tests/ui/entry_unnamed_image_arg.rs:8:22
   |
 8 | fn unnamed_image_arg(_: Handle, _st: SystemTable<Boot>) -> Status {
-  |                      ^^^^^^^^^
+  |                      ^

--- a/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
+++ b/uefi-macros/tests/ui/entry_unnamed_table_arg.stderr
@@ -2,4 +2,4 @@ error: Entry method's arguments must be named
  --> tests/ui/entry_unnamed_table_arg.rs:8:38
   |
 8 | fn unnamed_table_arg(_image: Handle, _: SystemTable<Boot>) -> Status {
-  |                                      ^^^^^^^^^^^^^^^^^^^^
+  |                                      ^


### PR DESCRIPTION
When the macro produces an error due to unnamed arguments, point precisely at the `_` part of the argument, rather than the whole argument including the type.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
