### PR TITLE
cstr[ing]16: convenience functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 - There is a new `fs` module that provides a high-level API for file-system
   access. The API is close to the `std::fs` module.
+- Multiple convenience methods for `CString16` and `CStr16`, including:
+  - `CStr16::as_slice()`
+  - `CStr16::num_chars()`
+  - `CStr16::is_empty()`
+  - `CString16::new()`
+  - `CString16::is_empty()`
+  - `CString16::num_chars()`
+  - `CString16::replace_char()`
+  - `CString16::push()`
+  - `CString16::push_str()`
+  - `From<&CStr16>` for `CString16`
+  - `From<&CStr16>` for `String`
+  - `From<&CString16>` for `String`
 
 ### Changed
 
@@ -16,6 +29,7 @@
 - `Error::new` and `Error::from` now panic if the status is `SUCCESS`.
 - `Image::get_image_file_system` now returns a `fs::FileSystem` instead of the
   protocol.
+- `CString16::default` now always contains a null character.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/data_types/chars.rs
+++ b/uefi/src/data_types/chars.rs
@@ -65,6 +65,17 @@ pub const NUL_8: Char8 = Char8(0);
 #[repr(transparent)]
 pub struct Char16(u16);
 
+impl Char16 {
+    /// Creates a UCS-2 character from a Rust character without checks.
+    ///
+    /// # Safety
+    /// The caller must be sure that the character is valid.
+    #[must_use]
+    pub const unsafe fn from_u16_unchecked(val: u16) -> Self {
+        Self(val)
+    }
+}
+
 impl TryFrom<char> for Char16 {
     type Error = CharConversionError;
 
@@ -125,4 +136,4 @@ impl fmt::Display for Char16 {
 }
 
 /// UCS-2 version of the NUL character
-pub const NUL_16: Char16 = Char16(0);
+pub const NUL_16: Char16 = unsafe { Char16::from_u16_unchecked(0) };


### PR DESCRIPTION
For #747 I'm about to add a `PathBuf` struct as wrapper around `CString16`, akin to the standard library. For this, a lot of convenience functions are missing on `CStr16` and `CString16`. This PR adds those.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
