### PR TITLE
xtask: Add check-raw

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Verify generated code is up-to-date
         run: cargo xtask gen-code --check
 
+      - name: Run additional checks on the uefi-raw package
+        run: cargo xtask check-raw
+
   # Run the build with our current stable MSRV (specified in
   # ./msrv_toolchain.toml). This serves to check that we don't
   # accidentally start relying on a new feature without intending

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +628,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,4 +828,5 @@ dependencies = [
  "serde_json",
  "syn 2.0.15",
  "tempfile",
+ "walkdir",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,9 +14,10 @@ itertools = "0.10.5"
 mbrman = "0.5.1"
 nix = { version = "0.26.1", default-features = false, features = ["fs"] }
 os_info = { version = "3.6.0", default-features = false }
-proc-macro2 = "1.0.46"
+proc-macro2 = { version = "1.0.46", features = ["span-locations"] }
 quote = "1.0.21"
 regex = "1.8.1"
 serde_json = "1.0.73"
 syn = { version = "2.0.0", features = ["full"] }
 tempfile = "3.5.0"
+walkdir = "2.3.3"

--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -1,0 +1,548 @@
+//! Validate various properties of the code in the `uefi-raw` package.
+//!
+//! For example, this checks that no Rust enums are used, that structs have an
+//! appropriate repr for FFI, that raw pointers are used instead of references,
+//! and many other things.
+
+use anyhow::Result;
+use fs_err as fs;
+use proc_macro2::TokenStream;
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+use std::process;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::token::Comma;
+use syn::{
+    parenthesized, Abi, Attribute, Field, Fields, FieldsNamed, FieldsUnnamed, File, Item,
+    ItemConst, ItemMacro, ItemStruct, ItemType, LitInt, ReturnType, Type, TypeBareFn, TypePtr,
+    Visibility,
+};
+use walkdir::WalkDir;
+
+/// All possible validation error kinds.
+#[derive(Debug, Eq, PartialEq)]
+enum ErrorKind {
+    ForbiddenAbi,
+    ForbiddenAttr,
+    ForbiddenItemKind,
+    ForbiddenRepr,
+    ForbiddenType,
+    MalformedAttrs,
+    MissingPub,
+    MissingUnsafe,
+    UnderscoreField,
+    UnknownRepr,
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::ForbiddenAbi => "forbidden ABI",
+                Self::ForbiddenAttr => "forbidden attribute",
+                Self::ForbiddenItemKind => "forbidden type of item",
+                Self::ForbiddenRepr => "forbidden repr",
+                Self::ForbiddenType => "forbidden type",
+                Self::MalformedAttrs => "malformed attribute contents",
+                Self::MissingPub => "missing pub",
+                Self::MissingUnsafe => "missing unsafe",
+                Self::UnderscoreField => "field name starts with `_`",
+                Self::UnknownRepr => "unknown repr",
+            }
+        )
+    }
+}
+
+/// Validation error type that includes the error location.
+struct Error {
+    kind: ErrorKind,
+    path: PathBuf,
+    line: usize,
+    column: usize,
+    code: String,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Format the error in the same way a compiler would, which allows
+        // editors/IDEs to parse the source location.
+        write!(
+            f,
+            "error: {}\n  --> {}:{}:{}\n{}",
+            self.kind,
+            self.path.display(),
+            self.line,
+            self.column + 1,
+            self.code,
+        )
+    }
+}
+
+impl Error {
+    fn new(kind: ErrorKind, path: &Path, spanned: &dyn Spanned) -> Self {
+        let span = spanned.span();
+        Self {
+            kind,
+            // Getting the source path from the span is not yet stable:
+            // https://github.com/rust-lang/rust/issues/54725
+            path: path.to_path_buf(),
+            line: span.start().line,
+            column: span.start().column,
+            // This is `None` in unit tests.
+            code: span.source_text().unwrap_or_default(),
+        }
+    }
+}
+
+/// True if the visibility is public without restriction (i.e. just `pub`, not
+/// `pub(crate)` or similar).
+fn is_pub(vis: &Visibility) -> bool {
+    matches!(vis, Visibility::Public(_))
+}
+
+/// Type repr. A type may have more than one of these (e.g. both `C` and `Packed`).
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+enum Repr {
+    Align(usize),
+    C,
+    Packed,
+    Transparent,
+}
+
+/// A restricted view of `Attribute`, limited to just the attributes that are
+/// expected in `uefi-raw`.
+#[derive(Clone, Copy)]
+enum ParsedAttr {
+    Derive,
+    Doc,
+    Repr(Repr),
+}
+
+/// Parse `attrs` into a list of the more restricted `ParsedAttr` enum.
+fn parse_attrs(attrs: &[Attribute], src: &Path) -> Result<Vec<ParsedAttr>, Error> {
+    let mut va = Vec::new();
+    for attr in attrs {
+        let path = attr.path();
+
+        if path.is_ident("derive") {
+            va.push(ParsedAttr::Derive);
+        } else if path.is_ident("doc") {
+            va.push(ParsedAttr::Doc);
+        } else if path.is_ident("repr") {
+            let mut unknown_repr_found = false;
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("C") {
+                    va.push(ParsedAttr::Repr(Repr::C));
+                } else if meta.path.is_ident("packed") {
+                    va.push(ParsedAttr::Repr(Repr::Packed));
+                } else if meta.path.is_ident("transparent") {
+                    va.push(ParsedAttr::Repr(Repr::Transparent));
+                } else if meta.path.is_ident("align") {
+                    let content;
+                    parenthesized!(content in meta.input);
+                    let lit: LitInt = content.parse()?;
+                    let num = lit.base10_parse()?;
+                    va.push(ParsedAttr::Repr(Repr::Align(num)));
+                } else {
+                    unknown_repr_found = true;
+                }
+                Ok(())
+            })
+            .map_err(|_| Error::new(ErrorKind::MalformedAttrs, src, attr))?;
+            if unknown_repr_found {
+                return Err(Error::new(ErrorKind::UnknownRepr, src, attr));
+            }
+        } else {
+            return Err(Error::new(ErrorKind::ForbiddenAttr, src, attr));
+        }
+    }
+    Ok(va)
+}
+
+/// Get a sorted list of all reprs from attributes.
+fn get_reprs(attrs: &[ParsedAttr]) -> Vec<Repr> {
+    let mut reprs: Vec<_> = attrs
+        .iter()
+        .filter_map(|attr| {
+            if let ParsedAttr::Repr(repr) = attr {
+                Some(*repr)
+            } else {
+                None
+            }
+        })
+        .collect();
+    reprs.sort();
+    reprs
+}
+
+/// True if the function is `extern efiapi`.
+fn is_efiapi(f: &TypeBareFn) -> bool {
+    if let Some(Abi {
+        name: Some(name), ..
+    }) = &f.abi
+    {
+        if name.value() == "efiapi" {
+            return true;
+        }
+    }
+    false
+}
+
+/// Validate a type (used for fields, arguments, and return types).
+fn check_type(ty: &Type, src: &Path) -> Result<(), Error> {
+    match ty {
+        Type::BareFn(f) => check_fn_ptr(f, src),
+        Type::Path(_) => {
+            // Allow.
+            Ok(())
+        }
+        Type::Ptr(TypePtr { elem, .. }) => check_type(elem, src),
+        ty => Err(Error::new(ErrorKind::ForbiddenType, src, ty)),
+    }
+}
+
+/// Validate a function pointer.
+fn check_fn_ptr(f: &TypeBareFn, src: &Path) -> Result<(), Error> {
+    // Require `extern efiapi`.
+    if !is_efiapi(f) {
+        return Err(Error::new(ErrorKind::ForbiddenAbi, src, f));
+    }
+
+    // Require `unsafe`.
+    if f.unsafety.is_none() {
+        return Err(Error::new(ErrorKind::MissingUnsafe, src, f));
+    }
+
+    // Validate argument types.
+    for arg in &f.inputs {
+        check_type(&arg.ty, src)?;
+    }
+
+    // Validate return type.
+    match &f.output {
+        ReturnType::Default => {}
+        ReturnType::Type(_, output) => check_type(output, src)?,
+    }
+
+    Ok(())
+}
+
+/// Validate all struct fields. This is used for both named and unnamed fields.
+fn check_fields(fields: &Punctuated<Field, Comma>, src: &Path) -> Result<(), Error> {
+    for field in fields {
+        // Ensure field is public.
+        if !is_pub(&field.vis) {
+            return Err(Error::new(ErrorKind::MissingPub, src, field));
+        }
+
+        // Ensure field name doesn't start with `_`.
+        if let Some(ident) = &field.ident {
+            if ident.to_string().starts_with('_') {
+                return Err(Error::new(ErrorKind::UnderscoreField, src, ident));
+            }
+        }
+
+        // Ensure a valid field type.
+        check_type(&field.ty, src)?;
+    }
+    Ok(())
+}
+
+/// Validate a struct.
+fn check_struct(item: &ItemStruct, src: &Path) -> Result<(), Error> {
+    if !is_pub(&item.vis) {
+        return Err(Error::new(ErrorKind::MissingPub, src, &item.vis));
+    }
+
+    let attrs = parse_attrs(&item.attrs, src)?;
+
+    match &item.fields {
+        Fields::Named(FieldsNamed { named, .. }) => check_fields(named, src)?,
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => check_fields(unnamed, src)?,
+        Fields::Unit => {}
+    }
+
+    let reprs = get_reprs(&attrs);
+    let allowed_reprs: &[&[Repr]] = &[&[Repr::C], &[Repr::C, Repr::Packed], &[Repr::Transparent]];
+    if !allowed_reprs.contains(&reprs.as_slice()) {
+        return Err(Error::new(ErrorKind::ForbiddenRepr, src, item));
+    }
+
+    Ok(())
+}
+
+/// Validate a macro.
+fn check_macro(item: &ItemMacro, src: &Path) -> Result<(), Error> {
+    let mac = &item.mac;
+
+    // Check that uses of the `bitflags` macro always set `repr(transparent)`.
+    if mac.path.is_ident("bitflags") {
+        // Parse just the attributes.
+        struct Attrs(Vec<Attribute>);
+        impl Parse for Attrs {
+            fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+                let x = input.call(Attribute::parse_outer)?;
+                let _: TokenStream = input.parse()?;
+                Ok(Self(x))
+            }
+        }
+        let attrs: Attrs = mac
+            .parse_body()
+            .map_err(|_| Error::new(ErrorKind::MalformedAttrs, src, mac))?;
+        let attrs = parse_attrs(&attrs.0, src)?;
+
+        let reprs = get_reprs(&attrs);
+        let allowed_reprs: &[&[Repr]] = &[&[Repr::Transparent]];
+        if !allowed_reprs.contains(&reprs.as_slice()) {
+            return Err(Error::new(ErrorKind::ForbiddenRepr, src, mac));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a top-level item.
+fn check_item(item: &Item, src: &Path) -> Result<(), Error> {
+    match item {
+        Item::Const(ItemConst { vis, ty, .. }) => {
+            if !is_pub(vis) {
+                return Err(Error::new(ErrorKind::MissingPub, src, item));
+            }
+
+            check_type(ty, src)?;
+        }
+        Item::Struct(item) => {
+            check_struct(item, src)?;
+        }
+        Item::Macro(item) => {
+            check_macro(item, src)?;
+        }
+        Item::Type(ItemType { vis, .. }) => {
+            if !is_pub(vis) {
+                return Err(Error::new(ErrorKind::MissingPub, src, item));
+            }
+        }
+        Item::Impl(_) | Item::Mod(_) | Item::Use(_) => {
+            // Allow.
+        }
+        item => {
+            return Err(Error::new(ErrorKind::ForbiddenItemKind, src, item));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate an entire source file.
+fn check_file(src: &Path) -> Result<()> {
+    println!("checking {}", src.display());
+
+    let code = fs::read_to_string(src)?;
+    let ast: File = syn::parse_str(&code)?;
+
+    for item in ast.items.iter() {
+        // Don't propagate check errors, instead format the error in the same
+        // way as a compiler so that IDEs can parse it.
+        if let Err(err) = check_item(item, src) {
+            println!("{err}");
+            process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate the `uefi-raw` package.
+pub fn check_raw() -> Result<()> {
+    let package_path = Path::new("uefi-raw");
+    assert!(package_path.exists());
+
+    for entry in WalkDir::new(package_path) {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Some(ext) = path.extension() {
+            if ext == "rs" {
+                check_file(path)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    fn src() -> &'static Path {
+        Path::new("test")
+    }
+
+    fn check_item_err(item: Item, expected_error: ErrorKind) {
+        assert_eq!(check_item(&item, src()).unwrap_err().kind, expected_error);
+    }
+
+    #[test]
+    fn test_invalid_item() {
+        // Rust enums are not allowed.
+        check_item_err(
+            parse_quote! {
+                pub enum E {
+                    A
+                }
+            },
+            ErrorKind::ForbiddenItemKind,
+        );
+    }
+
+    #[test]
+    fn test_macro() {
+        // bitflags `repr` must be transparent.
+        check_item_err(
+            parse_quote! {
+                bitflags! {
+                    #[repr(C)]
+                    pub struct Flags: u32 {
+                        const A = 1;
+                    }
+                }
+            },
+            ErrorKind::ForbiddenRepr,
+        );
+    }
+
+    #[test]
+    fn test_fn_ptr() {
+        let check_fn_err = |f, expected_error| {
+            assert_eq!(check_fn_ptr(&f, src()).unwrap_err().kind, expected_error);
+        };
+
+        // Valid fn ptr.
+        assert!(check_fn_ptr(
+            &parse_quote! {
+                unsafe extern "efiapi" fn()
+            },
+            src(),
+        )
+        .is_ok());
+
+        // Not `extern efiapi`.
+        check_fn_err(
+            parse_quote! {
+                unsafe extern "C" fn()
+            },
+            ErrorKind::ForbiddenAbi,
+        );
+
+        // Fn pointer is missing `unsafe`.
+        check_fn_err(
+            parse_quote! {
+                extern "efiapi" fn()
+            },
+            ErrorKind::MissingUnsafe,
+        );
+
+        // Forbidden argument type: reference.
+        check_fn_err(
+            parse_quote! {
+                unsafe extern "efiapi" fn(a: &u32)
+            },
+            ErrorKind::ForbiddenType,
+        );
+
+        // Forbidden return type: reference.
+        check_fn_err(
+            parse_quote! {
+                unsafe extern "efiapi" fn() -> &u32
+            },
+            ErrorKind::ForbiddenType,
+        );
+    }
+
+    #[test]
+    fn test_struct() {
+        // Valid struct.
+        assert!(check_struct(
+            &parse_quote! {
+                #[repr(C)]
+                pub struct S {
+                    pub f: u32,
+                }
+            },
+            src(),
+        )
+        .is_ok());
+
+        // Missing `pub` on struct.
+        check_item_err(
+            parse_quote! {
+                #[repr(C)]
+                struct S {
+                    pub f: u32,
+                }
+            },
+            ErrorKind::MissingPub,
+        );
+
+        // Missing `pub` on field.
+        check_item_err(
+            parse_quote! {
+                #[repr(C)]
+                pub struct S {
+                    f: u32,
+                }
+            },
+            ErrorKind::MissingPub,
+        );
+
+        // Field name starts with `_`.
+        check_item_err(
+            parse_quote! {
+                #[repr(C)]
+                pub struct S {
+                    pub _f: u32,
+                }
+            },
+            ErrorKind::UnderscoreField,
+        );
+
+        // Forbidden `repr`.
+        check_item_err(
+            parse_quote! {
+                pub struct S {
+                    pub f: u32,
+                }
+            },
+            ErrorKind::ForbiddenRepr,
+        );
+
+        // Forbidden attr.
+        check_item_err(
+            parse_quote! {
+                #[hello]
+                #[repr(C)]
+                pub struct S {
+                    pub f: u32,
+                }
+            },
+            ErrorKind::ForbiddenAttr,
+        );
+
+        // Forbidden field type: reference.
+        check_item_err(
+            parse_quote! {
+                #[repr(C)]
+                pub struct S {
+                    pub f: &u32,
+                }
+            },
+            ErrorKind::ForbiddenType,
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 mod arch;
 mod cargo;
+mod check_raw;
 mod device_path;
 mod disk;
 mod net;
@@ -210,6 +211,7 @@ fn main() -> Result<()> {
 
     match &opt.action {
         Action::Build(build_opt) => build(build_opt),
+        Action::CheckRaw(_) => check_raw::check_raw(),
         Action::Clippy(clippy_opt) => clippy(clippy_opt),
         Action::Doc(doc_opt) => doc(doc_opt),
         Action::GenCode(gen_opt) => device_path::gen_code(gen_opt),

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -66,6 +66,7 @@ pub struct Opt {
 #[derive(Debug, Subcommand)]
 pub enum Action {
     Build(BuildOpt),
+    CheckRaw(CheckRawOpt),
     Clippy(ClippyOpt),
     Doc(DocOpt),
     GenCode(GenCodeOpt),
@@ -88,6 +89,10 @@ pub struct BuildOpt {
     #[clap(long, action)]
     pub feature_permutations: bool,
 }
+
+/// Check various properties of the uefi-raw code.
+#[derive(Debug, Parser)]
+pub struct CheckRawOpt {}
 
 /// Run clippy on all the packages.
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Running `cargo xtask check-raw` validates various properties of the code in the `uefi-raw` package. For example, it checks that no Rust enums are used, that structs have an appropriate repr for FFI, that raw pointers are used instead of references, and many other things.

This is run in CI as part of the lint job.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
