### PR TITLE
ci: Drop test_latest_release job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,28 +104,6 @@ jobs:
       - name: Verify generated code is up-to-date
         run: cargo xtask gen-code --check
 
-  # This job tests that the template app builds successfully with the
-  # released versions of the libraries on crates.io.
-  #
-  # Since a nightly toolchain is currently required to build uefi-rs,
-  # the released versions can suddenly stop building when a new nightly
-  # compiler with a breaking change is released. This job provides an
-  # alert when this situation occurs.
-  test_latest_release:
-    name: Build the template against the released version of uefi-rs
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - name: Set MSRV toolchain
-      run: cp .github/workflows/msrv_toolchain.toml rust-toolchain.toml
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Build
-      run: cargo xtask test-latest-release
-
   windows:
     name: Check that the build works on a Windows target
     runs-on: windows-latest

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -72,7 +72,6 @@ pub enum Action {
     Miri(MiriOpt),
     Run(QemuOpt),
     Test(TestOpt),
-    TestLatestRelease(TestLatestReleaseOpt),
 }
 
 /// Build all the uefi packages.
@@ -189,7 +188,3 @@ pub struct TestOpt {
     #[clap(long, action)]
     pub skip_macro_tests: bool,
 }
-
-/// Build the template against the crates.io packages.
-#[derive(Debug, Parser)]
-pub struct TestLatestReleaseOpt;


### PR DESCRIPTION
This job was useful when we were on the nightly channel and using various unstable features that could break at any time, but there's not much value to keeping it now that we're on the stable channel.

The other minor thing the job checked was that the specific build command provided in the tutorial (originally in `BUILDING.md`) works. That was helpful back when we had some unstable (and verbose) `-Zbuild-std` flags, but now the build command is just `cargo build --target x86_64-unknown-uefi` which doesn't really need testing.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
