### PR TITLE
uefi: Switch Rng repr from C to transparent

### DIFF
--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -7,7 +7,7 @@ use core::{mem, ptr};
 pub use uefi_raw::protocol::rng::RngAlgorithmType;
 
 /// Rng protocol
-#[repr(C)]
+#[repr(transparent)]
 #[unsafe_protocol(uefi_raw::protocol::rng::RngProtocol::GUID)]
 pub struct Rng(uefi_raw::protocol::rng::RngProtocol);
 


### PR DESCRIPTION
It shouldn't really make a difference here, but `repr(transparent)` is semantically clearer.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
