### PR TITLE
uefi-raw: Drop dep on uefi-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.2.1",
  "ptr_meta",
- "uefi-macros",
  "uguid",
 ]
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.68"
 [dependencies]
 bitflags = "2.1"
 ptr_meta = { version = "0.2.0", default-features = false }
-uefi-macros = "0.11.0"
 uguid = "2.0.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We don't actually need this dep anymore since the uguid dep is providing the guid macro.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
