### PR TITLE
uefi: Drop `'boot` lifetime from Output protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `HandleBuffer` and `ProtocolsPerHandle` now implement `Deref`. The
   `HandleBuffer::handles` and `ProtocolsPerHandle::protocols` methods have been
   deprecated.
+- Removed `'boot` lifetime from the `Output` protocol.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -33,10 +33,8 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
 }
 
 fn find_protocol(bt: &BootServices) {
-    type SearchedProtocol<'boot> = proto::console::text::Output<'boot>;
-
     let handles = bt
-        .find_handles::<SearchedProtocol>()
+        .find_handles::<proto::console::text::Output>()
         .expect("Failed to retrieve list of handles");
 
     assert!(

--- a/uefi/src/logger.rs
+++ b/uefi/src/logger.rs
@@ -23,7 +23,7 @@ use core::ptr::NonNull;
 /// `disable` method before exiting UEFI boot services in order to prevent
 /// undefined behaviour from inadvertent logging.
 pub struct Logger {
-    writer: Option<NonNull<Output<'static>>>,
+    writer: Option<NonNull<Output>>,
 }
 
 impl Logger {

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -346,9 +346,9 @@ struct SystemTableImpl {
     stdin_handle: Handle,
     stdin: *mut text::Input,
     stdout_handle: Handle,
-    stdout: *mut text::Output<'static>,
+    stdout: *mut text::Output,
     stderr_handle: Handle,
-    stderr: *mut text::Output<'static>,
+    stderr: *mut text::Output,
     /// Runtime services table.
     runtime: &'static RuntimeServices,
     /// Boot services table.


### PR DESCRIPTION
The `Output` protocol has an internal pointer to an `OutputData` object. This was represented as a reference with the `'boot` lifetime, but this isn't quite right since the actual lifetime could be shorter than boot services. Furthermore, in several places the lifetime was set to `'static`, which is definitely not correct.

Fix by dropping the lifetime parameter, and instead just use a raw pointer. This is more in line with how we've implemented other protocols.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
