### PR TITLE
Relax bitflags dep version to 2.0.0

### DIFF
--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 rust-version = "1.68"
 
 [dependencies]
-bitflags = "2.3"
+bitflags = "2.0.0"
 ptr_meta = { version = "0.2.0", default-features = false }
 uguid = "2.0.0"
 

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -24,7 +24,7 @@ panic-on-logger-errors = []
 unstable = []
 
 [dependencies]
-bitflags = "2.3.1"
+bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"


### PR DESCRIPTION
Any of the 2.0/2.1/2.2/2.3 releases should be fine.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
