### PR TITLE
ci: Increase Windows timeout to 10 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Run VM tests
         run: cargo xtask run --target x86_64 --ci
-        timeout-minutes: 6
+        timeout-minutes: 10
 
   # Run the build with our current stable MSRV (specified in
   # ./msrv_toolchain.toml). This serves to check that we don't


### PR DESCRIPTION
This job is still timing out sometimes. There are some open bugs about slow Windows runners, maybe relevant:
https://github.com/actions/runner-images/issues/7320

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
