### PR TITLE
OVMF: enable "cargo xtask run" under NixOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{md,json}]
+[*.{json,md,nix,yml}]
 indent_style = space
 indent_size = 2

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,13 @@
+# Pinned nixpkgs version.
+
+let
+  # Picked a recent commit from the nixos-22.11-small branch.
+  # https://github.com/NixOS/nixpkgs/tree/nixos-22.11-small
+  #
+  # When you change this, also change the sha256 hash!
+  rev = "a45745ac9e4e1eb86397ab22e2a8823120ab9a4c";
+in
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+  sha256 = "sha256:1acllp8yxp1rwncxsxnxl9cwkm97wxfnd6ryclmvll3sa39j9b1z";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+let
+  pkgsSrc = import ./nix/nixpkgs.nix;
+  pkgs = import pkgsSrc {};
+in
+pkgs.mkShell rec {
+  nativeBuildInputs = with pkgs; [
+  ];
+
+  buildInputs = with pkgs; [
+  ];
+
+  # Set ENV vars.
+  # These are automatically the right files for the current CPU (if available).
+  # https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/applications/virtualization/OVMF/default.nix#L80
+  OVMF_CODE="${pkgs.OVMF.firmware}";
+  OVMF_VARS="${pkgs.OVMF.variables}";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,8 @@ let
 in
 pkgs.mkShell rec {
   nativeBuildInputs = with pkgs; [
+    rustup
+    qemu
   ];
 
   buildInputs = with pkgs; [

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,7 @@ heck = "0.4.0"
 itertools = "0.10.5"
 mbrman = "0.5.1"
 nix = "0.26.1"
+os_info = { version = "3.6.0", default-features = false }
 proc-macro2 = "1.0.46"
 quote = "1.0.21"
 regex = "1.5.4"

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -5,7 +5,7 @@ use crate::pipe::Pipe;
 use crate::tpm::Swtpm;
 use crate::util::command_to_string;
 use crate::{net, platform};
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use regex::bytes::Regex;
 use serde_json::{json, Value};
 use std::env;
@@ -14,6 +14,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use tempfile::TempDir;
+#[cfg(target_os = "linux")]
+use {std::fs::Permissions, std::os::unix::fs::PermissionsExt};
 
 #[derive(Clone, Copy, Debug)]
 enum OvmfFileType {
@@ -60,6 +62,18 @@ struct OvmfPaths {
 }
 
 impl OvmfPaths {
+    /// If OVMF files can not or should not be found at well-known locations,
+    /// this optional environment variable can point to it.
+    ///
+    /// This variable points to the `_CODE.fd` file.
+
+    const ENV_VAR_OVMF_CODE: &'static str = "OVMF_CODE";
+    /// If OVMF files can not or should not be found at well-known locations,
+    /// this optional environment variable can point to it.
+    ///
+    /// This variable points to the `_VARS.fd` file.
+    const ENV_VAR_OVMF_VARS: &'static str = "OVMF_VARS";
+
     fn get_path(&self, file_type: OvmfFileType) -> &Path {
         match file_type {
             OvmfFileType::Code => &self.code,
@@ -151,6 +165,24 @@ impl OvmfPaths {
         }
     }
 
+    /// If a user uses NixOS, this function returns an error if the user didn't
+    /// set the environment variables `OVMF_CODE` and `OVMF_VARS`.
+    ///
+    /// It returns nothing as the environment variables are resolved at a
+    /// higher level. NixOS doesn't have globally installed software (without
+    /// hacky and non-idiomatic workarounds).
+    fn assist_nixos_users() -> Result<()> {
+        let os_info = os_info::get();
+        if os_info.os_type() == os_info::Type::NixOS {
+            let code = env::var_os(Self::ENV_VAR_OVMF_CODE);
+            let vars = env::var_os(Self::ENV_VAR_OVMF_VARS);
+            if !matches!((code, vars), (Some(_), Some(_))) {
+                return Err(anyhow!("Run `$ nix-shell` for OVMF files."));
+            }
+        }
+        Ok(())
+    }
+
     /// Get the Windows OVMF paths for the given guest arch.
     fn windows(arch: UefiArch) -> Self {
         match arch {
@@ -172,7 +204,7 @@ impl OvmfPaths {
 
     /// Get candidate paths where OVMF code/vars might exist for the
     /// given guest arch and host platform.
-    fn get_candidate_paths(arch: UefiArch) -> Vec<Self> {
+    fn get_candidate_paths(arch: UefiArch) -> Result<Vec<Self>> {
         let mut candidates = Vec::new();
         if platform::is_linux() {
             candidates.push(Self::arch_linux(arch));
@@ -181,20 +213,21 @@ impl OvmfPaths {
             }
             candidates.push(Self::debian_linux(arch));
             candidates.push(Self::fedora_linux(arch));
+            Self::assist_nixos_users()?;
         }
         if platform::is_windows() {
             candidates.push(Self::windows(arch));
         }
-        candidates
+        Ok(candidates)
     }
 
     /// Search for an OVMF file (either code or vars).
     ///
-    /// If `user_provided_path` is not None, it is always used. An error
-    /// is returned if the path does not exist.
-    ///
-    /// Otherwise, the paths in `candidates` are searched to find one
-    /// that exists. If none of them exist, an error is returned.
+    /// There are multiple locations where a file is searched at in the following
+    /// priority:
+    /// 1. User-defined location: See [`OvmfFileType::get_user_provided_path`]
+    /// 2. Well-known location of common Linux distributions by using the
+    ///    paths in `candidates`.
     fn find_ovmf_file(
         file_type: OvmfFileType,
         opt: &QemuOpt,
@@ -231,9 +264,10 @@ impl OvmfPaths {
         }
     }
 
-    /// Find path to OVMF files.
+    /// Find path to OVMF files by the strategy documented for
+    /// [`Self::find_ovmf_file`].
     fn find(opt: &QemuOpt, arch: UefiArch) -> Result<Self> {
-        let candidates = Self::get_candidate_paths(arch);
+        let candidates = Self::get_candidate_paths(arch)?;
 
         let code = Self::find_ovmf_file(OvmfFileType::Code, opt, &candidates)?;
         let vars = Self::find_ovmf_file(OvmfFileType::Vars, opt, &candidates)?;
@@ -521,6 +555,10 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // versions of OVMF won't boot if the vars file isn't writeable.
     let ovmf_vars = tmp_dir.join("ovmf_vars");
     fs_err::copy(&ovmf_paths.vars, &ovmf_vars)?;
+    // Necessary, as for example on NixOS, the files are read-only inside
+    // the Nix store.
+    #[cfg(target_os = "linux")]
+    fs_err::set_permissions(&ovmf_vars, Permissions::from_mode(0o666))?;
 
     add_pflash_args(&mut cmd, &ovmf_paths.code, PflashMode::ReadOnly);
     add_pflash_args(&mut cmd, &ovmf_vars, PflashMode::ReadWrite);


### PR DESCRIPTION
This enables to run `cargo xtask run` under NixOS. The challenge is to find the OVMF files.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
