### PR TITLE
uefi: Minor cleanups in the fs module doc

### DIFF
--- a/uefi/src/fs/mod.rs
+++ b/uefi/src/fs/mod.rs
@@ -1,35 +1,31 @@
 //! A high-level file system API for UEFI applications close to the `fs` module
 //! from Rust's standard library.
 //!
-//! ## Difference to typical File System Abstractions
+//! # Difference to typical File System Abstractions
 //! Users perform actions on dedicated volumes: For example, the boot volume,
 //! such as a CD-rom, USB-stick, or any other storage device.
 //!
-//! ### UNIX
-//! Unlike in the API of typical UNIX file system abstractions, there is no
-//! virtual file system.
+//! Unlike in the API of typical UNIX file system abstractions, there is
+//! no virtual file system.
 //!
-//! ### Windows
-//! Unlike in Windows, there is no way to access volumes by a dedicated name.
+//! Unlike Windows, there is no way to access volumes by a dedicated name.
 //!
-//! ## Paths
+//! # Paths
 //! All paths are absolute and follow the FAT-like file system conventions for
 //! paths. Thus, there is no current working directory and path components
-//! like `.` and `.."`are not supported. In other words, the current working
-//! directory is always `/`, i.e., the root, of the opened volume. This may
-//! change in the future but is currently sufficient.
+//! like `.` and `..` are not supported. In other words, the current working
+//! directory is always `/`, i.e., the root, of the opened volume.
 //!
 //! Symlinks or hard-links are not supported but only directories and regular
 //! files with plain linear paths to them.
 //!
-//! ## API Hints
+//! # API Hints
 //! There are no `File` and `Path` abstractions similar to those from `std` that
 //! are publicly exported. Instead, paths to files are provided as `&str`, and
 //! will be validated and transformed internally to the correct type.
 //! Furthermore, there are no `File` objects that are exposed to users. Instead,
 //! it is intended to work with the file system as in `std::fs`.
 //!
-//! ### Synchronization
 //! There is no automatic synchronization of the file system for concurrent
 //! accesses. This is in the responsibility of the user.
 


### PR DESCRIPTION
* Typo fix
* Dropped "This may change in the future but is currently sufficient", I think it's usually clearer to stick to how things currently are in the docs, we can update the doc in the future if we actually change the API.
* Moved some things out of separate headers, the rustdoc style for h1/h2/h3 is so similar it's hard to even see stuff is semantically nested anyway.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
