### PR TITLE
Set rust-version = 1.68 in all public packages

### DIFF
--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-osdev/uefi-rs"
 keywords = ["uefi", "efi"]
 categories = ["embedded", "no-std", "api-bindings"]
 license = "MPL-2.0"
+rust-version = "1.68"
 
 [lib]
 proc-macro = true

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-osdev/uefi-rs"
 keywords = ["uefi", "efi"]
 categories = ["embedded", "no-std", "api-bindings"]
 license = "MPL-2.0"
+rust-version = "1.68"
 
 [dependencies]
 uefi = { version = "0.20.0", features = ["global_allocator"] }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-osdev/uefi-rs"
 keywords = ["uefi", "efi"]
 categories = ["embedded", "no-std", "api-bindings"]
 license = "MPL-2.0"
+rust-version = "1.68"
 
 [features]
 default = ["panic-on-logger-errors"]


### PR DESCRIPTION
This indicates the MSRV, see cargo docs for more details: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
