### PR TITLE
Add uefi to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "template",
+    "uefi",
     "uefi-macros",
     "uefi-services",
     "uefi-test-runner",


### PR DESCRIPTION
I'm confused as to how this hasn't caused problems to be missing -- like why does `cargo fmt --all` work for the `uefi` crate even though it was missing from this list?

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
