### PR TITLE
Move newtype_enum macro to uefi-raw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
+ "uefi-raw",
 ]
 
 [[package]]

--- a/uefi-raw/src/enums.rs
+++ b/uefi-raw/src/enums.rs
@@ -30,7 +30,7 @@
 ///
 /// Usage example:
 /// ```
-/// use uefi::newtype_enum;
+/// # use uefi_raw::newtype_enum;
 /// newtype_enum! {
 /// #[derive(Ord, PartialOrd)]
 /// pub enum UnixBool: i32 => #[allow(missing_docs)] {

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -13,3 +13,6 @@
 #![deny(clippy::all)]
 #![deny(clippy::ptr_as_ptr, unused)]
 #![deny(clippy::must_use_candidate)]
+
+#[macro_use]
+mod enums;

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -30,6 +30,7 @@ log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"
 uefi-macros = "0.11.0"
+uefi-raw = "0.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -128,9 +128,6 @@ pub mod chars;
 pub use self::chars::{Char16, Char8};
 
 #[macro_use]
-mod enums;
-
-#[macro_use]
 mod opaque;
 
 mod strs;

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -93,6 +93,9 @@ extern crate alloc;
 extern crate self as uefi;
 
 #[macro_use]
+extern crate uefi_raw;
+
+#[macro_use]
 pub mod data_types;
 #[cfg(feature = "alloc")]
 pub use self::data_types::CString16;


### PR DESCRIPTION
* uefi: Add dependency on uefi-raw

* Move newtype_enum macro to uefi-raw
    
    Most if not all of the newtype_enums will move to `uefi-raw`, so we need the
    macro there. The macro is still exposed in `uefi` as well, so no public API
    change.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
