### PR TITLE
macros: allow to create empty cstr8/16 slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
   any effect.
 - The `unsafe_protocol` macro now accepts the path of a `Guid` constant in
   addition to a string literal.
+- The `cstr8` and the `cstr16` macros now both accept `(nothing)` and `""`
+  (empty inputs) to create valid empty strings. They include the null-byte.
 
 ## uefi-services - [Unreleased]
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -127,3 +127,24 @@ pub(crate) mod mem;
 pub(crate) mod polyfill;
 
 mod util;
+
+#[cfg(test)]
+// Crates that create procedural macros can't unit test the macros they export.
+// Therefore, we do some tests here.
+mod macro_tests {
+    use uefi_macros::{cstr16, cstr8};
+
+    #[test]
+    fn cstr8_macro_literal() {
+        let _empty1 = cstr8!();
+        let _empty2 = cstr8!("");
+        let _regular = cstr8!("foobar");
+    }
+
+    #[test]
+    fn cstr16_macro_literal() {
+        let _empty1 = cstr16!();
+        let _empty2 = cstr16!("");
+        let _regular = cstr16!("foobar");
+    }
+}


### PR DESCRIPTION
Allow to use `cstr8!()`, `cstr8!("")`, `cstr16!()`, and `cstr16!("")` to create empty strings. I need this for #771 .

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
