### PR TITLE
Add Revision to uefi-raw and use it from uefi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   number of new `Guid` methods.
 - The `MEMORY_DESCRIPTOR_VERSION` constant has been moved to
   `MemoryDescriptor::VERSION`.
+- The `Revision` struct's one field is now public.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -18,6 +18,7 @@
 mod enums;
 
 pub mod protocol;
+pub mod table;
 
 mod status;
 

--- a/uefi-raw/src/table/mod.rs
+++ b/uefi-raw/src/table/mod.rs
@@ -1,0 +1,5 @@
+//! Standard UEFI tables.
+
+mod revision;
+
+pub use revision::Revision;

--- a/uefi-raw/src/table/revision.rs
+++ b/uefi-raw/src/table/revision.rs
@@ -32,7 +32,7 @@ use core::fmt;
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
-pub struct Revision(u32);
+pub struct Revision(pub u32);
 
 // Allow missing docs, there's nothing useful to document about these
 // constants.

--- a/uefi/src/table/mod.rs
+++ b/uefi/src/table/mod.rs
@@ -10,9 +10,6 @@ pub trait Table {
 mod header;
 pub use self::header::Header;
 
-mod revision;
-pub use self::revision::Revision;
-
 mod system;
 pub use self::system::{Boot, Runtime, SystemTable};
 
@@ -20,3 +17,5 @@ pub mod boot;
 pub mod runtime;
 
 pub mod cfg;
+
+pub use uefi_raw::table::Revision;


### PR DESCRIPTION
One API change: the struct's one field is now public. This fits better with uefi-raw, and doesn't cause any problems for the re-export in uefi.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
