### PR TITLE
xtask: add "cargo xtask fmt" (and formatting for nix and yml files)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-patch"]
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,12 +1,9 @@
 name: Book
-
 on:
   push:
-    branches: [ main ]
-
+    branches: [main]
 permissions:
   contents: write
-
 # Adapted from:
 # https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions#github-pages-deploy
 jobs:
@@ -14,34 +11,34 @@ jobs:
     if: github.repository == 'rust-osdev/uefi-rs'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Install mdbook
-      run: |
-        mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        echo `pwd`/mdbook >> $GITHUB_PATH
-    - name: Deploy GitHub Pages
-      run: |
-        cd book
-        mdbook build
-        git worktree add gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
-        cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        # Place the book under a "HEAD" directory so that we can later
-        # add other versions (e.g. "stable" or "v0.17") without breaking
-        # URLs.
-        rm -rf HEAD
-        mv ../book HEAD
-        git add HEAD
-        # Add an index in the root to redirect to HEAD. If we eventually
-        # serve multiple versions, this can be changed to a real index.
-        cp ../head_redirect.html index.html
-        git add index.html
-        # Commit and push.
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install mdbook
+        run: |
+          mkdir mdbook
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          echo `pwd`/mdbook >> $GITHUB_PATH
+      - name: Deploy GitHub Pages
+        run: |
+          cd book
+          mdbook build
+          git worktree add gh-pages gh-pages
+          git config user.name "Deploy from CI"
+          git config user.email ""
+          cd gh-pages
+          # Delete the ref to avoid keeping history.
+          git update-ref -d refs/heads/gh-pages
+          # Place the book under a "HEAD" directory so that we can later
+          # add other versions (e.g. "stable" or "v0.17") without breaking
+          # URLs.
+          rm -rf HEAD
+          mv ../book HEAD
+          git add HEAD
+          # Add an index in the root to redirect to HEAD. If we eventually
+          # serve multiple versions, this can be changed to a real index.
+          cp ../head_redirect.html index.html
+          git add index.html
+          # Commit and push.
+          git commit -m "Deploy $GITHUB_SHA to gh-pages"
+          git push --force

--- a/.github/workflows/developer_productivity.yml
+++ b/.github/workflows/developer_productivity.yml
@@ -1,9 +1,7 @@
 name: Developer Productivity
-
 on:
   push:
   pull_request:
-
 jobs:
   # Job to run change detection
   changes:
@@ -21,7 +19,6 @@ jobs:
             nix-src:
               - 'nix/**'
               - 'shell.nix'
-
   # This is a convenience test to verify that the toolchain provided by
   # shell.nix is valid and can build + run the integration test.
   #
