### PR TITLE
xtask: Improve QEMU boot time

### DIFF
--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -492,6 +492,12 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
 
     cmd.args(["-device", "virtio-rng-pci"]);
 
+    // Set the boot menu timeout to zero. On aarch64 in particular this speeds
+    // up the boot a lot. Note that we have to enable the menu here even though
+    // we are skipping right past it, otherwise `splash-time` is ignored in
+    // favor of a hardcoded default timeout.
+    cmd.args(["-boot", "menu=on,splash-time=0"]);
+
     match arch {
         UefiArch::AArch64 => {
             // Use a generic ARM environment. Sadly qemu can't emulate a


### PR DESCRIPTION
On aarch64 it sits for a while on the initial screen and shows a progress bar to give the user time to enter the boot menu. We don't want to do that in our tests, so set the timeout to zero.

Even though we're skipping the boot menu, we have to also enable it here, otherwise the timeout value is ignored and a hardcoded platform default of 3 seconds is used.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
