### PR TITLE
Remove some more protocol lifetime parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 - `HandleBuffer` and `ProtocolsPerHandle` now implement `Deref`. The
   `HandleBuffer::handles` and `ProtocolsPerHandle::protocols` methods have been
   deprecated.
-- Removed `'boot` lifetime from the `Output` protocol.
+- Removed `'boot` lifetime from the `GraphicsOutput`, `Output`, `Pointer`, and
+  `Serial` protocols.
 - The generic type `Data` of `uefi::Error<Data: Debug>` doesn't need to be
   `Display` to be compatible with `core::error::Error`. Note that the error
   Trait requires the `unstable` feature.

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -7,14 +7,14 @@ use core::mem::MaybeUninit;
 /// Provides information about a pointer device.
 #[repr(C)]
 #[unsafe_protocol("31878c87-0b75-11d5-9a4f-0090273fc14d")]
-pub struct Pointer<'boot> {
+pub struct Pointer {
     reset: extern "efiapi" fn(this: &mut Pointer, ext_verif: bool) -> Status,
     get_state: extern "efiapi" fn(this: &Pointer, state: *mut PointerState) -> Status,
     wait_for_input: Event,
-    mode: &'boot PointerMode,
+    mode: *const PointerMode,
 }
 
-impl<'boot> Pointer<'boot> {
+impl Pointer {
     /// Resets the pointer device hardware.
     ///
     /// The `extended_verification` parameter is used to request that UEFI
@@ -54,7 +54,7 @@ impl<'boot> Pointer<'boot> {
     /// Returns a reference to the pointer device information.
     #[must_use]
     pub const fn mode(&self) -> &PointerMode {
-        self.mode
+        unsafe { &*self.mode }
     }
 }
 


### PR DESCRIPTION
Similar to https://github.com/rust-osdev/uefi-rs/pull/689, drop some `'boot` lifetimes from a few more older protocol implementations. These protocols have internal data pointers, and they are best expressed as raw pointers because we don't actually control the lifetime. When returning the data via a method we can tie the borrow's lifetime to `&self`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
