### PR TITLE
Release uefi-raw-0.2.0, uefi-0.22.0, and uefi-services-0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## uefi - [Unreleased]
 
+## uefi-macros - [Unreleased]
+
+## uefi-services - [Unreleased]
+
+## uefi - 0.22.0 (2023-06-01)
+
 ### Added
 
 - Added `BootServices::install_configuration_table`.
@@ -18,9 +24,9 @@
 - `RegularFile::read` now reads in 1 MiB chunks to avoid a bug in some
   firmware. This fix also applies to `fs::FileSystem::read`.
 
-## uefi-macros - [Unreleased]
+## uefi-services - 0.19.0 (2023-06-01)
 
-## uefi-services - [Unreleased]
+- Internal updates for changes in `uefi`.
 
 ## uefi - 0.21.0 (2023-05-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,19 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -575,6 +594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +652,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -817,13 +851,29 @@ dependencies = [
 [[package]]
 name = "uefi"
 version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b568c22d9ed54fb8695eff4252975063a3fa20281049df911d0237b44b86b6a"
+dependencies = [
+ "bitflags 2.3.1",
+ "derive_more",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw 0.1.0",
+ "uguid",
+]
+
+[[package]]
+name = "uefi"
+version = "0.22.0"
 dependencies = [
  "bitflags 2.3.1",
  "log",
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.2.0",
  "uguid",
 ]
 
@@ -835,7 +885,18 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi",
+ "uefi 0.21.0",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
+dependencies = [
+ "bitflags 2.3.1",
+ "ptr_meta",
+ "uguid",
 ]
 
 [[package]]
@@ -854,7 +915,7 @@ dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.21.0",
 ]
 
 [[package]]
@@ -863,7 +924,7 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.22.0",
  "uefi-services",
 ]
 
@@ -871,7 +932,7 @@ dependencies = [
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi",
+ "uefi 0.21.0",
  "uefi-services",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.1.0",
  "uguid",
 ]
 
@@ -841,6 +841,17 @@ dependencies = [
 [[package]]
 name = "uefi-raw"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
+dependencies = [
+ "bitflags 2.3.1",
+ "ptr_meta",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.3.1",
  "ptr_meta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,12 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,19 +197,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -594,15 +575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,12 +624,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -850,22 +816,6 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b568c22d9ed54fb8695eff4252975063a3fa20281049df911d0237b44b86b6a"
-dependencies = [
- "bitflags 2.3.1",
- "derive_more",
- "log",
- "ptr_meta",
- "ucs2",
- "uefi-macros",
- "uefi-raw 0.1.0",
- "uguid",
-]
-
-[[package]]
-name = "uefi"
 version = "0.22.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -873,7 +823,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw 0.2.0",
+ "uefi-raw",
  "uguid",
 ]
 
@@ -885,18 +835,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi 0.22.0",
-]
-
-[[package]]
-name = "uefi-raw"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
-dependencies = [
- "bitflags 2.3.1",
- "ptr_meta",
- "uguid",
+ "uefi",
 ]
 
 [[package]]
@@ -906,17 +845,6 @@ dependencies = [
  "bitflags 2.3.1",
  "ptr_meta",
  "uguid",
-]
-
-[[package]]
-name = "uefi-services"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de55164b5fc3eddb8619add9fa14d91321bb337507e1f0d065a992060f1ccafc"
-dependencies = [
- "cfg-if",
- "log",
- "uefi 0.21.0",
 ]
 
 [[package]]
@@ -926,7 +854,7 @@ dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi 0.22.0",
+ "uefi",
 ]
 
 [[package]]
@@ -935,16 +863,16 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi 0.22.0",
- "uefi-services 0.19.0",
+ "uefi",
+ "uefi-services",
 ]
 
 [[package]]
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi 0.22.0",
- "uefi-services 0.18.0",
+ "uefi",
+ "uefi-services",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw 0.1.0",
+ "uefi-raw",
  "uguid",
 ]
 
@@ -836,17 +836,6 @@ dependencies = [
  "syn 2.0.15",
  "trybuild",
  "uefi",
-]
-
-[[package]]
-name = "uefi-raw"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
-dependencies = [
- "bitflags 2.3.1",
- "ptr_meta",
- "uguid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,19 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -575,6 +594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +652,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -816,6 +850,22 @@ dependencies = [
 
 [[package]]
 name = "uefi"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b568c22d9ed54fb8695eff4252975063a3fa20281049df911d0237b44b86b6a"
+dependencies = [
+ "bitflags 2.3.1",
+ "derive_more",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw 0.1.0",
+ "uguid",
+]
+
+[[package]]
+name = "uefi"
 version = "0.22.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -823,7 +873,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.2.0",
  "uguid",
 ]
 
