### PR TITLE
Move InterfaceType to uefi-raw

### DIFF
--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -3,6 +3,13 @@
 use crate::{PhysicalAddress, VirtualAddress};
 use bitflags::bitflags;
 
+newtype_enum! {
+/// Interface type of a protocol interface.
+pub enum InterfaceType: u32 => {
+    /// Native interface
+    NATIVE_INTERFACE = 0,
+}}
+
 bitflags! {
     /// Flags describing the capabilities of a memory range.
     #[repr(transparent)]

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -20,7 +20,9 @@ use {
     ::alloc::vec::Vec,
 };
 
-pub use uefi_raw::table::boot::{MemoryAttribute, MemoryDescriptor, MemoryType, Tpl};
+pub use uefi_raw::table::boot::{
+    InterfaceType, MemoryAttribute, MemoryDescriptor, MemoryType, Tpl,
+};
 
 // TODO: this similar to `SyncUnsafeCell`. Once that is stabilized we
 // can use it instead.
@@ -2137,16 +2139,6 @@ impl<'a> HandleBuffer<'a> {
         // appropriate lifetime of the slice.
         unsafe { slice::from_raw_parts(self.buffer, self.count) }
     }
-}
-
-newtype_enum! {
-/// Interface type of a protocol interface
-///
-/// Only has one variant when this was written (v2.10 of the UEFI spec)
-pub enum InterfaceType: i32 => {
-    /// Native interface
-    NATIVE_INTERFACE    = 0,
-}
 }
 
 /// Opaque pointer returned by [`BootServices::register_protocol_notify`] to be used


### PR DESCRIPTION
Also changed the underlying type to `u32`. It doesn't really matter in this case; from the FFI perspective they are the same here. But `u32` is more common, so use that.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
