### PR TITLE
Rework "Building UEFI programs" sections in the readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,9 @@ most of the library's functionality.
 Check out the testing project's [`README.md`](uefi-test-runner/README.md) for
 prerequisites for running the tests.
 
-## Building UEFI programs
+## MSRV
 
-For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
-
-The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-11-22.
-
-[unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
+See the [uefi package's README](uefi/README.md#MSRV).
 
 ## Contributing
 

--- a/uefi/README.md
+++ b/uefi/README.md
@@ -47,15 +47,12 @@ For additional information, refer to the [UEFI specification][spec].
 [spec]: http://www.uefi.org/specifications
 [uefi-rs book]: https://rust-osdev.github.io/uefi-rs/HEAD
 
-## Building UEFI programs
-
-For instructions on how to create your own UEFI apps, see the [tutorial].
+## MSRV
 
 The uefi-rs crates currently require some [unstable features].
 The nightly MSRV is currently 2022-11-22.
 
 [unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
-[tutorial]: https://rust-osdev.github.io/uefi-rs/HEAD/tutorial/introduction.html
 
 ## License
 


### PR DESCRIPTION
These sections were mostly duplicated between the top-level readme and the `uefi` package's readme. In the top-level readme, it had a broken link to the `BUILDING.md` document which has been deleted.

Since we now have "Documentation" sections in both those readmes, the "Building UEFI programs" section was mostly redundent, except for the part about MSRV. Add new MSRV sections, and in the top-level readme just link to the `uefi` package's readme so that we don't have to update both places when the MSRV changes.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
