### PR TITLE
device_path: add more convenience (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `Event::from_ptr`, `Event::as_ptr`, and `Handle::as_ptr`.
 - Added `ScopedProtocol::get` and `ScopedProtocol::get_mut` to access
   potentially-null interfaces without panicking.
+- `DevicePath::to_string` and `DevicePathNode::to_string`
 
 ### Changed
 - Renamed `LoadImageSource::FromFilePath` to `LoadImageSource::FromDevicePath`

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -1,3 +1,5 @@
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use uefi::prelude::*;
 use uefi::proto::device_path::text::*;
 use uefi::proto::device_path::{DevicePath, LoadedImageDevicePath};
@@ -7,57 +9,113 @@ use uefi::table::boot::BootServices;
 pub fn test(image: Handle, bt: &BootServices) {
     info!("Running device path protocol test");
 
-    let loaded_image = bt
-        .open_protocol_exclusive::<LoadedImage>(image)
-        .expect("Failed to open LoadedImage protocol");
+    // test 1/2: test low-level API by directly opening all protocols
+    {
+        let loaded_image = bt
+            .open_protocol_exclusive::<LoadedImage>(image)
+            .expect("Failed to open LoadedImage protocol");
 
-    let device_path = bt
-        .open_protocol_exclusive::<DevicePath>(loaded_image.device())
-        .expect("Failed to open DevicePath protocol");
+        let device_path = bt
+            .open_protocol_exclusive::<DevicePath>(loaded_image.device())
+            .expect("Failed to open DevicePath protocol");
 
-    let device_path_to_text = bt
-        .open_protocol_exclusive::<DevicePathToText>(
-            bt.get_handle_for_protocol::<DevicePathToText>()
-                .expect("Failed to get DevicePathToText handle"),
-        )
-        .expect("Failed to open DevicePathToText protocol");
+        let device_path_to_text = bt
+            .open_protocol_exclusive::<DevicePathToText>(
+                bt.get_handle_for_protocol::<DevicePathToText>()
+                    .expect("Failed to get DevicePathToText handle"),
+            )
+            .expect("Failed to open DevicePathToText protocol");
 
-    let device_path_from_text = bt
-        .open_protocol_exclusive::<DevicePathFromText>(
-            bt.get_handle_for_protocol::<DevicePathFromText>()
-                .expect("Failed to get DevicePathFromText handle"),
-        )
-        .expect("Failed to open DevicePathFromText protocol");
+        let device_path_from_text = bt
+            .open_protocol_exclusive::<DevicePathFromText>(
+                bt.get_handle_for_protocol::<DevicePathFromText>()
+                    .expect("Failed to get DevicePathFromText handle"),
+            )
+            .expect("Failed to open DevicePathFromText protocol");
 
-    for path in device_path.node_iter() {
-        info!(
-            "path: type={:?}, subtype={:?}, length={}",
-            path.device_type(),
-            path.sub_type(),
-            path.length(),
-        );
+        for path in device_path.node_iter() {
+            info!(
+                "path: type={:?}, subtype={:?}, length={}",
+                path.device_type(),
+                path.sub_type(),
+                path.length(),
+            );
 
-        let text = device_path_to_text
-            .convert_device_node_to_text(bt, path, DisplayOnly(true), AllowShortcuts(false))
-            .expect("Failed to convert device path to text");
-        let text = &*text;
-        info!("path name: {text}");
+            let text = device_path_to_text
+                .convert_device_node_to_text(bt, path, DisplayOnly(true), AllowShortcuts(false))
+                .expect("Failed to convert device path to text");
+            let text = &*text;
+            info!("path name: {text}");
 
-        let convert = device_path_from_text
-            .convert_text_to_device_node(text)
-            .expect("Failed to convert text to device path");
-        assert_eq!(path, convert);
+            let convert = device_path_from_text
+                .convert_text_to_device_node(text)
+                .expect("Failed to convert text to device path");
+            assert_eq!(path, convert);
+        }
+
+        // Get the `LoadedImageDevicePath`. Verify it start with the same nodes as
+        // `device_path`.
+        let loaded_image_device_path = bt
+            .open_protocol_exclusive::<LoadedImageDevicePath>(image)
+            .expect("Failed to open LoadedImageDevicePath protocol");
+
+        for (n1, n2) in device_path
+            .node_iter()
+            .zip(loaded_image_device_path.node_iter())
+        {
+            assert_eq!(n1, n2);
+        }
     }
 
-    // Get the `LoadedImageDevicePath`. Verify it start with the same nodes as
-    // `device_path`.
-    let loaded_image_device_path = bt
-        .open_protocol_exclusive::<LoadedImageDevicePath>(image)
-        .expect("Failed to open LoadedImageDevicePath protocol");
-    for (n1, n2) in device_path
-        .node_iter()
-        .zip(loaded_image_device_path.node_iter())
+    // test 2/2: test high-level to-string api
     {
-        assert_eq!(n1, n2);
+        let loaded_image_device_path = bt
+            .open_protocol_exclusive::<LoadedImageDevicePath>(image)
+            .expect("Failed to open LoadedImageDevicePath protocol");
+        let device_path: &DevicePath = &loaded_image_device_path;
+
+        let path_components = device_path
+            .node_iter()
+            .map(|node| node.to_string(bt, DisplayOnly(false), AllowShortcuts(false)))
+            .map(|str| str.unwrap().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        let expected_device_path_str_components = &[
+            "PciRoot(0x0)",
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            "Pci(0x1F,0x2)",
+            #[cfg(target_arch = "aarch64")]
+            "Pci(0x4,0x0)",
+            // Sata device only used on x86.
+            // See xtask utility.
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            "Sata(0x0,0xFFFF,0x0)",
+            "HD(1,MBR,0xBE1AFDFA,0x3F,0xFBFC1)",
+            "\\efi\\boot\\test_runner.efi",
+        ];
+        let expected_device_path_str =
+            expected_device_path_str_components
+                .iter()
+                .fold(String::new(), |mut acc, next| {
+                    if !acc.is_empty() {
+                        acc.push('/');
+                    }
+                    acc.push_str(next);
+                    acc
+                });
+
+        assert_eq!(
+            path_components.as_slice(),
+            expected_device_path_str_components
+        );
+
+        // Test that to_string works for device_paths
+        let path = device_path
+            .to_string(bt, DisplayOnly(false), AllowShortcuts(false))
+            .unwrap()
+            .unwrap()
+            .to_string();
+
+        assert_eq!(path, expected_device_path_str);
     }
 }

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -598,6 +598,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
         None
     };
 
+    // Print the actual used QEMU command for running the test.
     println!("{}", command_to_string(&cmd));
 
     cmd.stdin(Stdio::piped());


### PR DESCRIPTION
This MR adds convenient methods to transform device paths easier to text. This should make it easier for devs to work with device paths (through convenient debug output).

### The debug output of my example is sth like this:

**for the first helper method (`.to_node_string_pairs`)**

![image](https://github.com/rust-osdev/uefi-rs/assets/5737016/67b384ff-3b3f-4b44-9bba-3867d22ab8c2)

**for the second helper method (`.to_string`)**

![image](https://github.com/rust-osdev/uefi-rs/assets/5737016/53f7a64b-3f8d-48c5-9877-63a3267b7d2e)



## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
