### PR TITLE
Switch to the stable channel :tada: 

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-# Oldest nightly that currently works with `cargo xtask build`.
-channel = "nightly-2022-11-22"
+channel = "1.68"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,6 +108,10 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v3
 
+    # TODO: for now our latest release (0.19.1) requires nightly.
+    - name: Set nightly toolchain
+      run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
+
     - name: Build
       run: cargo xtask test-latest-release
 
@@ -143,12 +147,17 @@ jobs:
     - name: Build
       run: cargo xtask build
 
+  # This job requires the nightly channel, but keep it as a separate job from
+  # `nightly_channel` because it takes a while to run.
   build_feature_permutations:
     name: Check that the build works for all feature combinations
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
+
+    - name: Set nightly toolchain so that `unstable` can be included
+      run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
 
     - name: Build
       run: cargo xtask build --feature-permutations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## uefi - [Unreleased]
 
+As of this release, the UEFI crates work on the stable channel. This requires
+Rust 1.68 or higher.
+
 ### Added
 
 - Added the `ComponentName1` and `ComponentName2` protocols. The `ComponentName`

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -41,9 +41,7 @@ This is some boilerplate that all Rust UEFI applications will
 need. `no_main` is needed because the UEFI application entry point is
 different from the standard Rust `main` function. `no_std` is needed to
 turn off the `std` library; the `core` and `alloc` crates can still be
-used. And `feature(abi_efiapi)` is needed because UEFI applications have
-a special calling convention that is not yet stabilized in the Rust
-compiler.
+used.
 
 Next up are some `use` lines. Nothing too exciting here; the
 `uefi::prelude` module is intended to be glob-imported, and exports a

--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -1,24 +1,18 @@
 # Building
 
-## Nightly toolchain
+## Toolchain
 
-Rust's nightly toolchain is currently required because uefi-rs uses some
-unstable features.
-
-The easiest way to set this up is using a [rustup toolchain file]. In
-the root of your repository, add `rust-toolchain.toml`:
+In order to compile for UEFI, an appropriate target must be installed. The
+easiest way to set this up is using a [rustup toolchain file]. In the root of
+your repository, add `rust-toolchain.toml`:
 
 ```toml
 [toolchain]
-channel = "nightly"
-targets = ["x86_64-unknown-uefi"]
+targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]
 ```
 
-Here we have specified the `x86_64-unknown-uefi` target; there are also
-`i686-unknown-uefi` and `aarch64-unknown-uefi` targets available.
-
-Note that nightly releases can sometimes break, so you might opt to pin
-to a specific release. For example, `channel = "nightly-2022-11-10"`.
+Here we have specified all three of the currently-supported UEFI targets; you
+can remove some if you don't need them.
 
 ## Build the application
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/template/README.md
+++ b/template/README.md
@@ -8,7 +8,7 @@ UEFI application developed using `uefi-rs`.
 
 ## File structure
 
-- [`rust-toolchain.toml`](rust-toolchain.toml) sets the nightly channel.
+- [`rust-toolchain.toml`](rust-toolchain.toml) adds the UEFI targets.
 - [`Cargo.toml`](./Cargo.toml) shows the necessary dependencies.
 - [`src/main.rs`](./src/main.rs) has a minimal entry point that
   initializes the `uefi-services` crate and exits successfully.

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -1,7 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 use uefi::prelude::*;
 

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -224,7 +224,6 @@ fn get_function_arg_name(f: &ItemFn, arg_index: usize, errors: &mut TokenStream2
 ///
 /// ```no_run
 /// #![no_main]
-/// #![feature(abi_efiapi)]
 ///
 /// use uefi::prelude::*;
 ///

--- a/uefi-macros/tests/ui/entry_bad_abi.stderr
+++ b/uefi-macros/tests/ui/entry_bad_abi.stderr
@@ -2,4 +2,4 @@ error: Entry method must have no ABI modifier
  --> tests/ui/entry_bad_abi.rs:8:1
   |
 8 | extern "C" fn main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
-  | ^^^^^^^^^^
+  | ^^^^^^

--- a/uefi-macros/tests/ui/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/entry_bad_return_type.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
  --> tests/ui/entry_bad_return_type.rs:8:1
   |
 8 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Status`, found `bool`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Status`, found `bool`
   |
   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> Status`
              found fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool`

--- a/uefi-macros/tests/ui/guid_bad_hex_group2.stderr
+++ b/uefi-macros/tests/ui/guid_bad_hex_group2.stderr
@@ -1,5 +1,5 @@
 error: GUID component "Gaaa" is not a hexadecimal number
- --> tests/ui/guid_bad_hex_group2.rs:5:44
+ --> tests/ui/guid_bad_hex_group2.rs:5:34
   |
 5 | const BadHexGroup2: Guid = guid!("aaaaaaaa-Gaaa-aaaa-aaaa-aaaaaaaaaaaa");
-  |                                            ^^^^
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/uefi-macros/tests/ui/guid_bad_hex_group5.stderr
+++ b/uefi-macros/tests/ui/guid_bad_hex_group5.stderr
@@ -1,5 +1,5 @@
 error: GUID component "aaaaaaaaaaaG" is not a hexadecimal number
- --> tests/ui/guid_bad_hex_group5.rs:5:59
+ --> tests/ui/guid_bad_hex_group5.rs:5:34
   |
 5 | const BadHexGroup5: Guid = guid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaG");
-  |                                                           ^^^^^^^^^^^^
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -27,7 +27,6 @@
 //! [`exit_boot_services`]: uefi::table::SystemTable::exit_boot_services
 
 #![no_std]
-#![feature(alloc_error_handler)]
 #![feature(abi_efiapi)]
 #![deny(clippy::must_use_candidate)]
 #![allow(stable_features)]
@@ -256,12 +255,4 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             }
         }
     }
