### PR TITLE
uefi-macros: Drop !Send and !Sync from unsafe_protocol macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
 
 ## uefi-macros - [Unreleased]
 
+- The `unsafe_protocol` struct no longer makes protocols `!Send` and
+  `!Sync`. Protocols can only be used while boot services are active, and that's
+  already a single-threaded environment, so these negative traits do not have
+  any effect.
+
 ## uefi-services - [Unreleased]
 
 ## uefi - 0.20.0 (2023-03-19)

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -14,10 +14,8 @@ use core::ffi::c_void;
 
 /// Common trait implemented by all standard UEFI protocols.
 ///
-/// According to the UEFI's specification, protocols are `!Send` (they expect to
-/// be run on the bootstrap processor) and `!Sync` (they are not thread-safe).
-/// You can derive the `Protocol` trait, add these bounds, and specify the
-/// protocol's GUID using the [`unsafe_protocol`] macro.
+/// You can derive the `Protocol` trait and specify the protocol's GUID using
+/// the [`unsafe_protocol`] macro.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Protocols can only be used while boot services are active, and that's already a single-threaded environment [1], so these negative traits do not have any effect. (Note that many protocols will still be automatically `!Send`/`!Sync` due to containing raw pointers.)

In addition, there's nothing particularly special about protocols; we have lots of structs that are intended for use during boot services and can't be safely shared between threads. There are no threads to worry about in the UEFI environment though, so none of them need to be explictly marked `!Send`/`!Sync`.

[1]: https://github.com/rust-lang/rust/blob/4f87a63edcef5c8c06229ff13e0f64f427537378/compiler/rustc_target/src/spec/uefi_msvc_base.rs#L47

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
