### PR TITLE
Allow passing a constant's path into unsafe_protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,12 @@
 
 ## uefi-macros - [Unreleased]
 
-- The `unsafe_protocol` struct no longer makes protocols `!Send` and
+- The `unsafe_protocol` macro no longer makes protocols `!Send` and
   `!Sync`. Protocols can only be used while boot services are active, and that's
   already a single-threaded environment, so these negative traits do not have
   any effect.
+- The `unsafe_protocol` macro now accepts the path of a `Guid` constant in
+  addition to a string literal.
 
 ## uefi-services - [Unreleased]
 


### PR DESCRIPTION
For example, instead of this:

`#[unsafe_protocol("12345678-1234-5678-1234-567812345678")]`

You can do this:

`#[unsafe_protocol(path::of::some::guid::constant)]`

This is helpful to avoid repeating the GUID if you happen to have it defined somewhere else already.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
