### PR TITLE
Fix and enable uefi-raw unit/doc tests

### DIFF
--- a/uefi-raw/src/table/revision.rs
+++ b/uefi-raw/src/table/revision.rs
@@ -22,7 +22,7 @@ use core::fmt;
 /// Examples:
 ///
 /// ```
-/// use uefi::table::Revision;
+/// # use uefi_raw::table::Revision;
 /// assert_eq!(Revision::EFI_1_02.to_string(), "1.02");
 /// assert_eq!(Revision::EFI_1_10.to_string(), "1.10");
 /// assert_eq!(Revision::EFI_2_00.to_string(), "2.0");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -180,7 +180,7 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
     };
     run_cmd(cargo.command()?)?;
 
-    let mut packages = vec![Package::Uefi];
+    let mut packages = vec![Package::UefiRaw, Package::Uefi];
     if !test_opt.skip_macro_tests {
         packages.push(Package::UefiMacros);
     }


### PR DESCRIPTION
I missed enabling unit tests for uefi-raw before. This fixes that, and also fixes one error in the doctests.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
