### PR TITLE
uefi: Improve fs error Display impls, drop derive_more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,25 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,15 +386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,12 +404,6 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -584,7 +550,6 @@ name = "uefi"
 version = "0.21.0"
 dependencies = [
  "bitflags 2.2.1",
- "derive_more",
  "log",
  "ptr_meta",
  "ucs2",

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -25,7 +25,6 @@ unstable = []
 
 [dependencies]
 bitflags = "2.1.0"
-derive_more = { version = "0.99.17", features = ["display"] }
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"

--- a/uefi/src/fs/path/validation.rs
+++ b/uefi/src/fs/path/validation.rs
@@ -8,10 +8,10 @@
 use super::Path;
 use crate::fs::CHARACTER_DENY_LIST;
 use crate::Char16;
-use derive_more::Display;
+use core::fmt::{self, Display, Formatter};
 
 /// Errors related to file paths.
-#[derive(Debug, Clone, Eq, PartialEq, Display)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PathError {
     /// The path is empty / points to nothing.
     Empty,
@@ -20,6 +20,22 @@ pub enum PathError {
     EmptyComponent,
     /// There are illegal characters in the path.
     IllegalChar(Char16),
+}
+
+impl Display for PathError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "path is empty"),
+            Self::EmptyComponent => write!(f, "path contains an empty component"),
+            Self::IllegalChar(c) => {
+                write!(
+                    f,
+                    "path contains an illegal character (value {})",
+                    u16::from(*c)
+                )
+            }
+        }
+    }
 }
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
Add some custom Display impls for the various error types to provide more sentence-oriented messages. Drop `derive_more` since it's no longer used.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
