### PR TITLE
xtask: Drop an unused test file

### DIFF
--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -441,9 +441,6 @@ fn build_esp_dir(opt: &QemuOpt) -> Result<PathBuf> {
     }
     fs_err::copy(built_file, boot_dir.join(output_file))?;
 
-    // Add a test file that is used in the media protocol tests.
-    fs_err::write(boot_dir.join("test_input.txt"), "test input data")?;
-
     Ok(esp_dir)
 }
 


### PR DESCRIPTION
The test file that is actually read in the tests is the one created in disk.rs, so drop this vestigial file.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
