### PR TITLE
uefi: Add opaque_type macro

### DIFF
--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -130,6 +130,9 @@ pub use self::chars::{Char16, Char8};
 #[macro_use]
 mod enums;
 
+#[macro_use]
+mod opaque;
+
 mod strs;
 pub use self::strs::{
     CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16Error,

--- a/uefi/src/data_types/opaque.rs
+++ b/uefi/src/data_types/opaque.rs
@@ -1,0 +1,27 @@
+/// Create an opaque struct suitable for use as an FFI pointer.
+///
+/// The internal representation uses the recommendation in the [nomicon].
+///
+/// [nomicon]: https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
+#[macro_export]
+macro_rules! opaque_type {
+    (
+        $(#[$struct_attrs:meta])*
+        $struct_vis:vis struct $struct_name:ident;
+    ) => {
+        // Create the struct with the fields recommended by the nomicon.
+        $(#[$struct_attrs])*
+        #[repr(C)]
+        $struct_vis struct $struct_name {
+            _data: [u8; 0],
+            _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+        }
+
+        // Impl Debug, just show the struct name.
+        impl core::fmt::Debug for $struct_name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_struct(stringify!($struct_name)).finish()
+            }
+        }
+    }
+}

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -84,21 +84,15 @@ pub use device_path_gen::{
 use crate::proto::{unsafe_protocol, ProtocolPointer};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};
-use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 use ptr_meta::Pointee;
 
-/// Opaque type that should be used to represent a pointer to a
-/// [`DevicePath`] or [`DevicePathNode`] in foreign function interfaces. This
-/// type produces a thin pointer, unlike [`DevicePath`] and
-/// [`DevicePathNode`].
-#[repr(C, packed)]
-#[derive(Debug)]
-pub struct FfiDevicePath {
-    // This representation is recommended by the nomicon:
-    // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
-    _data: [u8; 0],
-    _marker: PhantomData<(*mut u8, PhantomPinned)>,
+opaque_type! {
+    /// Opaque type that should be used to represent a pointer to a
+    /// [`DevicePath`] or [`DevicePathNode`] in foreign function interfaces. This
+    /// type produces a thin pointer, unlike [`DevicePath`] and
+    /// [`DevicePathNode`].
+    pub struct FfiDevicePath;
 }
 
 /// Header that appears at the start of every [`DevicePathNode`].

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -4,7 +4,6 @@ use core::fmt::{Debug, Formatter};
 use core::{
     ffi::c_void,
     iter::from_fn,
-    marker::{PhantomData, PhantomPinned},
     mem::MaybeUninit,
     ptr::{null, null_mut},
 };
@@ -653,16 +652,11 @@ pub enum BootstrapType {
     PxeTest = 65535,
 }
 
-/// Opaque type that should be used to represent a pointer to a [`DiscoverInfo`] in
-/// foreign function interfaces. This type produces a thin pointer, unlike
-/// [`DiscoverInfo`].
-#[repr(C, packed)]
-#[derive(Debug)]
-pub struct FfiDiscoverInfo {
-    // This representation is recommended by the nomicon:
-    // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
-    _data: [u8; 0],
-    _marker: PhantomData<(*mut u8, PhantomPinned)>,
+opaque_type! {
+    /// Opaque type that should be used to represent a pointer to a [`DiscoverInfo`] in
+    /// foreign function interfaces. This type produces a thin pointer, unlike
+    /// [`DiscoverInfo`].
+    pub struct FfiDiscoverInfo;
 }
 
 /// This struct contains optional parameters for [`BaseCode::discover`].

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -15,7 +15,7 @@ use crate::proto::unsafe_protocol;
 use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
 use crate::{Error, Result, Status};
 use core::fmt::{self, Debug, Formatter};
-use core::marker::{PhantomData, PhantomPinned};
+use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
 use core::ptr;
 use ptr_meta::Pointee;
@@ -224,16 +224,11 @@ impl PartialEq for PcrEvent {
     }
 }
 
-/// Opaque type that should be used to represent a pointer to a [`PcrEvent`] in
-/// foreign function interfaces. This type produces a thin pointer, unlike
-/// [`PcrEvent`].
-#[repr(C, packed)]
-#[derive(Debug)]
-pub struct FfiPcrEvent {
-    // This representation is recommended by the nomicon:
-    // https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
-    _data: [u8; 0],
-    _marker: PhantomData<(*mut u8, PhantomPinned)>,
+opaque_type! {
+    /// Opaque type that should be used to represent a pointer to a [`PcrEvent`] in
+    /// foreign function interfaces. This type produces a thin pointer, unlike
+    /// [`PcrEvent`].
+    pub struct FfiPcrEvent;
 }
 
 /// TPM event log.


### PR DESCRIPTION
There are several places where we copy a rather abstruse pattern from the nomicon for representing opaque structs for FFI purposes [1]. This is necessary until such time as as a proper extern type [2] is stabilized.

To avoid having to copy-paste this pattern, add a simple macro for it.

[1]: https://doc.rust-lang.org/stable/nomicon/ffi.html#representing-opaque-structs
[2]: https://rust-lang.github.io/rfcs/1861-extern-types.html

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
