### PR TITLE
gop: Derive PartialEq on ModeInfo

### DIFF
--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -399,7 +399,7 @@ impl Mode {
 }
 
 /// Information about a graphics output mode.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub struct ModeInfo {
     // The only known version, associated with the current spec, is 0.


### PR DESCRIPTION
To check which mode is currently active, have to compare the ModeInfo structs.
https://blog.fpmurphy.com/2015/05/check-available-text-and-graphics-modes-from-uefi-shell.html does the same.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
