### PR TITLE
debug everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Rust 1.68 or higher.
 - `FileType`, `FileHandle`, `RegularFile`, and `Directory` now implement `Debug`.
 - Added `RuntimeServices::delete_variable()` helper method.
 - Implement `Borrow` for `CString16` and `ToOwned` for `CStr16`.
+- Every public struct now implements `Debug`. Exceptions are cases when there
+  is no sensible way of presenting a useful Debug representation, such as for
+  Unions.
 
 ### Changed
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -28,6 +28,7 @@
 
 #![no_std]
 #![deny(clippy::must_use_candidate)]
+#![deny(missing_debug_implementations)]
 
 extern crate log;
 // Core types.

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -49,6 +49,7 @@ pub fn exit_boot_services() {
 /// Allocator which uses the UEFI pool allocation functions.
 ///
 /// Only valid for as long as the UEFI boot services are available.
+#[derive(Debug)]
 pub struct Allocator;
 
 unsafe impl GlobalAlloc for Allocator {

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -41,6 +41,7 @@ impl Handle {
 ///
 /// If you need to have a nullable event, use `Option<Event>`.
 #[repr(transparent)]
+#[derive(Debug)]
 pub struct Event(NonNull<c_void>);
 
 impl Event {

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -163,6 +163,7 @@ impl<'a, T: Copy> IntoIterator for &'a UnalignedSlice<'a, T> {
 }
 
 /// Iterator for a [`UnalignedSlice`].
+#[derive(Debug)]
 pub struct UnalignedSliceIntoIter<'a, T: Copy> {
     slice: UnalignedSlice<'a, T>,
     index: usize,
@@ -179,6 +180,7 @@ impl<'a, T: Copy> Iterator for UnalignedSliceIntoIter<'a, T> {
 }
 
 /// Iterator for a [`UnalignedSlice`] reference.
+#[derive(Debug)]
 pub struct UnalignedSliceIter<'a, T: Copy> {
     slice: &'a UnalignedSlice<'a, T>,
     index: usize,

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -83,6 +83,7 @@
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
 #![deny(clippy::all)]
 #![deny(clippy::must_use_candidate)]
+#![deny(missing_debug_implementations)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/uefi/src/logger.rs
+++ b/uefi/src/logger.rs
@@ -22,6 +22,7 @@ use core::ptr::NonNull;
 /// If this logger is used as a global logger, you must disable it using the
 /// `disable` method before exiting UEFI boot services in order to prevent
 /// undefined behaviour from inadvertent logging.
+#[derive(Debug)]
 pub struct Logger {
     writer: Option<NonNull<Output>>,
 }

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -53,6 +53,7 @@
 use crate::proto::unsafe_protocol;
 use crate::util::usize_from_u32;
 use crate::{Result, Status};
+use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
@@ -375,6 +376,7 @@ pub struct PixelBitmask {
 }
 
 /// Represents a graphics mode compatible with a given graphics device.
+#[derive(Debug)]
 pub struct Mode {
     index: u32,
     info_sz: usize,
@@ -469,6 +471,15 @@ impl<'gop> Iterator for ModeIter<'gop> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let size = (self.max - self.current) as usize;
         (size, Some(size))
+    }
+}
+
+impl<'gop> Debug for ModeIter<'gop> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModeIter")
+            .field("current", &self.current)
+            .field("max", &self.max)
+            .finish()
     }
 }
 
@@ -578,6 +589,7 @@ pub enum BltOp<'buf> {
 }
 
 /// Direct access to a memory-mapped frame buffer
