### PR TITLE
uefi: Consistently set repr(transparent) on bitflags

### DIFF
--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -156,6 +156,7 @@ bitflags! {
     /// The control bits of a device. These are defined in the [RS-232] standard.
     ///
     /// [RS-232]: https://en.wikipedia.org/wiki/RS-232
+    #[repr(transparent)]
     pub struct ControlBits: u32 {
         /// Clear to send
         const CLEAR_TO_SEND = 0x10;

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1019,6 +1019,7 @@ impl DhcpV4Packet {
 
 bitflags! {
     /// Represents the 'flags' field for a [`DhcpV4Packet`].
+    #[repr(transparent)]
     pub struct DhcpV4Flags: u16 {
         /// Should be set when the client cannot receive unicast IP datagrams
         /// until its protocol software has been configured with an IP address.

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -271,6 +271,7 @@ impl SimpleNetwork {
 
 bitflags! {
     /// Flags to pass to receive_filters to enable/disable reception of some kinds of packets.
+    #[repr(transparent)]
     pub struct ReceiveFlags : u32 {
         /// Receive unicast packets.
         const UNICAST = 0x01;
@@ -288,6 +289,7 @@ bitflags! {
 bitflags! {
     /// Flags returned by get_interrupt_status to indicate which interrupts have fired on the
     /// interface since the last call.
+    #[repr(transparent)]
     pub struct InterruptStatus : u32 {
         /// Packet received.
         const RECEIVE = 0x01;

--- a/uefi/src/proto/pi/mp.rs
+++ b/uefi/src/proto/pi/mp.rs
@@ -26,6 +26,7 @@ bitflags! {
     /// if the processor is enabled or disabled, and if
     /// the processor is healthy.
     #[derive(Default)]
+    #[repr(transparent)]
     struct StatusFlag: u32 {
         /// Processor is playing the role of BSP.
         const PROCESSOR_AS_BSP_BIT = 1;

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1933,6 +1933,7 @@ impl Align for MemoryDescriptor {
 
 bitflags! {
     /// Flags describing the capabilities of a memory range.
+    #[repr(transparent)]
     pub struct MemoryAttribute: u64 {
         /// Supports marking as uncacheable.
         const UNCACHEABLE = 0x1;
@@ -2169,6 +2170,7 @@ impl<'guid> SearchType<'guid> {
 
 bitflags! {
     /// Flags describing the type of an UEFI event and its attributes.
+    #[repr(transparent)]
     pub struct EventType: u32 {
         /// The event is a timer event and may be passed to `BootServices::set_timer()`
         /// Note that timers only function during boot services time.

--- a/uefi/src/table/cfg.rs
+++ b/uefi/src/table/cfg.rs
@@ -60,6 +60,7 @@ pub struct PropertiesTable {
 
 bitflags! {
     /// Flags describing memory protection.
+    #[repr(transparent)]
     pub struct MemoryProtectionAttribute: usize {
         /// If this bit is set, then the UEFI implementation will mark pages
         /// containing data as non-executable.

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -368,6 +368,7 @@ pub struct TimeParams {
 
 bitflags! {
     /// A bitmask containing daylight savings time information.
+    #[repr(transparent)]
     pub struct Daylight: u8 {
         /// Time is affected by daylight savings time.
         const ADJUST_DAYLIGHT = 0x01;
@@ -584,6 +585,7 @@ pub struct TimeCapabilities {
 
 bitflags! {
     /// Flags describing the attributes of a variable.
+    #[repr(transparent)]
     pub struct VariableAttributes: u32 {
         /// Variable is maintained across a power cycle.
         const NON_VOLATILE = 0x01;


### PR DESCRIPTION
We use bitflags with FFI interfaces, so we should ensure the struct layout is correct.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
