### PR TITLE
Move some runtime services types to uefi-raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Renamed `FileSystemIOErrorContext` to `IoErrorContext`.
+- `ResetType` is now a newtype-enum instead of a Rust enum. Its members now have
+  upper-case names.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-raw/src/table/mod.rs
+++ b/uefi-raw/src/table/mod.rs
@@ -4,6 +4,7 @@ mod header;
 mod revision;
 
 pub mod boot;
+pub mod runtime;
 
 pub use header::Header;
 pub use revision::Revision;

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -3,6 +3,28 @@
 use crate::{guid, Guid};
 use bitflags::bitflags;
 
+newtype_enum! {
+    /// The type of system reset.
+    pub enum ResetType: u32 => {
+        /// System-wide reset.
+        ///
+        /// This is analogous to power cycling the device.
+        COLD = 0,
+
+        /// System-wide re-initialization.
+        ///
+        /// If the system doesn't support a warm reset, this will trigger a cold
+        /// reset.
+        WARM = 1,
+
+        /// The system is powered off.
+        SHUTDOWN = 2,
+
+        /// A platform-specific reset type.
+        PLATFORM_SPECIFIC = 3,
+    }
+}
+
 /// Real time clock capabilities.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(C)]

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -1,0 +1,72 @@
+//! UEFI services available at runtime, even after the OS boots.
+
+use crate::{guid, Guid};
+use bitflags::bitflags;
+
+/// Real time clock capabilities.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+pub struct TimeCapabilities {
+    /// Reporting resolution of the clock in counts per second. 1 for a normal
+    /// PC-AT CMOS RTC device, which reports the time with 1-second resolution.
+    pub resolution: u32,
+
+    /// Timekeeping accuracy in units of 1e-6 parts per million.
+    pub accuracy: u32,
+
+    /// Whether a time set operation clears the device's time below the
+    /// "resolution" reporting level. False for normal PC-AT CMOS RTC devices.
+    pub sets_to_zero: bool,
+}
+
+bitflags! {
+    /// Flags describing the attributes of a variable.
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct VariableAttributes: u32 {
+        /// Variable is maintained across a power cycle.
+        const NON_VOLATILE = 0x01;
+
+        /// Variable is accessible during the time that boot services are
+        /// accessible.
+        const BOOTSERVICE_ACCESS = 0x02;
+
+        /// Variable is accessible during the time that runtime services are
+        /// accessible.
+        const RUNTIME_ACCESS = 0x04;
+
+        /// Variable is stored in the portion of NVR allocated for error
+        /// records.
+        const HARDWARE_ERROR_RECORD = 0x08;
+
+        /// Deprecated.
+        const AUTHENTICATED_WRITE_ACCESS = 0x10;
+
+        /// Variable payload begins with an EFI_VARIABLE_AUTHENTICATION_2
+        /// structure.
+        const TIME_BASED_AUTHENTICATED_WRITE_ACCESS = 0x20;
+
+        /// This is never set in the attributes returned by
+        /// `get_variable`. When passed to `set_variable`, the variable payload
+        /// will be appended to the current value of the variable if supported
+        /// by the firmware.
+        const APPEND_WRITE = 0x40;
+
+        /// Variable payload begins with an EFI_VARIABLE_AUTHENTICATION_3
+        /// structure.
+        const ENHANCED_AUTHENTICATED_ACCESS = 0x80;
+    }
+}
+
+newtype_enum! {
+    /// Variable vendor GUID. This serves as a namespace for variables to
+    /// avoid naming conflicts between vendors. The UEFI specification
+    /// defines some special values, and vendors will define their own.
+    pub enum VariableVendor: Guid => {
+        /// Used to access global variables.
+        GLOBAL_VARIABLE = guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c"),
+
+        /// Used to access EFI signature database variables.
+        IMAGE_SECURITY_DATABASE = guid!("d719b2cb-3d3a-4596-a3bc-dad00e67656f"),
+    }
+}

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -225,7 +225,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             if let Some(st) = unsafe { SYSTEM_TABLE.as_ref() } {
                 use uefi::table::runtime::ResetType;
                 st.runtime_services()
-                    .reset(ResetType::Shutdown, uefi::Status::ABORTED, None);
+                    .reset(ResetType::SHUTDOWN, uefi::Status::ABORTED, None);
             }
 
             // If we don't have any shutdown mechanism handy, the best we can do is loop

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -181,7 +181,7 @@ fn shutdown(mut st: SystemTable<Boot>) -> ! {
         // Shut down the system
         let rt = unsafe { st.runtime_services() };
         rt.reset(
-            uefi::table::runtime::ResetType::Shutdown,
+            uefi::table::runtime::ResetType::SHUTDOWN,
             Status::SUCCESS,
             None,
         );

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -2,12 +2,14 @@
 
 use super::{Header, Revision};
 use crate::table::boot::MemoryDescriptor;
-use crate::{guid, CStr16, Char16, Error, Guid, Result, Status, StatusExt};
+use crate::{CStr16, Char16, Error, Guid, Result, Status, StatusExt};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::{fmt, ptr};
+
+pub use uefi_raw::table::runtime::{TimeCapabilities, VariableAttributes, VariableVendor};
 
 #[cfg(feature = "alloc")]
 use {
@@ -601,74 +603,6 @@ impl PartialEq for Time {
 }
 
 impl Eq for Time {}
-
-/// Real time clock capabilities
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[repr(C)]
-pub struct TimeCapabilities {
-    /// Reporting resolution of the clock in counts per second. 1 for a normal
-    /// PC-AT CMOS RTC device, which reports the time with 1-second resolution.
-    pub resolution: u32,
-
-    /// Timekeeping accuracy in units of 1e-6 parts per million.
-    pub accuracy: u32,
-
-    /// Whether a time set operation clears the device's time below the
-    /// "resolution" reporting level. False for normal PC-AT CMOS RTC devices.
-    pub sets_to_zero: bool,
-}
-
-bitflags! {
-    /// Flags describing the attributes of a variable.
-    #[repr(transparent)]
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct VariableAttributes: u32 {
-        /// Variable is maintained across a power cycle.
-        const NON_VOLATILE = 0x01;
-
-        /// Variable is accessible during the time that boot services are
-        /// accessible.
-        const BOOTSERVICE_ACCESS = 0x02;
-
-        /// Variable is accessible during the time that runtime services are
-        /// accessible.
-        const RUNTIME_ACCESS = 0x04;
-
-        /// Variable is stored in the portion of NVR allocated for error
-        /// records.
-        const HARDWARE_ERROR_RECORD = 0x08;
-
-        /// Deprecated.
-        const AUTHENTICATED_WRITE_ACCESS = 0x10;
-
-        /// Variable payload begins with an EFI_VARIABLE_AUTHENTICATION_2
-        /// structure.
-        const TIME_BASED_AUTHENTICATED_WRITE_ACCESS = 0x20;
-
-        /// This is never set in the attributes returned by
-        /// `get_variable`. When passed to `set_variable`, the variable payload
-        /// will be appended to the current value of the variable if supported
-        /// by the firmware.
-        const APPEND_WRITE = 0x40;
-
-        /// Variable payload begins with an EFI_VARIABLE_AUTHENTICATION_3
-        /// structure.
-        const ENHANCED_AUTHENTICATED_ACCESS = 0x80;
-    }
-}
-
-newtype_enum! {
-    /// Variable vendor GUID. This serves as a namespace for variables to
-    /// avoid naming conflicts between vendors. The UEFI specification
-    /// defines some special values, and vendors will define their own.
-    pub enum VariableVendor: Guid => {
-        /// Used to access global variables.
-        GLOBAL_VARIABLE = guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c"),
-
-        /// Used to access EFI signature database variables.
-        IMAGE_SECURITY_DATABASE = guid!("d719b2cb-3d3a-4596-a3bc-dad00e67656f"),
-    }
-}
 
 /// Unique key for a variable.
 #[cfg(feature = "alloc")]

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -9,7 +9,9 @@ use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::{fmt, ptr};
 
-pub use uefi_raw::table::runtime::{TimeCapabilities, VariableAttributes, VariableVendor};
+pub use uefi_raw::table::runtime::{
+    ResetType, TimeCapabilities, VariableAttributes, VariableVendor,
+};
 
 #[cfg(feature = "alloc")]
 use {
@@ -659,26 +661,4 @@ pub struct VariableStorageInfo {
 
     /// Maximum size of an individual variable of the specified type.
     pub maximum_variable_size: u64,
-}
-
-/// The type of system reset.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[repr(u32)]
-pub enum ResetType {
-    /// Resets all the internal circuitry to its initial state.
-    ///
-    /// This is analogous to power cycling the device.
-    Cold = 0,
-    /// The processor is reset to its initial state.
-    Warm,
-    /// The components are powered off.
-    Shutdown,
-    /// A platform-specific reset type.
-    ///
-    /// The additional data must be a pointer to
-    /// a null-terminated string followed by an UUID.
-    PlatformSpecific,
-    // SAFETY: This enum is never exposed to the user, but only fed as input to
-    //         the firmware. Therefore, unexpected values can never come from
-    //         the firmware, and modeling this as a Rust enum seems safe.
 }

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -217,7 +217,7 @@ impl SystemTable<Boot> {
         let boot_services = self.boot_services();
 
         // Reboot the device.
-        let reset = |status| -> ! { self.runtime_services().reset(ResetType::Cold, status, None) };
+        let reset = |status| -> ! { self.runtime_services().reset(ResetType::COLD, status, None) };
 
         // Get the size of the buffer to allocate. If that calculation
         // overflows treat it as an unrecoverable error.


### PR DESCRIPTION
These are direct moves with no changes to the types except for `ResetType`. That type has been changed to a newtype enum since it is used as an output parameter in `QueryCapsuleCapabilities`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
