### PR TITLE
uefi-raw: Add Char8/Char16

### DIFF
--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -26,6 +26,21 @@ mod status;
 pub use status::Status;
 pub use uguid::{guid, Guid};
 
+/// One-byte character.
+///
+/// Most strings in UEFI use [`Char16`], but a few places use one-byte
+/// characters. Unless otherwise noted, these are encoded as 8-bit ASCII using
+/// the ISO-Latin-1 character set.
+pub type Char8 = u8;
+
+/// Two-byte character.
+///
+/// Unless otherwise noted, the encoding is UCS-2. The UCS-2 encoding was
+/// defined by Unicode 2.1 and ISO/IEC 10646 standards, but is no longer part of
+/// the modern Unicode standards. It is essentially UTF-16 without support for
+/// surrogate pairs.
+pub type Char16 = u16;
+
 /// Physical memory address. This is always a 64-bit value, regardless
 /// of target platform.
 pub type PhysicalAddress = u64;


### PR DESCRIPTION
These definitions are just type aliases, unlike the more restrictive newtypes in the `uefi` package. In particular, the `uefi` package does not allow `Char16` to be created for surrogate pair characters. This is more restrictive than what UEFI actually specifies though; it says that `Char16` is _usually_ UCS-2, but particular uses may allow other encodings. So for `uefi-raw`, just treat `Char16` as numbers that can hold any `u16` value.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
