### PR TITLE
Format `use` consistently

### DIFF
--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -6,9 +6,10 @@ use proc_macro::TokenStream;
 
 use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, parse_quote, spanned::Spanned, Error, Fields, FnArg, Ident, ItemFn,
-    ItemStruct, LitStr, Pat, Visibility,
+    parse_macro_input, parse_quote, Error, Fields, FnArg, Ident, ItemFn, ItemStruct, LitStr, Pat,
+    Visibility,
 };
 
 macro_rules! err {

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -1,5 +1,6 @@
 use uefi::prelude::*;
-use uefi::proto::device_path::{text::*, DevicePath};
+use uefi::proto::device_path::text::*;
+use uefi::proto::device_path::DevicePath;
 use uefi::proto::loaded_image::LoadedImage;
 use uefi::table::boot::BootServices;
 

--- a/uefi-test-runner/src/proto/network/pxe.rs
+++ b/uefi-test-runner/src/proto/network/pxe.rs
@@ -1,11 +1,7 @@
-use uefi::{
-    prelude::BootServices,
-    proto::network::{
-        pxe::{BaseCode, DhcpV4Packet, IpFilter, IpFilters, UdpOpFlags},
-        IpAddress,
-    },
-    CStr8,
-};
+use uefi::prelude::BootServices;
+use uefi::proto::network::pxe::{BaseCode, DhcpV4Packet, IpFilter, IpFilters, UdpOpFlags};
+use uefi::proto::network::IpAddress;
+use uefi::CStr8;
 
 pub fn test(bt: &BootServices) {
     // Skip the test if the `pxe` feature is not enabled.

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -1,8 +1,7 @@
 use log::info;
-use uefi::guid;
 use uefi::prelude::*;
 use uefi::table::runtime::{VariableAttributes, VariableVendor};
-use uefi::Status;
+use uefi::{guid, Status};
 
 fn test_variables(rt: &RuntimeServices) {
     let name = cstr16!("UefiRsTestVar");

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module defines the basic data types that are used throughout uefi-rs
 
-use core::{ffi::c_void, ptr::NonNull};
+use core::ffi::c_void;
+use core::ptr::NonNull;
 
 /// Opaque handle to an UEFI entity (protocol, image...), guaranteed to be non-null.
 ///
@@ -121,8 +122,7 @@ pub type PhysicalAddress = u64;
 pub type VirtualAddress = u64;
 
 mod guid;
-pub use self::guid::Guid;
-pub use self::guid::Identify;
+pub use self::guid::{Guid, Identify};
 
 pub mod chars;
 pub use self::chars::{Char16, Char8};

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -5,8 +5,7 @@ use crate::data_types::UnalignedSlice;
 use crate::polyfill::vec_into_raw_parts;
 use alloc::borrow::{Borrow, ToOwned};
 use alloc::vec::Vec;
-use core::fmt;
-use core::ops;
+use core::{fmt, ops};
 
 /// Error returned by [`CString16::try_from::<&str>`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -2,11 +2,10 @@ use super::chars::{Char16, Char8, NUL_16, NUL_8};
 use super::UnalignedSlice;
 use crate::polyfill::maybe_uninit_slice_assume_init_ref;
 use core::ffi::CStr;
-use core::fmt;
 use core::iter::Iterator;
 use core::mem::MaybeUninit;
 use core::result::Result;
-use core::slice;
+use core::{fmt, slice};
 
 #[cfg(feature = "alloc")]
 use super::CString16;

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -96,8 +96,7 @@ extern crate self as uefi;
 pub mod data_types;
 #[cfg(feature = "alloc")]
 pub use self::data_types::CString16;
-pub use self::data_types::Identify;
-pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle};
+pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle, Identify};
 pub use uefi_macros::{cstr16, cstr8, entry, guid};
 
 mod result;

--- a/uefi/src/mem.rs
+++ b/uefi/src/mem.rs
@@ -1,7 +1,6 @@
 //! This is a utility module with helper methods for allocations/memory.
 
-use crate::ResultExt;
-use crate::{Result, Status};
+use crate::{Result, ResultExt, Status};
 use ::alloc::boxed::Box;
 use core::alloc::Layout;
 use core::fmt::Debug;

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -55,8 +55,7 @@ use crate::util::usize_from_u32;
 use crate::{Result, Status};
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
-use core::mem;
-use core::ptr;
+use core::{mem, ptr};
 
 /// Provides access to the video hardware's frame buffer.
 ///

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -8,12 +8,10 @@
 // if there is insufficient memory. So we treat any NULL output as an
 // `OUT_OF_RESOURCES` error.
 
-use crate::{
-    proto::device_path::{DevicePath, DevicePathNode, FfiDevicePath},
-    proto::unsafe_protocol,
-    table::boot::BootServices,
-    CStr16, Char16, Result, Status,
-};
+use crate::proto::device_path::{DevicePath, DevicePathNode, FfiDevicePath};
+use crate::proto::unsafe_protocol;
+use crate::table::boot::BootServices;
+use crate::{CStr16, Char16, Result, Status};
 use core::ops::Deref;
 
 /// This struct is a wrapper of `display_only` parameter

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -1,14 +1,13 @@
 //! `LoadedImage` protocol.
 
-use crate::{
-    data_types::FromSliceWithNulError,
-    proto::device_path::{DevicePath, FfiDevicePath},
-    proto::unsafe_protocol,
-    table::boot::MemoryType,
-    util::usize_from_u32,
-    CStr16, Handle, Status,
-};
-use core::{ffi::c_void, mem, slice};
+use crate::data_types::FromSliceWithNulError;
+use crate::proto::device_path::{DevicePath, FfiDevicePath};
+use crate::proto::unsafe_protocol;
+use crate::table::boot::MemoryType;
+use crate::util::usize_from_u32;
+use crate::{CStr16, Handle, Status};
+use core::ffi::c_void;
+use core::{mem, slice};
 
 /// The LoadedImage protocol. This can be opened on any image handle using the `HandleProtocol` boot service.
 #[repr(C)]

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -398,8 +398,7 @@ impl FileProtocolInfo for FileSystemVolumeLabel {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::table::runtime::TimeParams;
-    use crate::table::runtime::{Daylight, Time};
+    use crate::table::runtime::{Daylight, Time, TimeParams};
     use crate::CString16;
     use alloc::vec;
 

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -14,15 +14,15 @@ use crate::{CStr16, Char16, Guid, Result, Status};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::fmt::Debug;
-use core::mem;
-use core::ptr;
+use core::{mem, ptr};
 #[cfg(all(feature = "unstable", feature = "alloc"))]
 use {alloc::alloc::Global, core::alloc::Allocator};
 #[cfg(feature = "alloc")]
 use {alloc::boxed::Box, uefi::mem::make_boxed};
 
+pub use self::dir::Directory;
 pub use self::info::{FileInfo, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel, FromUefi};
-pub use self::{dir::Directory, regular::RegularFile};
+pub use self::regular::RegularFile;
 
 /// Common interface to `FileHandle`, `RegularFile`, and `Directory`.
 ///

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1,15 +1,14 @@
 //! PXE Base Code protocol.
 
+use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
-use core::{
-    ffi::c_void,
-    iter::from_fn,
-    mem::MaybeUninit,
-    ptr::{null, null_mut},
-};
+use core::iter::from_fn;
+use core::mem::MaybeUninit;
+use core::ptr::{null, null_mut};
 
+use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
+use crate::proto::unsafe_protocol;
 use crate::util::ptr_write_unaligned_and_add;
-use crate::{polyfill::maybe_uninit_slice_as_mut_ptr, proto::unsafe_protocol};
 use bitflags::bitflags;
 use ptr_meta::Pointee;
 

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -1,6 +1,8 @@
 //! `Rng` protocol.
 
-use crate::{data_types::Guid, guid, proto::unsafe_protocol, Result, Status};
+use crate::data_types::Guid;
+use crate::proto::unsafe_protocol;
+use crate::{guid, Result, Status};
 use core::{mem, ptr};
 
 newtype_enum! {

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -2,8 +2,7 @@ use super::field::NodeField;
 use super::group::DeviceType;
 use crate::device_path::util::is_doc_attr;
 use heck::ToShoutySnakeCase;
-use proc_macro2::Span;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{Attribute, Fields, Ident, ItemStruct, LitInt, LitStr};
 


### PR DESCRIPTION
Most of the project uses the style of only merging imports from the same module. Normally this isn't handled by `cargo fmt`, so there are some inconsistencies. There's an unstable option [1] to rustfmt to make imports consistent, so as a one-time operation apply that to all source files:

```
cargo fmt --all -- --config imports_granularity=Module
```

[1]: https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#module

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
