### PR TITLE
uefi: Implement Borrow/ToOwned for CString16/CStr16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   to `ComponentName1` otherwise.
 - `FileType`, `FileHandle`, `RegularFile`, and `Directory` now implement `Debug`.
 - Added `RuntimeServices::delete_variable()` helper method.
+- Implement `Borrow` for `CString16` and `ToOwned` for `CStr16`.
 
 ### Changed
 


### PR DESCRIPTION
`CString16` can be borrowed as `&CStr16`, and `CStr16` can be converted to `CString16` with `to_owned()`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
