### PR TITLE
uefi: Change file reading to read in 1 MiB chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   upper-case names.
 - `PointerMode` and `PointerState` now contain arrays rather than tuples, as
   tuples are not FFI safe.
+- `RegularFile::read` no longer returns `Option<usize>` in error data. A
+  `BUFFER_TOO_SMALL` error can only occur when reading a directory, not a file.
+- `RegularFile::read` now reads in 1 MiB chunks to avoid a bug in some
+  firmware. This fix also applies to `fs::FileSystem::read`.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -49,7 +49,7 @@ impl Directory {
         FileInfo::assert_aligned(buffer);
 
         // Read the directory entry into the aligned storage
-        self.0.read(buffer).map(|read_bytes| {
+        self.0.read_unchunked(buffer).map(|read_bytes| {
             // 0 read bytes signals that the last directory entry was read
             let last_directory_entry_read = read_bytes == 0;
             if last_directory_entry_read {


### PR DESCRIPTION
Some UEFI implementations have a bug where large reads will incorrectly return an error, so read in 1 MiB chunks to avoid that.

Fixes https://github.com/rust-osdev/uefi-rs/issues/825

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
