### PR TITLE
uefi: Fix use of tuples in pointer structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Renamed `FileSystemIOErrorContext` to `IoErrorContext`.
 - `ResetType` is now a newtype-enum instead of a Rust enum. Its members now have
   upper-case names.
+- `PointerMode` and `PointerState` now contain arrays rather than tuples, as
+  tuples are not FFI safe.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -64,9 +64,9 @@ impl Pointer {
 pub struct PointerMode {
     /// The pointer device's resolution on the X/Y/Z axis in counts/mm.
     /// If a value is 0, then the device does _not_ support that axis.
-    pub resolution: (u64, u64, u64),
+    pub resolution: [u64; 3],
     /// Whether the devices has a left button / right button.
-    pub has_button: (bool, bool),
+    pub has_button: [bool; 2],
 }
 
 /// The relative change in the pointer's state.
@@ -76,9 +76,9 @@ pub struct PointerState {
     /// The relative movement on the X/Y/Z axis.
     ///
     /// If `PointerMode` indicates an axis is not supported, it must be ignored.
-    pub relative_movement: (i32, i32, i32),
+    pub relative_movement: [i32; 3],
     /// Whether the left / right mouse button is currently pressed.
     ///
     /// If `PointerMode` indicates a button is not supported, it must be ignored.
-    pub button: (bool, bool),
+    pub button: [bool; 2],
 }


### PR DESCRIPTION
Tuples are not FFI safe, so replace them with arrays.

Demonstration of FFI warnings: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7c6a699b754782072e09c34debf621ff

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
