### PR TITLE
error: enable core::error::Error for all error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   `HandleBuffer::handles` and `ProtocolsPerHandle::protocols` methods have been
   deprecated.
 - Removed `'boot` lifetime from the `Output` protocol.
+- The generic type `Data` of `uefi::Error<Data: Debug>` doesn't need to be
+  `Display` to be compatible with `core::error::Error`. Note that the error
+  Trait requires the `unstable` feature.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -1,8 +1,11 @@
+//! Module for UEFI-specific error encodings. See [`Error`].
+
 use super::Status;
 use core::fmt::{Debug, Display};
 
-/// Errors emitted from UEFI entry point must propagate erroneous UEFI statuses,
-/// and may optionally propagate additional entry point-specific data.
+/// An UEFI-related error with optionally additional payload data. The error
+/// kind is encoded in the `status` field (see [`Status`]). Additional payload
+/// may be inside the `data` field.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error<Data: Debug = ()> {
     status: Status,

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -1,7 +1,7 @@
 use super::Status;
 use core::fmt::{Debug, Display};
 
-/// Errors emitted from UEFI entry point must propagate erronerous UEFI statuses,
+/// Errors emitted from UEFI entry point must propagate erroneous UEFI statuses,
 /// and may optionally propagate additional entry point-specific data.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error<Data: Debug = ()> {
@@ -40,11 +40,11 @@ impl From<Status> for Error<()> {
     }
 }
 
-impl<Data: Debug + Display> Display for Error<Data> {
+impl<Data: Debug> Display for Error<Data> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "UEFI Error {}: {}", self.status(), self.data())
+        write!(f, "UEFI Error {}: {:?}", self.status(), self.data())
     }
 }
 
 #[cfg(feature = "unstable")]
-impl<Data: Debug + Display> core::error::Error for Error<Data> {}
+impl<Data: Debug> core::error::Error for Error<Data> {}


### PR DESCRIPTION
Implements a solution for the discussion in https://github.com/rust-osdev/uefi-rs/issues/691.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
