### PR TITLE
uefi: Rename FileSystemIOErrorContext to IoErrorContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## uefi - [Unreleased]
 
+### Changed
+
+- Renamed `FileSystemIOErrorContext` to `IoErrorContext`.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/uefi-test-runner/src/fs/mod.rs
+++ b/uefi-test-runner/src/fs/mod.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use uefi::fs::{FileSystem, FileSystemIOErrorContext, IoError, PathBuf};
+use uefi::fs::{FileSystem, IoError, IoErrorContext, PathBuf};
 use uefi::proto::media::fs::SimpleFileSystem;
 use uefi::table::boot::ScopedProtocol;
 use uefi::{cstr16, fs, Status};
@@ -28,7 +28,7 @@ pub fn test(sfs: ScopedProtocol<SimpleFileSystem>) -> Result<(), fs::Error> {
     let err = fs.copy(cstr16!("not_found"), cstr16!("abc"));
     let expected_err = fs::Error::Io(IoError {
         path: PathBuf::from(cstr16!("not_found")),
-        context: FileSystemIOErrorContext::OpenError,
+        context: IoErrorContext::OpenError,
         uefi_error: uefi::Error::new(Status::NOT_FOUND, ()),
     });
     assert_eq!(err, Err(expected_err));

--- a/uefi/src/fs/file_system/error.rs
+++ b/uefi/src/fs/file_system/error.rs
@@ -23,14 +23,14 @@ pub struct IoError {
     /// The path that led to the error.
     pub path: PathBuf,
     /// The context in which the path was used.
-    pub context: FileSystemIOErrorContext,
+    pub context: IoErrorContext,
     /// The underlying UEFI error.
     pub uefi_error: crate::Error,
 }
 
 /// Enum that further specifies the context in that an [`Error`] occurred.
 #[derive(Debug, Clone, Display, PartialEq, Eq)]
-pub enum FileSystemIOErrorContext {
+pub enum IoErrorContext {
     /// Can't delete the directory.
     CantDeleteDirectory,
     /// Can't delete the file.

--- a/uefi/src/fs/file_system/fs.rs
+++ b/uefi/src/fs/file_system/fs.rs
@@ -85,7 +85,7 @@ impl<'a> FileSystem<'a> {
         file.get_boxed_info().map_err(|err| {
             Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::Metadata,
+                context: IoErrorContext::Metadata,
                 uefi_error: err,
             })
         })
@@ -100,7 +100,7 @@ impl<'a> FileSystem<'a> {
             .into_regular_file()
             .ok_or(Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::NotAFile,
+                context: IoErrorContext::NotAFile,
                 // We do not have a real UEFI error here as we have a logical
                 // problem.
                 uefi_error: Status::INVALID_PARAMETER.into(),
@@ -109,7 +109,7 @@ impl<'a> FileSystem<'a> {
         let info = file.get_boxed_info::<UefiFileInfo>().map_err(|err| {
             Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::Metadata,
+                context: IoErrorContext::Metadata,
                 uefi_error: err,
             })
         })?;
@@ -118,7 +118,7 @@ impl<'a> FileSystem<'a> {
         let read_bytes = file.read(vec.as_mut_slice()).map_err(|err| {
             Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::ReadFailure,
+                context: IoErrorContext::ReadFailure,
                 uefi_error: err.to_err_without_payload(),
             })
         })?;
@@ -139,7 +139,7 @@ impl<'a> FileSystem<'a> {
             .into_directory()
             .ok_or(Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::NotADirectory,
+                context: IoErrorContext::NotADirectory,
                 // We do not have a real UEFI error here as we have a logical
                 // problem.
                 uefi_error: Status::INVALID_PARAMETER.into(),
@@ -165,14 +165,14 @@ impl<'a> FileSystem<'a> {
             UefiFileType::Dir(dir) => dir.delete().map_err(|err| {
                 Error::Io(IoError {
                     path: path.to_path_buf(),
-                    context: FileSystemIOErrorContext::CantDeleteDirectory,
+                    context: IoErrorContext::CantDeleteDirectory,
                     uefi_error: err,
                 })
             }),
             UefiFileType::Regular(_) => {
                 Err(Error::Io(IoError {
                     path: path.to_path_buf(),
-                    context: FileSystemIOErrorContext::NotADirectory,
+                    context: IoErrorContext::NotADirectory,
                     // We do not have a real UEFI error here as we have a logical
                     // problem.
                     uefi_error: Status::INVALID_PARAMETER.into(),
@@ -223,13 +223,13 @@ impl<'a> FileSystem<'a> {
             UefiFileType::Regular(file) => file.delete().map_err(|err| {
                 Error::Io(IoError {
                     path: path.to_path_buf(),
-                    context: FileSystemIOErrorContext::CantDeleteFile,
+                    context: IoErrorContext::CantDeleteFile,
                     uefi_error: err,
                 })
             }),
             UefiFileType::Dir(_) => Err(Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::NotAFile,
+                context: IoErrorContext::NotAFile,
                 // We do not have a real UEFI error here as we have a logical
                 // problem.
                 uefi_error: Status::INVALID_PARAMETER.into(),
@@ -272,14 +272,14 @@ impl<'a> FileSystem<'a> {
         handle.write(content.as_ref()).map_err(|err| {
             Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::WriteFailure,
+                context: IoErrorContext::WriteFailure,
                 uefi_error: err.to_err_without_payload(),
             })
         })?;
         handle.flush().map_err(|err| {
             Error::Io(IoError {
                 path: path.to_path_buf(),
-                context: FileSystemIOErrorContext::FlushFailure,
+                context: IoErrorContext::FlushFailure,
                 uefi_error: err,
             })
         })?;
@@ -295,7 +295,7 @@ impl<'a> FileSystem<'a> {
                     path.push(SEPARATOR_STR);
                     path
                 },
-                context: FileSystemIOErrorContext::CantOpenVolume,
+                context: IoErrorContext::CantOpenVolume,
                 uefi_error: err,
             })
         })
@@ -327,7 +327,7 @@ impl<'a> FileSystem<'a> {
                 log::trace!("Can't open file {path}: {err:?}");
                 Error::Io(IoError {
                     path: path.to_path_buf(),
-                    context: FileSystemIOErrorContext::OpenError,
+                    context: IoErrorContext::OpenError,
                     uefi_error: err,
                 })
             })


### PR DESCRIPTION
It's already in the `fs` module, so the `FileSystem` part is redundent. Also, `IO` -> `Io` to match `IoError`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
