### PR TITLE
Disable some tests on aarch64

### DIFF
--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -14,6 +14,9 @@ log = { version = "0.4.17", default-features = false }
 qemu-exit = "3.0.0"
 
 [features]
+# Enable the debug support protocol test.
+debug_support = []
+
 # Enable the multiprocessor test. This only works if KVM is enabled.
 multi_processor = []
 

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -67,6 +67,10 @@ fn test_debug_port(bt: &BootServices) {
 }
 
 fn test_debug_support(bt: &BootServices) {
+    if cfg!(not(feature = "debug_support")) {
+        return;
+    }
+
     info!("Running UEFI debug connection protocol test");
     let handles = bt
         .find_handles::<DebugSupport>()

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -66,6 +66,7 @@ pub enum Feature {
     ServicesLogger,
 
     // `uefi-test-runner` features.
+    DebugSupport,
     MultiProcessor,
     Pxe,
     TestUnstable,
@@ -86,6 +87,7 @@ impl Feature {
             Self::Qemu => "uefi-services/qemu",
             Self::ServicesLogger => "uefi-services/logger",
 
+            Self::DebugSupport => "uefi-test-runner/debug_support",
             Self::MultiProcessor => "uefi-test-runner/multi_processor",
             Self::Pxe => "uefi-test-runner/pxe",
             Self::TestUnstable => "uefi-test-runner/unstable",
@@ -107,6 +109,7 @@ impl Feature {
             Package::UefiServices => vec![Self::PanicHandler, Self::Qemu, Self::ServicesLogger],
             Package::UefiTestRunner => {
                 vec![
+                    Self::DebugSupport,
                     Self::MultiProcessor,
                     Self::Pxe,
                     Self::TestUnstable,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -138,9 +138,9 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
         None => {}
     }
 
-    // Enable the multi-processor test if KVM is available. KVM is
-    // available on Linux generally, but not in our CI.
-    if platform::is_linux() && !opt.ci {
+    // Enable the multi-processor test if not targeting AARCH64, and if KVM is
+    // available. KVM is available on Linux generally, but not in our CI.
+    if *opt.target != UefiArch::AArch64 && platform::is_linux() && !opt.ci {
         features.push(Feature::MultiProcessor);
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -119,6 +119,12 @@ fn run_miri() -> Result<()> {
 fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
     let mut features = vec![];
 
+    // Enable the DebugSupport test on supported platforms. Not available on
+    // AARCH64 since edk2 commit f4213fed34.
+    if *opt.target != UefiArch::AArch64 {
+        features.push(Feature::DebugSupport);
+    }
+
     // Enable the PXE test unless networking is disabled or the arch doesn't
     // support it.
     if *opt.target == UefiArch::X86_64 && !opt.disable_network {


### PR DESCRIPTION
Recent versions of edk2 no longer expose some protocols, so disable them on aarch64.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
