### PR TITLE
fs: add new error type

### DIFF
--- a/uefi/src/fs/file_system/error.rs
+++ b/uefi/src/fs/file_system/error.rs
@@ -1,0 +1,82 @@
+use crate::fs::{PathBuf, PathError};
+use alloc::string::FromUtf8Error;
+use core::fmt::Debug;
+use derive_more::Display;
+
+/// All errors that can happen when working with the [`FileSystem`].
+///
+/// [`FileSystem`]: super::FileSystem
+#[derive(Debug, Clone, Display, PartialEq, Eq)]
+pub enum Error {
+    /// IO (low-level UEFI-errors) errors. See [`IoError`].
+    Io(IoError),
+    /// Path-related errors. See [`PathError`].
+    Path(PathError),
+    /// Can't parse file content as UTF-8. See [`FromUtf8Error`].
+    Utf8Encoding(FromUtf8Error),
+}
+
+/// UEFI-error with context when working with the underlying UEFI file protocol.
+#[derive(Debug, Clone, Display, PartialEq, Eq)]
+#[display(fmt = "IoError({},{})", context, path)]
+pub struct IoError {
+    /// The path that led to the error.
+    pub path: PathBuf,
+    /// The context in which the path was used.
+    pub context: FileSystemIOErrorContext,
+    /// The underlying UEFI error.
+    pub uefi_error: crate::Error,
+}
+
+/// Enum that further specifies the context in that a [`Error`]
+/// occurred.
+#[derive(Debug, Clone, Display, PartialEq, Eq)]
+pub enum FileSystemIOErrorContext {
+    /// Can't delete the directory.
+    CantDeleteDirectory,
+    /// Can't delete the file.
+    CantDeleteFile,
+    /// Error flushing file.
+    FlushFailure,
+    /// Can't open the root directory of the underlying volume.
+    CantOpenVolume,
+    /// Error while reading the metadata of the file.
+    Metadata,
+    /// Could not open the given path. One possible reason is that the file does
+    /// not exist.
+    OpenError,
+    /// Error reading file.
+    ReadFailure,
+    /// Error writing bytes.
+    WriteFailure,
+    /// The path exists but does not correspond to a directory when a directory
+    /// was expected.
+    NotADirectory,
+    /// The path exists but does not correspond to a file when a file was
+    /// expected.
+    NotAFile,
+}
+
+impl From<PathError> for Error {
+    fn from(value: PathError) -> Self {
+        Self::Path(value)
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Error::Io(err) => Some(err),
+            Error::Path(err) => Some(err),
+            Error::Utf8Encoding(err) => Some(err),
+        }
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for IoError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.uefi_error)
+    }
+}

--- a/uefi/src/fs/file_system/fs.rs
+++ b/uefi/src/fs/file_system/fs.rs
@@ -1,6 +1,6 @@
 //! Module for [`FileSystem`].
 
-use super::*;
+use super::super::*;
 use crate::fs::path::{validate_path, PathError};
 use crate::proto::media::file::{FileAttribute, FileInfo, FileType};
 use crate::table::boot::ScopedProtocol;

--- a/uefi/src/fs/file_system/mod.rs
+++ b/uefi/src/fs/file_system/mod.rs
@@ -1,0 +1,3 @@
+mod fs;
+
+pub use fs::*;

--- a/uefi/src/fs/file_system/mod.rs
+++ b/uefi/src/fs/file_system/mod.rs
@@ -1,3 +1,5 @@
+mod error;
 mod fs;
 
+pub use error::*;
 pub use fs::*;

--- a/uefi/src/fs/mod.rs
+++ b/uefi/src/fs/mod.rs
@@ -35,7 +35,7 @@ mod file_system;
 mod path;
 mod uefi_types;
 
-pub use file_system::{FileSystem, FileSystemError, FileSystemResult};
+pub use file_system::*;
 pub use path::*;
 
 use dir_entry_iter::*;

--- a/uefi/src/fs/path/mod.rs
+++ b/uefi/src/fs/path/mod.rs
@@ -20,8 +20,8 @@ mod validation;
 pub use path::{Components, Path};
 pub use pathbuf::PathBuf;
 
-use uefi::data_types::chars::NUL_16;
-use uefi::{CStr16, Char16};
+use crate::data_types::chars::NUL_16;
+use crate::{CStr16, Char16};
 pub(super) use validation::validate_path;
 pub use validation::PathError;
 

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -2,9 +2,8 @@
 #![allow(clippy::module_inception)]
 
 use crate::fs::path::{PathBuf, SEPARATOR};
-use crate::CStr16;
+use crate::{CStr16, CString16};
 use core::fmt::{Display, Formatter};
-use uefi::CString16;
 
 /// A path similar to the `Path` of the standard library, but based on
 /// [`CStr16`] strings and [`SEPARATOR`] as separator.

--- a/uefi/src/fs/path/pathbuf.rs
+++ b/uefi/src/fs/path/pathbuf.rs
@@ -7,7 +7,7 @@ use core::fmt::{Display, Formatter};
 /// [`CString16`] strings and [`SEPARATOR`] as separator.
 ///
 /// `/` is replaced by [`SEPARATOR`] on the fly.
-#[derive(Debug, Default, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, Eq, PartialOrd, Ord)]
 pub struct PathBuf(CString16);
 
 impl PathBuf {

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -54,5 +54,19 @@ impl<Data: Debug> Display for Error<Data> {
     }
 }
 
+impl<Data: Debug> Error<Data> {
+    /// Transforms the generic payload of an error to `()`. This is useful if
+    /// you want
+    /// - to retain the erroneous status code,
+    /// - do not care about the payload, and
+    /// - refrain from generic type complexity in a higher API level.
+    pub fn to_err_without_payload(&self) -> Error<()> {
+        Error {
+            status: self.status,
+            data: (),
+        }
+    }
+}
+
 #[cfg(feature = "unstable")]
 impl<Data: Debug> core::error::Error for Error<Data> {}


### PR DESCRIPTION
In #472 I added an initial version of a file-system error type. I did not really like it. Therefore, this MR adds a new type which adds much more context to errors. I think, the new abstraction is helpful - yet kind of feature-creep 😁 

What do you think?

## Hints for Review
Changelog update is not needed I think, as none of the fs-related code is published yet.


## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
