### PR TITLE
uefi: Add delete_variable() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   wrapper will automatically select `ComponentName2` if available, and fall back
   to `ComponentName1` otherwise.
 - `FileType`, `FileHandle`, `RegularFile`, and `Directory` now implement `Debug`.
+- Added `RuntimeServices::delete_variable()` helper method.
 
 ### Changed
 

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -2,6 +2,7 @@ use log::info;
 use uefi::guid;
 use uefi::prelude::*;
 use uefi::table::runtime::{VariableAttributes, VariableVendor};
+use uefi::Status;
 
 fn test_variables(rt: &RuntimeServices) {
     let name = cstr16!("UefiRsTestVar");
@@ -37,6 +38,16 @@ fn test_variables(rt: &RuntimeServices) {
     if let Some(key) = variable_keys.first() {
         info!("First variable: {}", key);
     }
+
+    info!("Testing delete_variable()");
+    rt.delete_variable(name, &vendor)
+        .expect("failed to delete variable");
+    assert_eq!(
+        rt.get_variable(name, &vendor, &mut buf)
+            .unwrap_err()
+            .status(),
+        Status::NOT_FOUND
+    );
 }
 
 fn test_variable_info(rt: &RuntimeServices) {

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -245,6 +245,11 @@ impl RuntimeServices {
         }
     }
 
+    /// Deletes a UEFI variable.
+    pub fn delete_variable(&self, name: &CStr16, vendor: &VariableVendor) -> Result {
+        self.set_variable(name, vendor, VariableAttributes::empty(), &[])
+    }
+
     /// Get information about UEFI variable storage space for the type
     /// of variable specified in `attributes`.
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/uefi-rs/issues/681

Deleting a UEFI variable seems a useful low level primitive for this lib to provide. 

## Checklist
- [X] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [X] Update the changelog (if necessary)

Side note: Be gentle, I'm new to Rust and probably doing dumb things -- all advice welcome. Thx.