-}
-
-#[alloc_error_handler]
-fn out_of_memory(layout: ::core::alloc::Layout) -> ! {
-    panic!(
-        "Ran out of free memory while trying to allocate {:#?}",
-        layout
-    );
 }

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -27,9 +27,7 @@
 //! [`exit_boot_services`]: uefi::table::SystemTable::exit_boot_services
 
 #![no_std]
-#![feature(abi_efiapi)]
 #![deny(clippy::must_use_candidate)]
-#![allow(stable_features)]
 
 extern crate log;
 // Core types.

--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -2,8 +2,6 @@
 // ANCHOR: features
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 // ANCHOR_END: features
 
 // ANCHOR: use

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -1,8 +1,6 @@
 // ANCHOR: all
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 use log::info;
 use uefi::prelude::*;

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -1,8 +1,6 @@
 // ANCHOR: all
 #![no_main]
 #![no_std]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 extern crate alloc;
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(abi_efiapi)]
-#![allow(stable_features)]
 
 #[macro_use]
 extern crate log;

--- a/uefi/README.md
+++ b/uefi/README.md
@@ -49,10 +49,10 @@ For additional information, refer to the [UEFI specification][spec].
 
 ## MSRV
 
-The uefi-rs crates currently require some [unstable features].
-The nightly MSRV is currently 2022-11-22.
+The minimum supported Rust version is currently 1.68, which is the first Rust
+release that fully supports all necessary features on the stable channel.
 
-[unstable features]: https://github.com/rust-osdev/uefi-rs/issues/452
+In the future, our policy will be to support at least the past two stable releases.
 
 ## License
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -54,11 +54,7 @@
 //! - `panic-on-logger-errors` (enabled by default): Panic if a text
 //!   output error occurs in the logger.
 //! - `unstable`: Enable functionality that depends on [unstable
-//!   features] in the nightly compiler. Note that currently the `uefi`
-//!   crate _always_ requires unstable features even if the `unstable`
-//!   feature is not enabled, but once a couple more required features
-//!   are stabilized we intend to make the `uefi` crate work on the
-//!   stable channel by default.
+//!   features] in the nightly compiler.
 //!   As example, in conjunction with the `alloc`-feature, this gate allows
 //!   the `allocator_api` on certain functions.
 //!

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -79,7 +79,6 @@
 //! [spec]: https://uefi.org/specifications
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
-#![feature(abi_efiapi)]
 #![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -88,7 +87,6 @@
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
 #![deny(clippy::must_use_candidate)]
-#![allow(stable_features)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -50,7 +50,7 @@ fn build(opt: &BuildOpt) -> Result<()> {
 
     let cargo = Cargo {
         action: CargoAction::Build,
-        features: Feature::more_code(true, true),
+        features: Feature::more_code(false, true),
         packages: Package::all_except_xtask(),
         release: opt.build_mode.release,
         target: Some(*opt.target),
@@ -64,8 +64,7 @@ fn clippy(opt: &ClippyOpt) -> Result<()> {
     // Run clippy on all the UEFI packages.
     let cargo = Cargo {
         action: CargoAction::Clippy,
-        // for all possible features
-        features: Feature::more_code(true, true),
+        features: Feature::more_code(false, true),
         packages: Package::all_except_xtask(),
         release: false,
         target: Some(*opt.target),


### PR DESCRIPTION
Rust 1.68 is out, so we can use the stable channel now. This PR includes https://github.com/rust-osdev/uefi-rs/pull/617 and https://github.com/rust-osdev/uefi-rs/pull/636, removes nightly from the rust-toolchain files, updates the CI, and updates various docs.

Closes https://github.com/rust-osdev/uefi-rs/issues/452
Closes https://github.com/rust-osdev/uefi-rs/issues/638

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
