### PR TITLE
ci: Fix book token permission

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 # Adapted from:
 # https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions#github-pages-deploy
 jobs:


### PR DESCRIPTION
This job needs write access to the repo. Hopefully this change is sufficient; I don't know how to test other than merge and see what happens.

Fixes https://github.com/rust-osdev/uefi-rs/issues/762

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
