### PR TITLE
xtask: Upgrade to syn 2.0

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro2 = "1.0.46"
 quote = "1.0.21"
 regex = "1.5.4"
 serde_json = "1.0.73"
-syn = { version = "1.0.101", features = ["full"] }
+syn = { version = "2.0.0", features = ["full"] }
 tempfile = "3.2.0"

--- a/xtask/src/device_path/group.rs
+++ b/xtask/src/device_path/group.rs
@@ -2,7 +2,7 @@ use super::node::{is_node_attr, Node};
 use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Attribute, Ident, Item, ItemMod, ItemStruct, Meta};
+use syn::{Attribute, Ident, Item, ItemMod, ItemStruct};
 
 #[derive(Clone)]
 pub struct DeviceType(Ident);
@@ -170,14 +170,7 @@ impl NodeGroup {
 }
 
 fn is_build_attr(attr: &Attribute) -> bool {
-    if let Ok(Meta::Path(path)) = attr.parse_meta() {
-        if let Some(ident) = path.get_ident() {
-            if ident == "build" {
-                return true;
-            }
-        }
-    }
-    false
+    attr.path().is_ident("build")
 }
 
 fn has_build_attr(item: &Item) -> bool {

--- a/xtask/src/device_path/util.rs
+++ b/xtask/src/device_path/util.rs
@@ -2,18 +2,12 @@ use anyhow::{bail, Context, Result};
 use std::io::Write;
 use std::process::{Command, Stdio};
 use std::thread;
-use syn::{Attribute, Meta};
+use syn::Attribute;
 
 /// Returns true if the attribute is a `#[doc = "..."]` attribute,
 /// otherwise returns false.
 pub fn is_doc_attr(attr: &Attribute) -> bool {
-    if let Ok(Meta::NameValue(nv)) = attr.parse_meta() {
-        if let Some(ident) = nv.path.get_ident() {
-            return ident == "doc";
-        }
-    }
-
-    false
+    attr.path().is_ident("doc")
 }
 
 /// Run `rustfmt` on the `input` string and return the formatted code.


### PR DESCRIPTION
Some changes needed to use the new API for parsing attributes.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