+#[derive(Debug)]
 pub struct FrameBuffer<'gop> {
     base: *mut u8,
     size: usize,

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -111,6 +111,7 @@ impl From<RawKey> for Key {
 
 /// A key read from the console (UEFI version)
 #[repr(C)]
+#[derive(Debug)]
 pub struct RawKey {
     /// The key's scan code.
     /// or 0 if printable

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -288,6 +288,7 @@ impl OutputMode {
 }
 
 /// An iterator of the text modes (possibly) supported by a device.
+#[derive(Debug)]
 pub struct OutputModeIter<'out> {
     output: &'out mut Output,
     current: usize,

--- a/uefi/src/proto/debug/context.rs
+++ b/uefi/src/proto/debug/context.rs
@@ -4,6 +4,7 @@
 /// Universal EFI_SYSTEM_CONTEXT definition
 /// This is passed to debug callbacks
 #[repr(C)]
+#[allow(missing_debug_implementations)]
 pub union SystemContext {
     ebc: *mut SystemContextEBC,
     riscv_32: *mut SystemContextRiscV32,

--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -1,5 +1,6 @@
 /// Represents supported CPU exceptions.
 #[repr(C)]
+#[derive(Debug)]
 pub struct ExceptionType(isize);
 
 impl ExceptionType {

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -69,6 +69,7 @@ use alloc::vec::Vec;
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct DevicePathBuilder<'a> {
     storage: BuilderStorage<'a>,
 }
@@ -143,6 +144,7 @@ impl<'a> DevicePathBuilder<'a> {
     }
 }
 
+#[derive(Debug)]
 enum BuilderStorage<'a> {
     Buf {
         buf: &'a mut [MaybeUninit<u8>],

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -3038,6 +3038,7 @@ pub mod bios_boot_spec {
 
 /// Enum of references to all the different device path node
 /// types. Return type of [`DevicePathNode::as_enum`].
+#[derive(Debug)]
 pub enum DevicePathNodeEnum<'a> {
     /// Node that terminates a [`DevicePathInstance`].
     ///
@@ -3324,6 +3325,7 @@ pub mod build {
         /// Node that terminates a [`DevicePathInstance`].
         ///
         /// [`DevicePathInstance`]: crate::proto::device_path::DevicePathInstance
+        #[derive(Debug)]
         pub struct Instance;
         unsafe impl BuildNode for Instance {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
@@ -3350,6 +3352,7 @@ pub mod build {
         /// Node that terminates an entire [`DevicePath`].
         ///
         /// [`DevicePath`]: crate::proto::device_path::DevicePath
+        #[derive(Debug)]
         pub struct Entire;
         unsafe impl BuildNode for Entire {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
@@ -3378,6 +3381,7 @@ pub mod build {
     pub mod hardware {
         use super::*;
         /// PCI hardware device path node.
+        #[derive(Debug)]
         pub struct Pci {
             /// PCI function number.
             pub function: u8,
@@ -3416,6 +3420,7 @@ pub mod build {
         }
 
         /// PCCARD hardware device path node.
+        #[derive(Debug)]
         pub struct Pccard {
             /// Function number starting from 0.
             pub function: u8,
@@ -3448,6 +3453,7 @@ pub mod build {
         }
 
         /// Memory mapped hardware device path node.
+        #[derive(Debug)]
         pub struct MemoryMapped {
             /// Memory type.
             pub memory_type: MemoryType,
@@ -3492,6 +3498,7 @@ pub mod build {
         }
 
         /// Vendor-defined hardware device path node.
+        #[derive(Debug)]
         pub struct Vendor<'a> {
             /// Vendor-assigned GUID that defines the data that follows.
             pub vendor_guid: Guid,
@@ -3533,6 +3540,7 @@ pub mod build {
         }
 
         /// Controller hardware device path node.
+        #[derive(Debug)]
         pub struct Controller {
             /// Controller number.
             pub controller_number: u32,
@@ -3566,6 +3574,7 @@ pub mod build {
 
         /// Baseboard Management Controller (BMC) host interface hardware
         /// device path node.
+        #[derive(Debug)]
         pub struct Bmc {
             /// Host interface type.
             pub interface_type: crate::proto::device_path::hardware::BmcInterfaceType,
@@ -3610,6 +3619,7 @@ pub mod build {
     pub mod acpi {
         use super::*;
         /// ACPI device path node.
+        #[derive(Debug)]
         pub struct Acpi {
             /// Device's PnP hardware ID stored in a numeric 32-bit
             /// compressed EISA-type ID.
@@ -3644,6 +3654,7 @@ pub mod build {
         }
 
         /// Expanded ACPI device path node.
+        #[derive(Debug)]
         pub struct Expanded<'a> {
             /// Device's PnP hardware ID stored in a numeric 32-bit compressed
             /// EISA-type ID.
@@ -3715,6 +3726,7 @@ pub mod build {
         }
 
         /// ADR ACPI device path node.
+        #[derive(Debug)]
         pub struct Adr<'a> {
             /// ADR values. For video output devices the value of this field
             /// comes from Table B-2 ACPI 3.0 specification. At least one
@@ -3749,6 +3761,7 @@ pub mod build {
         }
 
         /// NVDIMM ACPI device path node.
+        #[derive(Debug)]
         pub struct Nvdimm {
             /// NFIT device handle.
             pub nfit_device_handle: u32,
@@ -3783,6 +3796,7 @@ pub mod build {
         /// Wrapper for [`u32`] ADR values that enforces at least one
         /// element is present.
         #[repr(transparent)]
+        #[derive(Debug)]
         pub struct AdrSlice([u32]);
         impl AdrSlice {
             /// Create a new `AdrSlice`. Returns `None` if the input slice
@@ -3807,6 +3821,7 @@ pub mod build {
     pub mod messaging {
         use super::*;
         /// ATAPI messaging device path node.
+        #[derive(Debug)]
         pub struct Atapi {
             /// Whether the ATAPI device is primary or secondary.
             pub primary_secondary: crate::proto::device_path::messaging::PrimarySecondary,
@@ -3851,6 +3866,7 @@ pub mod build {
         }
 
         /// SCSI messaging device path node.
+        #[derive(Debug)]
         pub struct Scsi {
             /// Target ID on the SCSI bus.
             pub target_id: u16,
@@ -3889,6 +3905,7 @@ pub mod build {
         }
 
         /// Fibre channel messaging device path node.
+        #[derive(Debug)]
         pub struct FibreChannel {
             /// Fibre Channel World Wide Name.
             pub world_wide_name: u64,
@@ -3928,6 +3945,7 @@ pub mod build {
         }
 
         /// Fibre channel extended messaging device path node.
+        #[derive(Debug)]
         pub struct FibreChannelEx {
             /// Fibre Channel end device port name (aka World Wide Name).
             pub world_wide_name: [u8; 8usize],
@@ -3967,6 +3985,7 @@ pub mod build {
         }
 
         /// 1394 messaging device path node.
+        #[derive(Debug)]
         pub struct Ieee1394 {
             /// 1394 Global Unique ID. Note that this is not the same as a
             /// UEFI GUID.
@@ -4001,6 +4020,7 @@ pub mod build {
         }
 
         /// USB messaging device path node.
+        #[derive(Debug)]
         pub struct Usb {
             /// USB parent port number.
             pub parent_port_number: u8,
@@ -4039,6 +4059,7 @@ pub mod build {
         }
 
         /// SATA messaging device path node.
+        #[derive(Debug)]
         pub struct Sata {
             /// The HBA port number that facilitates the connection to the
             /// device or a port multiplier. The value 0xffff is reserved.
@@ -4086,6 +4107,7 @@ pub mod build {
         }
 
         /// USB World Wide ID (WWID) messaging device path node.
+        #[derive(Debug)]
         pub struct UsbWwid<'a> {
             /// USB interface number.
             pub interface_number: u16,
@@ -4139,6 +4161,7 @@ pub mod build {
         }
 
         /// Device logical unit messaging device path node.
+        #[derive(Debug)]
         pub struct DeviceLogicalUnit {
             /// Logical Unit Number.
             pub logical_unit_number: u8,
@@ -4171,6 +4194,7 @@ pub mod build {
         }
 
         /// USB class messaging device path node.
+        #[derive(Debug)]
         pub struct UsbClass {
             /// USB vendor ID.
             pub vendor_id: u16,
@@ -4227,6 +4251,7 @@ pub mod build {
         }
 
         /// I2O messaging device path node.
+        #[derive(Debug)]
         pub struct I2o {
             /// Target ID (TID).
             pub target_id: u32,
@@ -4259,6 +4284,7 @@ pub mod build {
         }
 
         /// MAC address messaging device path node.
+        #[derive(Debug)]
         pub struct MacAddress {
             /// MAC address for a network interface, padded with zeros.
             pub mac_address: [u8; 32usize],
@@ -4298,6 +4324,7 @@ pub mod build {
         }
 
         /// IPv4 messaging device path node.
+        #[derive(Debug)]
         pub struct Ipv4 {
             /// Local IPv4 address.
             pub local_ip_address: [u8; 4usize],
@@ -4373,6 +4400,7 @@ pub mod build {
         }
 
         /// IPv6 messaging device path node.
+        #[derive(Debug)]
         pub struct Ipv6 {
             /// Local Ipv6 address.
             pub local_ip_address: [u8; 16usize],
@@ -4448,6 +4476,7 @@ pub mod build {
         }
 
         /// VLAN messaging device path node.
+        #[derive(Debug)]
         pub struct Vlan {
             /// VLAN identifier (0-4094).
             pub vlan_id: u16,
@@ -4480,6 +4509,7 @@ pub mod build {
         }
 
         /// InfiniBand messaging device path node.
+        #[derive(Debug)]
         pub struct Infiniband {
             /// Flags to identify/manage InfiniBand elements.
             pub resource_flags: crate::proto::device_path::messaging::InfinibandResourceFlags,
@@ -4538,6 +4568,7 @@ pub mod build {
         }
 
         /// UART messaging device path node.
+        #[derive(Debug)]
         pub struct Uart {
             /// Baud rate setting, or 0 to use the device's default.
             pub baud_rate: u64,
@@ -4589,6 +4620,7 @@ pub mod build {
         }
 
         /// Vendor-defined messaging device path node.
+        #[derive(Debug)]
         pub struct Vendor<'a> {
             /// Vendor-assigned GUID that defines the data that follows.
             pub vendor_guid: Guid,
@@ -4630,6 +4662,7 @@ pub mod build {
         }
 
         /// Serial Attached SCSI (SAS) extended messaging device path node.
+        #[derive(Debug)]
         pub struct SasEx {
             /// SAS address.
             pub sas_address: [u8; 8usize],
@@ -4680,6 +4713,7 @@ pub mod build {
         }
 
         /// iSCSI messaging device path node.
+        #[derive(Debug)]
         pub struct Iscsi<'a> {
             /// Network protocol.
             pub protocol: crate::proto::device_path::messaging::IscsiProtocol,
@@ -4744,6 +4778,7 @@ pub mod build {
         }
 
         /// NVM Express namespace messaging device path node.
+        #[derive(Debug)]
         pub struct NvmeNamespace {
             /// Namespace identifier (NSID). The values 0 and 0xffff_ffff
             /// are invalid.
@@ -4784,6 +4819,7 @@ pub mod build {
         }
 
         /// Uniform Resource Identifier (URI) messaging device path node.
+        #[derive(Debug)]
         pub struct Uri<'a> {
             /// URI as defined by [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986).
             pub value: &'a [u8],
@@ -4816,6 +4852,7 @@ pub mod build {
         }
 
         /// Universal Flash Storage (UFS) messaging device path node.
+        #[derive(Debug)]
         pub struct Ufs {
             /// Target ID on the UFS interface (PUN).
             pub target_id: u8,
@@ -4854,6 +4891,7 @@ pub mod build {
         }
 
         /// Secure Digital (SD) messaging device path node.
+        #[derive(Debug)]
         pub struct Sd {
             /// Slot number.
             pub slot_number: u8,
@@ -4886,6 +4924,7 @@ pub mod build {
         }
 
         /// Bluetooth messaging device path node.
+        #[derive(Debug)]
         pub struct Bluetooth {
             /// 48-bit bluetooth device address.
             pub device_address: [u8; 6usize],
@@ -4918,6 +4957,7 @@ pub mod build {
         }
 
         /// Wi-Fi messaging device path node.
+        #[derive(Debug)]
         pub struct Wifi {
             /// Service set identifier (SSID).
             pub ssid: [u8; 32usize],
@@ -4950,6 +4990,7 @@ pub mod build {
         }
 
         /// Embedded Multi-Media Card (eMMC) messaging device path node.
+        #[derive(Debug)]
         pub struct Emmc {
             /// Slot number.
             pub slot_number: u8,
@@ -4982,6 +5023,7 @@ pub mod build {
         }
 
         /// BluetoothLE messaging device path node.
+        #[derive(Debug)]
         pub struct BluetoothLe {
             /// 48-bit bluetooth device address.
             pub device_address: [u8; 6usize],
@@ -5020,6 +5062,7 @@ pub mod build {
         }
 
         /// DNS messaging device path node.
+        #[derive(Debug)]
         pub struct Dns<'a> {
             /// Whether the addresses are IPv4 or IPv6.
             pub address_type: crate::proto::device_path::messaging::DnsAddressType,
@@ -5058,6 +5101,7 @@ pub mod build {
         }
 
         /// NVDIMM namespace messaging device path node.
+        #[derive(Debug)]
         pub struct NvdimmNamespace {
             /// Namespace unique label identifier.
             pub uuid: [u8; 16usize],
@@ -5090,6 +5134,7 @@ pub mod build {
         }
 
         /// REST service messaging device path node.
+        #[derive(Debug)]
         pub struct RestService<'a> {
             /// Type of REST service.
             pub service_type: crate::proto::device_path::messaging::RestServiceType,
@@ -5133,6 +5178,7 @@ pub mod build {
         }
 
         /// NVME over Fabric (NVMe-oF) namespace messaging device path node.
+        #[derive(Debug)]
         pub struct NvmeOfNamespace<'a> {
             /// Namespace Identifier Type (NIDT).
             pub nidt: u8,
@@ -5180,6 +5226,7 @@ pub mod build {
         /// Vendor-specific REST service data. Only used for service type [`VENDOR`].
         ///
         /// [`VENDOR`]: uefi::proto::device_path::messaging::RestServiceType
+        #[derive(Debug)]
         pub struct RestServiceVendorData<'a> {
             /// Vendor GUID.
             pub vendor_guid: Guid,
@@ -5227,6 +5274,7 @@ pub mod build {
     pub mod media {
         use super::*;
         /// Hard drive media device path node.
+        #[derive(Debug)]
         pub struct HardDrive {
             /// Index of the partition, starting from 1.
             pub partition_number: u32,
@@ -5287,6 +5335,7 @@ pub mod build {
         }
 
         /// CD-ROM media device path node.
+        #[derive(Debug)]
         pub struct CdRom {
             /// Boot entry number from the boot catalog, or 0 for the
             /// default entry.
@@ -5332,6 +5381,7 @@ pub mod build {
         }
 
         /// Vendor-defined media device path node.
+        #[derive(Debug)]
         pub struct Vendor<'a> {
             /// Vendor-assigned GUID that defines the data that follows.
             pub vendor_guid: Guid,
@@ -5373,6 +5423,7 @@ pub mod build {
         }
 
         /// File path media device path node.
+        #[derive(Debug)]
         pub struct FilePath<'a> {
             /// Null-terminated path.
             pub path_name: &'a CStr16,
@@ -5405,6 +5456,7 @@ pub mod build {
         }
 
         /// Media protocol media device path node.
+        #[derive(Debug)]
         pub struct Protocol {
             /// The ID of the protocol.
             pub protocol_guid: Guid,
@@ -5437,6 +5489,7 @@ pub mod build {
         }
 
         /// PIWG firmware file media device path node.
+        #[derive(Debug)]
         pub struct PiwgFirmwareFile<'a> {
             /// Contents are defined in the UEFI PI Specification.
             pub data: &'a [u8],
@@ -5469,6 +5522,7 @@ pub mod build {
         }
 
         /// PIWG firmware volume media device path node.
+        #[derive(Debug)]
         pub struct PiwgFirmwareVolume<'a> {
             /// Contents are defined in the UEFI PI Specification.
             pub data: &'a [u8],
@@ -5501,6 +5555,7 @@ pub mod build {
         }
 
         /// Relative offset range media device path node.
+        #[derive(Debug)]
         pub struct RelativeOffsetRange {
             /// Offset of the first byte, relative to the parent device node.
             pub starting_offset: u64,
@@ -5540,6 +5595,7 @@ pub mod build {
         }
 
         /// RAM disk media device path node.
+        #[derive(Debug)]
         pub struct RamDisk {
             /// Starting memory address.
             pub starting_address: u64,
@@ -5621,6 +5677,7 @@ pub mod build {
     pub mod bios_boot_spec {
         use super::*;
         /// BIOS Boot Specification device path node.
+        #[derive(Debug)]
         pub struct BootSpecification<'a> {
             /// Device type as defined by the BIOS Boot Specification.
             pub device_type: u16,

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -93,6 +93,7 @@ use ptr_meta::Pointee;
 /// type produces a thin pointer, unlike [`DevicePath`] and
 /// [`DevicePathNode`].
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct FfiDevicePath {
     // This representation is recommended by the nomicon:
     // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
@@ -349,6 +350,7 @@ impl PartialEq for DevicePath {
 /// Iterator over the [`DevicePathInstance`]s in a [`DevicePath`].
 ///
 /// This struct is returned by [`DevicePath::instance_iter`].
+#[derive(Debug)]
 pub struct DevicePathInstanceIterator<'a> {
     remaining_path: Option<&'a DevicePath>,
 }
@@ -397,6 +399,7 @@ impl<'a> Iterator for DevicePathInstanceIterator<'a> {
     }
 }
 
+#[derive(Debug)]
 enum StopCondition {
     AnyEndNode,
     EndEntireNode,
@@ -407,6 +410,7 @@ enum StopCondition {
 ///
 /// This struct is returned by [`DevicePath::node_iter`] and
 /// [`DevicePathInstance::node_iter`].
+#[derive(Debug)]
 pub struct DevicePathNodeIterator<'a> {
     nodes: &'a [u8],
     stop_condition: StopCondition,

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -25,7 +25,7 @@ use core::ops::Deref;
 /// representation of the display node is used, where applicable.
 /// If `display_only` is FALSE, then the longer text representation
 /// of the display node is used.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DisplayOnly(pub bool);
 
 /// This struct is a wrapper of `allow_shortcuts` parameter
@@ -37,11 +37,12 @@ pub struct DisplayOnly(pub bool);
 /// type or subtype. If `allow_shortcuts is TRUE, then the
 /// shortcut forms of text representation for a device node
 /// can be used, where applicable.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct AllowShortcuts(pub bool);
 
 /// Wrapper for a string internally allocated from
 /// UEFI boot services memory.
+#[derive(Debug)]
 pub struct PoolString<'a> {
     boot_services: &'a BootServices,
     text: *const Char16,

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -7,6 +7,7 @@
 use crate::proto::unsafe_protocol;
 use crate::table::boot::{BootServices, ScopedProtocol};
 use crate::{CStr16, Error, Handle, Result, Status};
+use core::fmt::{Debug, Formatter};
 use core::{ptr, slice};
 
 /// Protocol that provides human-readable names for a driver and for each of the
@@ -239,6 +240,15 @@ impl<'a> ComponentName<'a> {
     }
 }
 
+impl<'a> Debug for ComponentName<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ComponentName::V1(_) => f.debug_tuple("V1").finish(),
+            ComponentName::V2(_) => f.debug_tuple("V2").finish(),
+        }
+    }
+}
+
 /// Error returned by [`ComponentName1::supported_languages`] and
 /// [`ComponentName2::supported_languages`].
 #[derive(Debug, Eq, PartialEq)]
@@ -251,7 +261,7 @@ pub enum LanguageError {
     },
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 enum LanguageIterKind {
     V1,
     V2,
@@ -259,6 +269,7 @@ enum LanguageIterKind {
 
 /// Iterator returned by [`ComponentName1::supported_languages`] and
 /// [`ComponentName2::supported_languages`].
+#[derive(Debug)]
 pub struct LanguageIter<'a> {
     languages: &'a [u8],
     kind: LanguageIterKind,

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -71,6 +71,7 @@ impl DiskIo {
 
 /// Asynchronous transaction token for disk I/O 2 operations.
 #[repr(C)]
+#[derive(Debug)]
 pub struct DiskIo2Token {
     /// Event to be signalled when an asynchronous disk I/O operation completes.
     pub event: Option<Event>,

--- a/uefi/src/proto/network/mod.rs
+++ b/uefi/src/proto/network/mod.rs
@@ -8,7 +8,7 @@ pub mod snp;
 /// Represents an IPv4/v6 address.
 ///
 /// Corresponds to the `EFI_IP_ADDRESS` type in the C API.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(C, align(4))]
 pub struct IpAddress(pub [u8; 16]);
 
@@ -34,6 +34,6 @@ impl IpAddress {
 /// Represents a MAC (media access control) address.
 ///
 /// Corresponds to the `EFI_MAC_ADDRESS` type in the C API.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct MacAddress(pub [u8; 32]);

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1,5 +1,6 @@
 //! PXE Base Code protocol.
 
+use core::fmt::{Debug, Formatter};
 use core::{
     ffi::c_void,
     iter::from_fn,
@@ -623,7 +624,7 @@ impl BaseCode {
 /// A type of bootstrap to perform in [`BaseCode::discover`].
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_BOOT_` constants in the C API.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u16)]
 #[allow(missing_docs)]
 pub enum BootstrapType {
@@ -656,6 +657,7 @@ pub enum BootstrapType {
 /// foreign function interfaces. This type produces a thin pointer, unlike
 /// [`DiscoverInfo`].
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct FfiDiscoverInfo {
     // This representation is recommended by the nomicon:
     // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
@@ -667,7 +669,7 @@ pub struct FfiDiscoverInfo {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_DISCOVER_INFO` type in the C API.
 #[repr(C)]
-#[derive(Pointee)]
+#[derive(Debug, Pointee)]
 pub struct DiscoverInfo {
     use_m_cast: bool,
     use_b_cast: bool,
@@ -770,6 +772,7 @@ impl DiscoverInfo {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_SRVLIST` type in the C API.
 #[repr(C)]
+#[derive(Debug)]
 pub struct Server {
     /// The type of Boot Server reply
     pub ty: u16,
@@ -820,7 +823,7 @@ enum TftpOpcode {
 /// MTFTP connection parameters
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_MTFTP_INFO` type in the C API.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct MtftpInfo {
     /// File multicast IP address. This is the IP address to which the server
@@ -866,6 +869,7 @@ bitflags! {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_IP_FILTER` type in the C API.
 #[repr(C)]
+#[derive(Debug)]
 pub struct IpFilter {
     /// A set of filters.
     pub filters: IpFilters,
@@ -929,6 +933,12 @@ pub union Packet {
     dhcpv6: DhcpV6Packet,
 }
 
+impl Debug for Packet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "<binary data>")
+    }
+}
+
 impl AsRef<[u8; 1472]> for Packet {
     fn as_ref(&self) -> &[u8; 1472] {
         unsafe { &self.raw }
@@ -951,7 +961,7 @@ impl AsRef<DhcpV6Packet> for Packet {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_DHCPV4_PACKET` type in the C API.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DhcpV4Packet {
     /// Packet op code / message type.
     pub bootp_opcode: u8,
@@ -1026,7 +1036,7 @@ bitflags! {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_DHCPV6_PACKET` type in the C API.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DhcpV6Packet {
     /// The message type.
     pub message_type: u8,
@@ -1050,6 +1060,7 @@ impl DhcpV6Packet {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_MODE` type in the C API.
 #[repr(C)]
+#[derive(Debug)]
 pub struct Mode {
     /// `true` if this device has been started by calling [`BaseCode::start`].
     /// This field is set to `true` by [`BaseCode::start`] and to `false` by
@@ -1208,6 +1219,7 @@ pub struct Mode {
 ///
 /// Corresponds to the `EFI_PXE_BASE_CODE_ARP_ENTRY` type in the C API.
 #[repr(C)]
+#[derive(Debug)]
 pub struct ArpEntry {
     /// The IP address.
     pub ip_addr: IpAddress,
@@ -1220,6 +1232,7 @@ pub struct ArpEntry {
 /// Corresponds to the `EFI_PXE_BASE_CODE_ROUTE_ENTRY` type in the C API.
 #[repr(C)]
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct RouteEntry {
     pub ip_addr: IpAddress,
     pub subnet_mask: IpAddress,
@@ -1231,6 +1244,7 @@ pub struct RouteEntry {
 /// Corresponds to the `EFI_PXE_BASE_CODE_ICMP_ERROR` type in the C API.
 #[repr(C)]
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct IcmpError {
     pub ty: u8,
     pub code: u8,
@@ -1250,10 +1264,16 @@ pub union IcmpErrorUnion {
     pub echo: IcmpErrorEcho,
 }
 
+impl Debug for IcmpErrorUnion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "<binary data>")
+    }
+}
+
 /// Corresponds to the `Echo` field in the anonymous union inside
 /// `EFI_PXE_BASE_CODE_ICMP_ERROR` in the C API.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[allow(missing_docs)]
 pub struct IcmpErrorEcho {
     pub identifier: u16,
@@ -1265,6 +1285,7 @@ pub struct IcmpErrorEcho {
 /// Corresponds to the `EFI_PXE_BASE_CODE_TFTP_ERROR` type in the C API.
 #[repr(C)]
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct TftpError {
     pub error_code: u8,
     pub error_string: [u8; 127],
@@ -1272,6 +1293,7 @@ pub struct TftpError {
 
 /// Returned by [`BaseCode::tftp_read_dir`].
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct TftpFileInfo<'a> {
     pub filename: &'a CStr8,
     pub size: u64,
@@ -1285,6 +1307,7 @@ pub struct TftpFileInfo<'a> {
 
 /// Returned by [`BaseCode::mtftp_read_dir`].
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct MtftpFileInfo<'a> {
     pub filename: &'a CStr8,
     pub ip_address: IpAddress,

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -532,6 +532,7 @@ impl NetworkStats {
 
 /// The Simple Network Mode
 #[repr(C)]
+#[derive(Debug)]
 pub struct NetworkMode {
     /// Reports the current state of the network interface
     pub state: NetworkState,
@@ -574,7 +575,7 @@ pub struct NetworkMode {
 }
 
 newtype_enum! {
-    /// The state of a network interface
+    /// The state of a network interface.
     pub enum NetworkState: u32 => {
         /// The interface has been stopped
         STOPPED = 0,

--- a/uefi/src/proto/shim/mod.rs
+++ b/uefi/src/proto/shim/mod.rs
@@ -34,7 +34,8 @@ struct Context {
 const SHA1_DIGEST_SIZE: usize = 20;
 const SHA256_DIGEST_SIZE: usize = 32;
 
-/// Authenticode hashes of some UEFI application
+/// Authenticode hashes of some UEFI application.
+#[derive(Debug)]
 pub struct Hashes {
     /// SHA256 Authenticode Digest
     pub sha256: [u8; SHA256_DIGEST_SIZE],

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -228,6 +228,7 @@ impl PartialEq for PcrEvent {
 /// foreign function interfaces. This type produces a thin pointer, unlike
 /// [`PcrEvent`].
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct FfiPcrEvent {
     // This representation is recommended by the nomicon:
     // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
@@ -244,6 +245,7 @@ pub struct FfiPcrEvent {
 /// [`v1::Tcg`]: Tcg
 /// [`v2::Tcg`]: super::v2::Tcg
 /// [`get_event_log_v2`]: super::v2::Tcg::get_event_log_v2
+#[derive(Debug)]
 pub struct EventLog<'a> {
     // Tie the lifetime to the protocol, and by extension, boot services.
     _lifetime: PhantomData<&'a Tcg>,
@@ -292,6 +294,7 @@ impl<'a> EventLog<'a> {
 }
 
 /// Iterator for events in [`EventLog`].
+#[derive(Debug)]
 pub struct EventLogIter<'a> {
     log: &'a EventLog<'a>,
     location: *const u8,
@@ -381,6 +384,7 @@ pub struct Tcg {
 }
 
 /// Return type of [`Tcg::status_check`].
+#[derive(Debug)]
 pub struct StatusCheck<'a> {
     /// Information about the protocol and the TPM device.
     pub protocol_capability: BootServiceCapability,

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -213,6 +213,16 @@ impl PcrEventInputs {
     }
 }
 
+impl Debug for PcrEventInputs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PcrEventInputs")
+            .field("size", &{ self.size })
+            .field("event_header", &self.event_header)
+            .field("event", &"<binary data>")
+            .finish()
+    }
+}
+
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AlgorithmDigestSize {
@@ -313,6 +323,7 @@ impl<'a> EventLogHeader<'a> {
 ///
 /// This type of event log can contain multiple hash types (e.g. SHA-1, SHA-256,
 /// SHA-512, etc).
+#[derive(Debug)]
 pub struct EventLog<'a> {
     // Tie the lifetime to the protocol, and by extension, boot services.
     _lifetime: PhantomData<&'a Tcg>,
@@ -394,6 +405,7 @@ impl<'a> IntoIterator for PcrEventDigests<'a> {
 }
 
 /// Iterator over a list of digests.
+#[derive(Debug)]
 pub struct PcrEventDigestIter<'a> {
     digests: PcrEventDigests<'a>,
     offset: usize,
@@ -511,6 +523,7 @@ impl<'a> PcrEvent<'a> {
 }
 
 /// Iterator for events in [`EventLog`].
+#[derive(Debug)]
 pub struct EventLogIter<'a> {
     log: &'a EventLog<'a>,
     header: Option<EventLogHeader<'a>>,

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1644,6 +1644,7 @@ impl Debug for BootServices {
 
 /// Used as a parameter of [`BootServices::load_image`] to provide the
 /// image source.
+#[derive(Debug)]
 pub enum LoadImageSource<'a> {
     /// Load an image from a buffer. The data will copied from the
     /// buffer, so the input reference doesn't need to remain valid
@@ -1701,6 +1702,7 @@ pub enum Tpl: usize => {
 /// RAII guard for task priority level changes
 ///
 /// Will automatically restore the former task priority level when dropped.
+#[derive(Debug)]
 pub struct TplGuard<'boot> {
     boot_services: &'boot BootServices,
     old_tpl: Tpl,
@@ -1731,6 +1733,7 @@ impl Drop for TplGuard<'_> {
 
 /// Attributes for [`BootServices::open_protocol`].
 #[repr(u32)]
+#[derive(Debug)]
 pub enum OpenProtocolAttributes {
     /// Used by drivers to get a protocol interface for a handle. The
     /// driver will not be informed if the interface is uninstalled or
@@ -1763,6 +1766,7 @@ pub enum OpenProtocolAttributes {
 }
 
 /// Parameters passed to [`BootServices::open_protocol`].
+#[derive(Debug)]
 pub struct OpenProtocolParams {
     /// The handle for the protocol to open.
     pub handle: Handle,
@@ -1783,6 +1787,7 @@ pub struct OpenProtocolParams {
 ///
 /// See also the [`BootServices`] documentation for details of how to open a
 /// protocol and why [`UnsafeCell`] is used.
+#[derive(Debug)]
 pub struct ScopedProtocol<'a, P: Protocol + ?Sized> {
     /// The protocol interface.
     interface: &'a UnsafeCell<P>,
@@ -1982,7 +1987,9 @@ bitflags! {
 #[repr(C)]
 pub struct MemoryMapKey(usize);
 
-/// A structure containing the size of a memory descriptor and the size of the memory map
+/// A structure containing the size of a memory descriptor and the size of the
+/// memory map.
+#[derive(Debug)]
 pub struct MemoryMapSize {
     /// Size of a single memory descriptor in bytes
     pub entry_size: usize,
@@ -1995,6 +2002,7 @@ pub struct MemoryMapSize {
 ///
 /// To iterate over the entries, call [`MemoryMap::entries`]. To get a sorted
 /// map, you manually have to call [`MemoryMap::sort`] first.
+#[derive(Debug)]
 pub struct MemoryMap<'buf> {
     key: MemoryMapKey,
     buf: &'buf mut [u8],
@@ -2195,7 +2203,8 @@ bitflags! {
 /// Raw event notification function
 type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>);
 
-/// Timer events manipulation
+/// Timer events manipulation.
+#[derive(Debug)]
 pub enum TimerTrigger {
     /// Cancel event's timer
     Cancel,
@@ -2211,6 +2220,7 @@ pub enum TimerTrigger {
 
 /// Protocol interface [`Guids`][Guid] that are installed on a [`Handle`] as
 /// returned by [`BootServices::protocols_per_handle`].
+#[derive(Debug)]
 pub struct ProtocolsPerHandle<'a> {
     // The pointer returned by `protocols_per_handle` has to be free'd with
     // `free_pool`, so keep a reference to boot services for that purpose.
@@ -2248,10 +2258,11 @@ impl<'a> ProtocolsPerHandle<'a> {
     }
 }
 
-/// A buffer that contains an array of [`Handles`][Handle] that support the requested protocol.
-/// Returned by [`BootServices::locate_handle_buffer`].
+/// A buffer that contains an array of [`Handles`][Handle] that support the
+/// requested protocol. Returned by [`BootServices::locate_handle_buffer`].
+#[derive(Debug)]
 pub struct HandleBuffer<'a> {
-    // The pointer returned by `locate_handle_buffer` has to be free'd with
+    // The pointer returned by `locate_handle_buffer` has to be freed with
     // `free_pool`, so keep a reference to boot services for that purpose.
     boot_services: &'a BootServices,
     count: usize,

--- a/uefi/src/table/cfg.rs
+++ b/uefi/src/table/cfg.rs
@@ -44,6 +44,7 @@ pub const PROPERTIES_TABLE_GUID: Guid = guid!("880aaca3-4adc-4a04-9079-b74734082
 
 /// This table contains additional information about the UEFI implementation.
 #[repr(C)]
+#[derive(Debug)]
 pub struct PropertiesTable {
     /// Version of the UEFI properties table.
     ///

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -331,7 +331,7 @@ pub struct Time {
 }
 
 /// Input parameters for [`Time::new`].
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TimeParams {
     /// Year in the range `1900..=9999`.
     pub year: u16,

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -11,14 +11,16 @@ use super::boot::{BootServices, MemoryDescriptor, MemoryMap, MemoryType};
 use super::runtime::{ResetType, RuntimeServices};
 use super::{cfg, Header, Revision};
 
-/// Marker trait used to provide different views of the UEFI System Table
+/// Marker trait used to provide different views of the UEFI System Table.
 pub trait SystemTableView {}
 
-/// Marker struct associated with the boot view of the UEFI System Table
+/// Marker struct associated with the boot view of the UEFI System Table.
+#[derive(Debug)]
 pub struct Boot;
 impl SystemTableView for Boot {}
 
-/// Marker struct associated with the run-time view of the UEFI System Table
+/// Marker struct associated with the run-time view of the UEFI System Table.
+#[derive(Debug)]
 pub struct Runtime;
 impl SystemTableView for Runtime {}
 
@@ -44,7 +46,6 @@ impl SystemTableView for Runtime {}
 /// UEFI boot services in the eye of the Rust borrow checker) and a runtime view
 /// will be provided to replace it.
 #[repr(transparent)]
-#[derive(Debug)]
 pub struct SystemTable<View: SystemTableView> {
     table: &'static SystemTableImpl,
     _marker: PhantomData<View>,

--- a/xtask/src/device_path/group.rs
+++ b/xtask/src/device_path/group.rs
@@ -151,6 +151,7 @@ impl NodeGroup {
         quote!(
             /// Enum of references to all the different device path node
             /// types. Return type of [`DevicePathNode::as_enum`].
+            #[derive(Debug)]
             pub enum DevicePathNodeEnum<'a> {
                 #(#variants),*
             }

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -128,6 +128,8 @@ impl Node {
             quote!()
         };
 
+        // For packed structs, we do not need the #[derive(Debug)] as we
+        // generate an implementation.
         quote!(
             #(#struct_docs)*
             #[repr(C, packed)]
@@ -291,6 +293,7 @@ impl Node {
         if self.fields.is_empty() {
             return quote!(
                 #(#struct_docs)*
+                #[derive(Debug)]
                 pub struct #struct_ident;
             );
         }
@@ -315,6 +318,7 @@ impl Node {
         let struct_lifetime = self.builder_lifetime();
         quote!(
             #(#struct_docs)*
+            #[derive(Debug)]
             pub struct #struct_ident #struct_lifetime {
                 #(#fields),*
             }

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -288,6 +288,7 @@ mod acpi {
     /// element is present.
     #[build]
     #[repr(transparent)]
+    #[derive(Debug)]
     pub struct AdrSlice([u32]);
 
     #[build]
@@ -941,6 +942,7 @@ mod messaging {
     ///
     /// [`VENDOR`]: uefi::proto::device_path::messaging::RestServiceType
     #[build]
+    #[derive(Debug)]
     pub struct RestServiceVendorData<'a> {
         /// Vendor GUID.
         pub vendor_guid: Guid,


### PR DESCRIPTION
From my personal experience, the `this type should implement debug but this not` consideration is not worth it. I think, everything should be `Debug`, except for sensitive data (such as keys). I often found it frustrating when libraries I used didn't implement Debug for all the types.

From a short testing, this didn't change the file size of the uefi runner app. Hence, the overhead is negligible.

What do you think?


## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
