### PR TITLE
doc: build with --no-deps

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -256,6 +256,7 @@ impl Cargo {
                 document_private_items,
             } => {
                 action = "doc";
+                extra_args.push("--no-deps");
                 if self.warnings_as_errors {
                     cmd.env("RUSTDOCFLAGS", "-Dwarnings");
                 }
@@ -367,7 +368,7 @@ mod tests {
         };
         assert_eq!(
             command_to_string(&cargo.command().unwrap()),
-            "RUSTDOCFLAGS=-Dwarnings cargo doc --package uefi --package xtask --features global_allocator --document-private-items --open"
+            "RUSTDOCFLAGS=-Dwarnings cargo doc --package uefi --package xtask --features global_allocator --no-deps --document-private-items --open"
         );
     }
 }


### PR DESCRIPTION
Build documentation with `--no-deps` as this makes the documentation of the actual crate much clearer.

## Before (see bottom left):

![image](https://user-images.githubusercontent.com/5737016/229168162-b2635446-e384-447b-b5d8-7ad76456bac4.png)



## After:
![image](https://user-images.githubusercontent.com/5737016/229168187-4db491fe-5760-47a0-a9a7-707a13f7c70f.png)

This is also similar to what `docs.rs` shows on their website.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
