### PR TITLE
uefi: Add get_variable_boxed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `From<&CStr16>` for `CString16`
   - `From<&CStr16>` for `String`
   - `From<&CString16>` for `String`
+- Added `RuntimeServices::get_variable_boxed` (requires the `alloc` feature).
 
 ### Changed
 

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -29,6 +29,13 @@ fn test_variables(rt: &RuntimeServices) {
     assert_eq!(data, test_value);
     assert_eq!(attrs, test_attrs);
 
+    info!("Testing get_variable_boxed");
+    let (data, attrs) = rt
+        .get_variable_boxed(name, &vendor)
+        .expect("failed to get variable");
+    assert_eq!(&*data, test_value);
+    assert_eq!(attrs, test_attrs);
+
     info!("Testing variable_keys");
     let variable_keys = rt.variable_keys().expect("failed to get variable keys");
     info!("Found {} variables", variable_keys.len());


### PR DESCRIPTION
This alloc-only method is a more convenient form of `get_variable`.

Closes https://github.com/rust-osdev/uefi-rs/issues/776

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
