### PR TITLE
uefi: Clear the Vec in DevicePathBuilder::with_vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - The `Revision` struct's one field is now public.
 - Renamed `CStr8::to_bytes` to `CStr8::as_bytes` and changed the semantics:
   The trailing null character is now always included in the returned slice.
+- `DevicePathBuilder::with_vec` now clears the `Vec` before use.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -83,8 +83,11 @@ impl<'a> DevicePathBuilder<'a> {
     }
 
     /// Create a builder backed by a `Vec`.
+    ///
+    /// The `Vec` is cleared before use.
     #[cfg(feature = "alloc")]
     pub fn with_vec(v: &'a mut Vec<u8>) -> Self {
+        v.clear();
         Self {
             storage: BuilderStorage::Vec(v),
         }


### PR DESCRIPTION
Previously there was an implicit assumption that the `Vec` was empty; clear it to ensure this.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
