### PR TITLE
deps: bump bitflags from 1.0 to 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
 - Renamed `CStr8::to_bytes` to `CStr8::as_bytes` and changed the semantics:
   The trailing null character is now always included in the returned slice.
 - `DevicePathBuilder::with_vec` now clears the `Vec` before use.
+- `bitflags` bumped from `1.3` to `2.1`
+  - `GptPartitionAttributes` now has 16 additional `TYPE_SPECIFIC_BIT_<N>`
+    constants.
 
 ## uefi-macros - [Unreleased]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,7 +100,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
 ]
 
@@ -177,7 +183,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05669f8e7e2d7badc545c513710f0eba09c2fbef683eb859fd79c46c355048e0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "log",
 ]
@@ -293,7 +299,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -371,7 +377,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -406,7 +412,7 @@ version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -570,7 +576,7 @@ dependencies = [
 name = "uefi"
 version = "0.20.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.1.0",
  "derive_more",
  "log",
  "ptr_meta",
@@ -595,7 +601,7 @@ dependencies = [
 name = "uefi-raw"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.1.0",
  "ptr_meta",
  "uefi-macros",
  "uguid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.66"
+name = "anstyle"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "basic-toml"
@@ -37,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "bit_field"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -49,9 +55,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 
 [[package]]
 name = "bitvec"
@@ -85,9 +91,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.0"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,10 +102,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.0"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
+ "anstyle",
  "bitflags 1.3.2",
  "clap_lex",
 ]
@@ -113,7 +120,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -138,24 +145,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -170,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -208,9 +215,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -229,13 +236,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -249,21 +256,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.0"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "log"
@@ -276,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "mbrman"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b239f4755d00466e3ac1d55ddeaf77a66c7580352fc6cbc40d56c218fc94a9"
+checksum = "9c487024623ae38584610237dd1be8932bb2b324474b23c37a25f9fbe6bf5e9e"
 dependencies = [
  "bincode",
  "bitvec",
@@ -295,9 +302,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -307,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_info"
@@ -323,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -347,7 +354,7 @@ checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -358,9 +365,9 @@ checksum = "9ff023245bfcc73fb890e1f8d5383825b3131cc920020a5c487d6f113dfc428a"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -408,23 +415,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "semver"
@@ -434,9 +441,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -452,20 +459,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -480,9 +487,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -491,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -516,7 +523,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -530,22 +537,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -576,7 +583,7 @@ dependencies = [
 name = "uefi"
 version = "0.20.0"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.2.1",
  "derive_more",
  "log",
  "ptr_meta",
@@ -592,7 +599,7 @@ version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
  "trybuild",
  "uefi",
 ]
@@ -601,7 +608,7 @@ dependencies = [
 name = "uefi-raw"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.2.1",
  "ptr_meta",
  "uefi-macros",
  "uguid",
@@ -643,9 +650,9 @@ checksum = "594cc87e268a7b43d625d46c63cf1605d0e61bf66e4b1cd58c058ec0191e1f81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "winapi"
@@ -684,7 +691,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -693,13 +709,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -709,10 +740,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -721,10 +764,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -733,16 +788,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "wyz"
@@ -770,6 +843,6 @@ dependencies = [
  "quote",
  "regex",
  "serde_json",
- "syn 2.0.8",
+ "syn 2.0.15",
  "tempfile",
 ]

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 rust-version = "1.68"
 
 [dependencies]
-bitflags = "1.3.1"
+bitflags = "2.1"
 ptr_meta = { version = "0.2.0", default-features = false }
 uefi-macros = "0.11.0"
 uguid = "2.0.0"

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -6,6 +6,7 @@ use bitflags::bitflags;
 bitflags! {
     /// Flags describing the capabilities of a memory range.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MemoryAttribute: u64 {
         /// Supports marking as uncacheable.
         const UNCACHEABLE = 0x1;

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -24,7 +24,7 @@ panic-on-logger-errors = []
 unstable = []
 
 [dependencies]
-bitflags = "1.3.1"
+bitflags = "2.1.0"
 derive_more = { version = "0.99.17", features = ["display"] }
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -157,6 +157,7 @@ bitflags! {
     ///
     /// [RS-232]: https://en.wikipedia.org/wiki/RS-232
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ControlBits: u32 {
         /// Clear to send
         const CLEAR_TO_SEND = 0x10;
@@ -186,11 +187,11 @@ bitflags! {
         ///
         /// Up to date as of UEFI 2.7 / Serial protocol v1
         const SETTABLE =
-            ControlBits::DATA_TERMINAL_READY.bits
-            | ControlBits::REQUEST_TO_SEND.bits
-            | ControlBits::HARDWARE_LOOPBACK_ENABLE.bits
-            | ControlBits::SOFTWARE_LOOPBACK_ENABLE.bits
-            | ControlBits::HARDWARE_FLOW_CONTROL_ENABLE.bits;
+            ControlBits::DATA_TERMINAL_READY.bits()
+            | ControlBits::REQUEST_TO_SEND.bits()
+            | ControlBits::HARDWARE_LOOPBACK_ENABLE.bits()
+            | ControlBits::SOFTWARE_LOOPBACK_ENABLE.bits()
+            | ControlBits::HARDWARE_FLOW_CONTROL_ENABLE.bits();
     }
 }
 

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -2401,7 +2401,7 @@ pub mod messaging {
 
     }
 
-    bitflags! { # [doc = " Flags to identify/manage InfiniBand elements."] # [repr (transparent)] pub struct InfinibandResourceFlags : u32 { # [doc = " Set = service, unset = IOC."] const SERVICE = 0x0000_0001 ; # [doc = " Extended boot environment."] const EXTENDED_BOOT_ENVIRONMENT = 0x0000_0002 ; # [doc = " Console protocol."] const CONSOLE_PROTOCOL = 0x0000_0004 ; # [doc = " Storage protocol."] const STORAGE_PROTOCOL = 0x0000_0008 ; # [doc = " Network protocol."] const NETWORK_PROTOCOL = 0x0000_0010 ; }
+    bitflags! { # [doc = " Flags to identify/manage InfiniBand elements."] # [derive (Clone , Copy , Debug , Default , PartialEq , Eq , PartialOrd , Ord)] # [repr (transparent)] pub struct InfinibandResourceFlags : u32 { # [doc = " Set = service, unset = IOC."] const SERVICE = 0x0000_0001 ; # [doc = " Extended boot environment."] const EXTENDED_BOOT_ENVIRONMENT = 0x0000_0002 ; # [doc = " Console protocol."] const CONSOLE_PROTOCOL = 0x0000_0004 ; # [doc = " Storage protocol."] const STORAGE_PROTOCOL = 0x0000_0008 ; # [doc = " Network protocol."] const NETWORK_PROTOCOL = 0x0000_0010 ; }
 
     }
 
@@ -2417,7 +2417,7 @@ pub mod messaging {
 
     }
 
-    bitflags! { # [doc = " iSCSI login options."] # [repr (transparent)] pub struct IscsiLoginOptions : u16 { # [doc = " Header digest using CRC32. If not set, no header digest."] const HEADER_DIGEST_USING_CRC32 = 0x0002 ; # [doc = " Data digest using CRC32. If not set, no data digest."] const DATA_DIGEST_USING_CRC32 = 0x0008 ; # [doc = " Auth method none. If not set, auth method CHAP."] const AUTH_METHOD_NONE = 0x0800 ; # [doc = " CHAP UNI. If not set, CHAP BI."] const CHAP_UNI = 0x1000 ; }
+    bitflags! { # [doc = " iSCSI login options."] # [derive (Clone , Copy , Debug , Default , PartialEq , Eq , PartialOrd , Ord)] # [repr (transparent)] pub struct IscsiLoginOptions : u16 { # [doc = " Header digest using CRC32. If not set, no header digest."] const HEADER_DIGEST_USING_CRC32 = 0x0002 ; # [doc = " Data digest using CRC32. If not set, no data digest."] const DATA_DIGEST_USING_CRC32 = 0x0008 ; # [doc = " Auth method none. If not set, auth method CHAP."] const AUTH_METHOD_NONE = 0x0800 ; # [doc = " CHAP UNI. If not set, CHAP BI."] const CHAP_UNI = 0x1000 ; }
 
     }
 

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -394,6 +394,7 @@ pub enum FileMode {
 
 bitflags! {
     /// Attributes describing the properties of a file on the file system.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct FileAttribute: u64 {
         /// File can only be opened in [`FileMode::READ`] mode.

--- a/uefi/src/proto/media/partition.rs
+++ b/uefi/src/proto/media/partition.rs
@@ -2,7 +2,6 @@
 
 use crate::proto::unsafe_protocol;
 use crate::{guid, Char16, Guid};
-use bitflags::bitflags;
 
 newtype_enum! {
     /// MBR OS type.
@@ -66,7 +65,8 @@ newtype_enum! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
+
     /// Attributes describing a GPT partition.
     ///
     /// * Bit 0: [`REQUIRED_PARTITION`][Self::REQUIRED_PARTITION]
@@ -76,18 +76,17 @@ bitflags! {
     /// * Bits `48..=63`: See
     /// [`type_specific_bits`][Self::type_specific_bits] and
     /// [`RESERVED_FOR_PARTITION_TYPE`][Self::RESERVED_FOR_PARTITION_TYPE].
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct GptPartitionAttributes: u64 {
-        /// Partition is required for the platform to function.
-        const REQUIRED_PARTITION = 1 << 0;
-
-        /// No [`BlockIO`] protocol will be created for this partition.
+        /// Bit: Partition is required for the platform to function.
+        const REQUIRED_PARTITION = 1;
+        /// Bit: No [`BlockIO`] protocol will be created for this partition.
         ///
         /// [`BlockIO`]: uefi::proto::media::block::BlockIO
         const NO_BLOCK_IO_PROTOCOL = 1 << 1;
 
-        /// Indicates that special software on a legacy BIOS system may
+        /// Bit: Indicates that special software on a legacy BIOS system may
         /// treat this partition as bootable. UEFI boot managers must
         /// ignore the partition.
         const LEGACY_BIOS_BOOTABLE = 1 << 2;
@@ -95,6 +94,54 @@ bitflags! {
         /// Mask for bits `48..=63`. The meaning of these bits depends
         /// on the partition type.
         const RESERVED_FOR_PARTITION_TYPE = 0xffff_0000_0000_0000;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_0 = 1 << 47;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_1 = 1 << 48;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_2 = 1 << 49;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_3 = 1 << 50;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_4 = 1 << 51;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_5 = 1 << 52;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_6 = 1 << 53;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_7 = 1 << 54;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_8 = 1 << 55;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_9 = 1 << 56;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_10 = 1 << 57;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_11 = 1 << 58;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_12 = 1 << 59;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_13 = 1 << 60;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_14 = 1 << 61;
+
+        /// The meaning of this bit depends on the partition type.
+        const TYPE_SPECIFIC_BIT_15 = 1 << 62;
     }
 }
 
@@ -103,7 +150,7 @@ impl GptPartitionAttributes {
     /// on the partition's type (see [`GptPartitionEntry::partition_type_guid`]).
     #[must_use]
     pub const fn type_specific_bits(&self) -> u16 {
-        (self.bits >> 48) as u16
+        (self.0.bits() >> 48) as u16
     }
 }
 
@@ -232,7 +279,8 @@ mod tests {
 
     #[test]
     fn test_partition_attributes() {
-        let attr = GptPartitionAttributes::from_bits(0xabcd_0000_0000_0007).unwrap();
+        let attr: GptPartitionAttributes =
+            GptPartitionAttributes::from_bits_retain(0xabcd_0000_0000_0007);
         assert_eq!(attr.type_specific_bits(), 0xabcd);
     }
 }

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -829,6 +829,7 @@ pub struct MtftpInfo {
 // No corresponding type in the UEFI spec, it just uses UINT16.
 bitflags! {
     /// Flags for UDP read and write operations.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct UdpOpFlags: u16 {
         /// Receive a packet sent from any IP address in UDP read operations.
@@ -893,6 +894,7 @@ impl IpFilter {
 
 bitflags! {
     /// IP receive filters.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct IpFilters: u8 {
         /// Enable the Station IP address.
@@ -1009,6 +1011,7 @@ impl DhcpV4Packet {
 bitflags! {
     /// Represents the 'flags' field for a [`DhcpV4Packet`].
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct DhcpV4Flags: u16 {
         /// Should be set when the client cannot receive unicast IP datagrams
         /// until its protocol software has been configured with an IP address.

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -124,16 +124,23 @@ impl SimpleNetwork {
         if let Some(mcast_filter) = mcast_filter {
             (self.receive_filters)(
                 self,
-                enable.bits,
-                disable.bits,
+                enable.bits(),
+                disable.bits(),
                 reset_mcast_filter,
                 mcast_filter.len(),
                 NonNull::new(mcast_filter.as_ptr() as *mut _),
             )
             .to_result()
         } else {
-            (self.receive_filters)(self, enable.bits, disable.bits, reset_mcast_filter, 0, None)
-                .to_result()
+            (self.receive_filters)(
+                self,
+                enable.bits(),
+                disable.bits(),
+                reset_mcast_filter,
+                0,
+                None,
+            )
+            .to_result()
         }
     }
 
@@ -267,6 +274,7 @@ impl SimpleNetwork {
 bitflags! {
     /// Flags to pass to receive_filters to enable/disable reception of some kinds of packets.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ReceiveFlags : u32 {
         /// Receive unicast packets.
         const UNICAST = 0x01;
@@ -285,6 +293,7 @@ bitflags! {
     /// Flags returned by get_interrupt_status to indicate which interrupts have fired on the
     /// interface since the last call.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct InterruptStatus : u32 {
         /// Packet received.
         const RECEIVE = 0x01;

--- a/uefi/src/proto/pi/mp.rs
+++ b/uefi/src/proto/pi/mp.rs
@@ -25,8 +25,8 @@ bitflags! {
     /// Flags indicating if the processor is BSP or AP,
     /// if the processor is enabled or disabled, and if
     /// the processor is healthy.
-    #[derive(Default)]
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     struct StatusFlag: u32 {
         /// Processor is playing the role of BSP.
         const PROCESSOR_AS_BSP_BIT = 1;

--- a/uefi/src/proto/tcg/mod.rs
+++ b/uefi/src/proto/tcg/mod.rs
@@ -28,7 +28,7 @@ bitflags! {
     /// Hash algorithms the protocol can provide.
     ///
     /// The [`v1`] protocol only supports SHA1.
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct HashAlgorithm: u32 {
         /// SHA-1 hash.

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -60,7 +60,7 @@ impl BootServiceCapability {
     pub fn hash_algorithm(&self) -> HashAlgorithm {
         // Safety: the value should always be 0x1 (indicating SHA-1), but
         // we don't care if it's some unexpected value.
-        unsafe { HashAlgorithm::from_bits_unchecked(u32::from(self.hash_algorithm_bitmap)) }
+        HashAlgorithm::from_bits_retain(u32::from(self.hash_algorithm_bitmap))
     }
 
     /// Whether the TPM device is present.

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -38,7 +38,7 @@ bitflags! {
     /// Event log formats supported by the firmware.
     ///
     /// Corresponds to the C typedef `EFI_TCG2_EVENT_ALGORITHM_BITMAP`.
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct EventLogFormat: u32 {
         /// Firmware supports the SHA-1 log format.
@@ -125,7 +125,7 @@ impl BootServiceCapability {
 
 bitflags! {
     /// Flags for the [`Tcg::hash_log_extend_event`] function.
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct HashLogExtendEventFlags: u64 {
         /// Extend an event but don't log it.

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -2011,6 +2011,7 @@ impl<'guid> SearchType<'guid> {
 bitflags! {
     /// Flags describing the type of an UEFI event and its attributes.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct EventType: u32 {
         /// The event is a timer event and may be passed to `BootServices::set_timer()`
         /// Note that timers only function during boot services time.

--- a/uefi/src/table/cfg.rs
+++ b/uefi/src/table/cfg.rs
@@ -64,6 +64,7 @@ pub struct PropertiesTable {
 bitflags! {
     /// Flags describing memory protection.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MemoryProtectionAttribute: usize {
         /// If this bit is set, then the UEFI implementation will mark pages
         /// containing data as non-executable.

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -403,6 +403,7 @@ pub struct TimeParams {
 bitflags! {
     /// A bitmask containing daylight savings time information.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct Daylight: u8 {
         /// Time is affected by daylight savings time.
         const ADJUST_DAYLIGHT = 0x01;
@@ -620,6 +621,7 @@ pub struct TimeCapabilities {
 bitflags! {
     /// Flags describing the attributes of a variable.
     #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct VariableAttributes: u32 {
         /// Variable is maintained across a power cycle.
         const NON_VOLATILE = 0x01;

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -598,6 +598,7 @@ mod messaging {
 
     bitflags! {
         /// Flags to identify/manage InfiniBand elements.
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
         #[repr(transparent)]
         pub struct InfinibandResourceFlags: u32 {
             /// Set = service, unset = IOC.
@@ -742,6 +743,7 @@ mod messaging {
 
     bitflags! {
         /// iSCSI login options.
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
         #[repr(transparent)]
         pub struct IscsiLoginOptions: u16 {
             /// Header digest using CRC32. If not set, no header digest.


### PR DESCRIPTION
This updates bitflags from version 1 to version 2.

TL;DR: Now every struct needs to manually implement copy, clone, partial ord, etc.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