@@ -32,21 +29,21 @@ jobs:
     if: ${{ needs.changes.outputs.nix-src == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - uses: cachix/install-nix-action@v20
-      with:
-        # This channel is only required to invoke "nix-shell".
-        # Everything inside that nix-shell will use a pinned version of nixpkgs.
-        nix_path: nixpkgs=channel:nixos-23.05
-    # Dedicated step to separate all the
-    # "copying path '/nix/store/...' from 'https://cache.nixos.org'."
-    # messages from the actual build output. This job takes ~60secs.
-    - name: Prepare Nix Store
-      run: nix-shell --pure --run "cargo --version"
-    - name: Run VM tests
-      run: |
-        COMMAND="cargo +stable xtask run --target x86_64 --headless --ci --tpm=v1"
-        echo "Executing in nix shell now: $COMMAND"
-        nix-shell --pure --run "$COMMAND"
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: cachix/install-nix-action@v20
+        with:
+          # This channel is only required to invoke "nix-shell".
+          # Everything inside that nix-shell will use a pinned version of nixpkgs.
+          nix_path: nixpkgs=channel:nixos-23.05
+      # Dedicated step to separate all the
+      # "copying path '/nix/store/...' from 'https://cache.nixos.org'."
+      # messages from the actual build output. This job takes ~60secs.
+      - name: Prepare Nix Store
+        run: nix-shell --pure --run "cargo --version"
+      - name: Run VM tests
+        run: |
+          COMMAND="cargo +stable xtask run --target x86_64 --headless --ci --tpm=v1"
+          echo "Executing in nix shell now: $COMMAND"
+          nix-shell --pure --run "$COMMAND"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,7 +1,5 @@
 name: QA
-
-on: [ push, pull_request ]
-
+on: [push, pull_request]
 jobs:
   spellcheck:
     name: Spellcheck

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,4 @@
 name: Rust
-
 on:
   push:
     branches:
@@ -10,63 +9,50 @@ on:
       - main
       - version-*
   schedule:
-    - cron:  '0 0 * * 0-6'
-
+    - cron: '0 0 * * 0-6'
 jobs:
   test_aarch64:
     name: Integration Test (AArch64)
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Install qemu
-      run: |
-        sudo apt-get update
-        sudo apt-get install qemu-system-arm -y
-
-    - name: Run VM tests
-      run: cargo xtask run --target aarch64 --headless --ci
-      timeout-minutes: 4
-
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-arm -y
+      - name: Run VM tests
+        run: cargo xtask run --target aarch64 --headless --ci
+        timeout-minutes: 4
   test_x86_64:
     name: Integration Test (x86_64)
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Install qemu
-      run: |
-        sudo apt-get update
-        sudo apt-get install qemu-system-x86 swtpm -y
-
-    - name: Run VM tests
-      run: cargo xtask run --target x86_64 --headless --ci --tpm=v1
-      timeout-minutes: 4
-
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-x86 swtpm -y
+      - name: Run VM tests
+        run: cargo xtask run --target x86_64 --headless --ci --tpm=v1
+        timeout-minutes: 4
   test_ia32:
     name: Integration Test (IA-32)
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Install qemu
-      run: |
-        sudo apt-get update
-        sudo apt-get install qemu-system-x86 swtpm -y
-
-    - name: Run VM tests
-      run: cargo xtask run --target ia32 --headless --ci --tpm=v2
-      timeout-minutes: 4
-
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-x86 swtpm -y
+      - name: Run VM tests
+        run: cargo xtask run --target ia32 --headless --ci --tpm=v2
+        timeout-minutes: 4
   # Ensure that developers can build and use this crate on Windows.
   test_x86_64_windows:
     name: Integration Test (x86_64 Windows)
@@ -74,56 +60,42 @@ jobs:
     steps:
       - name: Install QEMU
         run: choco install qemu --version 2023.4.24
-
       - name: Checkout sources
         uses: actions/checkout@v3
-
       - uses: Swatinem/rust-cache@v2
-
       - name: Run VM tests
         run: cargo xtask run --target x86_64 --ci
         timeout-minutes: 10
-
   test:
     name: Unit + Doc Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
       - uses: Swatinem/rust-cache@v2
-
       - name: Run cargo test (without unstable)
         run: cargo xtask test
-
   lints:
     name: Lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
       - uses: Swatinem/rust-cache@v2
-
       - name: Run cargo fmt
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
-
       - name: Run clippy
         run: |
           rustup component add clippy
           cargo xtask clippy --warnings-as-errors
-
       - name: Run cargo doc (without unstable)
         run: cargo xtask doc --warnings-as-errors --document-private-items
-
       - name: Verify generated code is up-to-date
         run: cargo xtask gen-code --check
-
       - name: Run additional checks on the uefi-raw package
         run: cargo xtask check-raw
-
   # Run the build with our current stable MSRV (specified in
   # ./msrv_toolchain.toml). This serves to check that we don't
   # accidentally start relying on a new feature without intending
@@ -133,64 +105,49 @@ jobs:
     name: Build (stable MSRV)
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - name: Set toolchain
-      run: cp .github/workflows/msrv_toolchain.toml rust-toolchain.toml
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Build
-      run: cargo xtask build
-
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Set toolchain
+        run: cp .github/workflows/msrv_toolchain.toml rust-toolchain.toml
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo xtask build
   # This job requires the nightly channel, but keep it as a separate job from
   # `nightly_channel` because it takes a while to run.
   build_feature_permutations:
     name: Build (feature permutations)
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - name: Set nightly toolchain so that `unstable` can be included
-      run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Build
-      run: cargo xtask build --feature-permutations
-
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Set nightly toolchain so that `unstable` can be included
+        run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo xtask build --feature-permutations
   nightly_channel:
     name: Build (nightly + unstable feature)
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v3
-
-    - name: Install qemu
-      run: |
-        sudo apt-get update
-        sudo apt-get install qemu-system-x86 -y
-
-    - name: Enable nightly toolchain
-      run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Run VM tests with the `unstable` feature
-      run: cargo xtask run --target x86_64 --headless --ci --unstable
-      timeout-minutes: 4
-
-    - name: Run cargo doc with the `unstable` feature
-      run: cargo xtask doc --warnings-as-errors --document-private-items --unstable
-
-    - name: Run test with the `unstable` feature
-      # Skip testing uefi-macros on nightly because the tests that check the
-      # compiler error output produce different output on stable vs nightly.
-      run: cargo xtask test --unstable --skip-macro-tests
-
-    - name: Run unit tests and doctests under Miri
-      run: |
-        rustup component add miri
-        cargo xtask miri
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-x86 -y
+      - name: Enable nightly toolchain
+        run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
+      - uses: Swatinem/rust-cache@v2
+      - name: Run VM tests with the `unstable` feature
+        run: cargo xtask run --target x86_64 --headless --ci --unstable
+        timeout-minutes: 4
+      - name: Run cargo doc with the `unstable` feature
+        run: cargo xtask doc --warnings-as-errors --document-private-items --unstable
+      - name: Run test with the `unstable` feature
+        # Skip testing uefi-macros on nightly because the tests that check the
+        # compiler error output produce different output on stable vs nightly.
+        run: cargo xtask test --unstable --skip-macro-tests
+      - name: Run unit tests and doctests under Miri
+        run: |
+          rustup component add miri
+          cargo xtask miri

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,10 @@ pkgs.mkShell {
 
     # Rust toolchain
     rustup
+
+    # Other
+    yamlfmt
+    which # used by "cargo xtask fmt"
   ];
 
   # Set ENV vars.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -225,11 +225,11 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
 
         match run_cmd(command) {
             Ok(_) => {
-                eprintln!("✅ rust files format")
+                eprintln!("✅ rust files formatted")
             }
             Err(e) => {
                 if fmt_opt.check {
-                    eprintln!("❌ rust files to not pass check");
+                    eprintln!("❌ rust files do not pass check");
                 } else {
                     eprintln!("❌ rust formatter failed: {e:#?}");
                 }
@@ -244,15 +244,16 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
         if fmt_opt.check {
             command.arg("-lint");
         }
-        command.arg(".");
+        // We only have yml files here.
+        command.arg(".github");
 
         match run_cmd(command) {
             Ok(_) => {
-                eprintln!("✅ yml files format")
+                eprintln!("✅ yml files formatted")
             }
             Err(e) => {
                 if fmt_opt.check {
-                    eprintln!("❌ yml files to not pass check");
+                    eprintln!("❌ yml files do not pass check");
                 } else {
                     eprintln!("❌ yml formatter failed: {e:#?}");
                 }
@@ -269,15 +270,16 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
         if fmt_opt.check {
             command.arg("--check");
         }
-        command.arg(".");
+        command.arg("nix");
+        command.arg("shell.nix");
 
         match run_cmd(command) {
             Ok(_) => {
-                eprintln!("✅ nix files format")
+                eprintln!("✅ nix files formatted")
             }
             Err(e) => {
                 if fmt_opt.check {
-                    eprintln!("❌ nix files to not pass check");
+                    eprintln!("❌ nix files do not pass check");
                 } else {
                     eprintln!("❌ nix formatter failed: {e:#?}");
                 }

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -73,6 +73,7 @@ pub enum Action {
     Miri(MiriOpt),
     Run(QemuOpt),
     Test(TestOpt),
+    Fmt(FmtOpt),
 }
 
 /// Build all the uefi packages.
@@ -192,4 +193,12 @@ pub struct TestOpt {
     /// Skip the uefi-macros tests.
     #[clap(long, action)]
     pub skip_macro_tests: bool,
+}
+
+/// Run formatting on the repo.
+#[derive(Debug, Parser)]
+pub struct FmtOpt {
+    /// Just check but do not write files.
+    #[clap(long, action)]
+    pub check: bool,
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -34,7 +34,7 @@ pub fn command_to_string(cmd: &Command) -> String {
 /// Print a `Command` and run it, then check that it completes
 /// successfully.
 pub fn run_cmd(mut cmd: Command) -> Result<()> {
-    println!("{}", command_to_string(&cmd));
+    println!("run_cmd: '{}'", command_to_string(&cmd));
 
     let status = cmd.status()?;
     if status.success() {


### PR DESCRIPTION
This adds support for rustfmt, nixpkgs-fmt and yamlfmt via a new `cargo xtask fmt [--check]` command.

This needs #828 to be merged first.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