@@ -835,7 +885,18 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi",
+ "uefi 0.22.0",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
+dependencies = [
+ "bitflags 2.3.1",
+ "ptr_meta",
+ "uguid",
 ]
 
 [[package]]
@@ -850,11 +911,22 @@ dependencies = [
 [[package]]
 name = "uefi-services"
 version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de55164b5fc3eddb8619add9fa14d91321bb337507e1f0d065a992060f1ccafc"
+dependencies = [
+ "cfg-if",
+ "log",
+ "uefi 0.21.0",
+]
+
+[[package]]
+name = "uefi-services"
+version = "0.19.0"
 dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.22.0",
 ]
 
 [[package]]
@@ -863,16 +935,16 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi",
- "uefi-services",
+ "uefi 0.22.0",
+ "uefi-services 0.19.0",
 ]
 
 [[package]]
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi",
- "uefi-services",
+ "uefi 0.22.0",
+ "uefi-services 0.18.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,12 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,19 +197,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -594,15 +575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,12 +624,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -850,22 +816,6 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b568c22d9ed54fb8695eff4252975063a3fa20281049df911d0237b44b86b6a"
-dependencies = [
- "bitflags 2.3.1",
- "derive_more",
- "log",
- "ptr_meta",
- "ucs2",
- "uefi-macros",
- "uefi-raw 0.1.0",
- "uguid",
-]
-
-[[package]]
-name = "uefi"
 version = "0.22.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -873,7 +823,7 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw 0.2.0",
+ "uefi-raw",
  "uguid",
 ]
 
@@ -885,18 +835,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi 0.21.0",
-]
-
-[[package]]
-name = "uefi-raw"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
-dependencies = [
- "bitflags 2.3.1",
- "ptr_meta",
- "uguid",
+ "uefi",
 ]
 
 [[package]]
@@ -915,7 +854,7 @@ dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi 0.21.0",
+ "uefi",
 ]
 
 [[package]]
@@ -924,7 +863,7 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi 0.22.0",
+ "uefi",
  "uefi-services",
 ]
 
@@ -932,7 +871,7 @@ dependencies = [
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi 0.21.0",
+ "uefi",
  "uefi-services",
 ]
 

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -18,7 +18,7 @@ In `cargo.toml`, add a few dependencies:
 ```toml
 [dependencies]
 log = "0.4"
-uefi = "0.21"
+uefi = "0.22"
 uefi-services = "0.18"
 ```
 

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -19,7 +19,7 @@ In `cargo.toml`, add a few dependencies:
 [dependencies]
 log = "0.4"
 uefi = "0.22"
-uefi-services = "0.18"
+uefi-services = "0.19"
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 uefi = { version = "0.22.0", features = ["alloc"] }
-uefi-services = "0.18.0"
+uefi-services = "0.19.0"

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.21.0", features = ["alloc"] }
+uefi = { version = "0.22.0", features = ["alloc"] }
 uefi-services = "0.18.0"

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -21,4 +21,4 @@ syn = { version = "2.0.4", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.61"
-uefi = { version = "0.21.0", default-features = false }
+uefi = { version = "0.22.0", default-features = false }

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Rust OSDev team"]
 readme = "README.md"
 edition = "2021"

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Rust OSDev team"]
 readme = "README.md"
 edition = "2021"

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 rust-version = "1.68"
 
 [dependencies]
-uefi = { version = "0.21.0", features = ["global_allocator"] }
+uefi = { version = "0.22.0", features = ["global_allocator"] }
 log = { version = "0.4.5", default-features = false }
 cfg-if = "1.0.0"
 qemu-exit = { version = "3.0.1", optional = true }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["The Rust OSDev team"]
 readme = "README.md"
 edition = "2021"

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.2.0", default-features = false }
 ucs2 = "0.3.2"
 uefi-macros = "0.12.0"
-uefi-raw = "0.1.0"
+uefi-raw = "0.2.0"
 uguid = "2.0.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Closes https://github.com/rust-osdev/uefi-rs/issues/839

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
