### PR TITLE
uefi: consistent use of crate:: over uefi::

### DIFF
--- a/uefi/src/data_types/guid.rs
+++ b/uefi/src/data_types/guid.rs
@@ -136,7 +136,7 @@ pub unsafe trait Identify {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use uefi::guid;
+    use crate::guid;
 
     #[test]
     fn test_guid_display() {

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -1,8 +1,8 @@
 //! Module for directory iteration. See [`UefiDirectoryIter`].
 
 use super::*;
+use crate::Result;
 use alloc::boxed::Box;
-use uefi::Result;
 
 /// Iterates over the entries of an UEFI directory. It returns boxed values of
 /// type [`UefiFileInfo`].

--- a/uefi/src/fs/file_system.rs
+++ b/uefi/src/fs/file_system.rs
@@ -1,6 +1,8 @@
 //! Module for [`FileSystem`].
 
 use super::*;
+use crate::proto::media::file::{FileAttribute, FileInfo, FileType};
+use crate::table::boot::ScopedProtocol;
 use alloc::boxed::Box;
 use alloc::string::{FromUtf8Error, String, ToString};
 use alloc::vec::Vec;
@@ -10,8 +12,6 @@ use core::fmt::{Debug, Formatter};
 use core::ops::Deref;
 use derive_more::Display;
 use log::info;
-use uefi::proto::media::file::{FileAttribute, FileInfo, FileType};
-use uefi::table::boot::ScopedProtocol;
 
 /// All errors that can happen when working with the [`FileSystem`].
 #[derive(Debug, Clone, Display, PartialEq, Eq)]

--- a/uefi/src/fs/normalized_path.rs
+++ b/uefi/src/fs/normalized_path.rs
@@ -1,13 +1,13 @@
 //! Module for path normalization. See [`NormalizedPath`].
 
 use super::*;
+use crate::data_types::FromStrError;
+use crate::CString16;
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::ops::Deref;
 use derive_more::Display;
-use uefi::data_types::FromStrError;
-use uefi::CString16;
 
 /// The default separator for paths.
 pub const SEPARATOR: char = '\\';

--- a/uefi/src/fs/uefi_types.rs
+++ b/uefi/src/fs/uefi_types.rs
@@ -2,9 +2,9 @@
 //! to differ between high-level and low-level types and interfaces in this
 //! module.
 
-pub use uefi::proto::media::file::{
+pub use crate::proto::media::file::{
     Directory as UefiDirectoryHandle, File as UefiFileTrait, FileAttribute as UefiFileAttribute,
     FileHandle as UefiFileHandle, FileInfo as UefiFileInfo, FileMode as UefiFileMode,
     FileType as UefiFileType, RegularFile as UefiRegularFileHandle,
 };
-pub use uefi::proto::media::fs::SimpleFileSystem as SimpleFileSystemProtocol;
+pub use crate::proto::media::fs::SimpleFileSystem as SimpleFileSystemProtocol;

--- a/uefi/src/mem.rs
+++ b/uefi/src/mem.rs
@@ -1,12 +1,11 @@
 //! This is a utility module with helper methods for allocations/memory.
 
-use crate::{Result, ResultExt, Status};
+use crate::data_types::Align;
+use crate::{Error, Result, ResultExt, Status};
 use ::alloc::boxed::Box;
 use core::alloc::Layout;
 use core::fmt::Debug;
 use core::slice;
-use uefi::data_types::Align;
-use uefi::Error;
 
 #[cfg(not(feature = "unstable"))]
 use ::alloc::alloc::{alloc, dealloc};

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -5,7 +5,7 @@
 //!
 //! [`DevicePaths`]: DevicePath
 
-pub use uefi::proto::device_path::device_path_gen::build::*;
+pub use crate::proto::device_path::device_path_gen::build::*;
 
 use crate::polyfill::{maybe_uninit_slice_as_mut_ptr, maybe_uninit_slice_assume_init_ref};
 use crate::proto::device_path::{DevicePath, DevicePathNode};

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -3,9 +3,9 @@
 //! This protocol is used in the boot services environment to perform
 //! lexical comparison functions on Unicode strings for given languages.
 
+use crate::data_types::{CStr16, CStr8, Char16, Char8};
 use crate::proto::unsafe_protocol;
 use core::cmp::Ordering;
-use uefi::data_types::{CStr16, CStr8, Char16, Char8};
 
 /// The Unicode Collation Protocol.
 ///


### PR DESCRIPTION
Consistent use of `crate::` over `uefi::` in the codebase of `./uefi/src`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
