### PR TITLE
uefi: Fix wrong install_configuration_table() signature

### DIFF
--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -1,11 +1,13 @@
 use uefi::proto::console::text::Output;
 use uefi::table::boot::{BootServices, SearchType};
+use uefi::table::{Boot, SystemTable};
 use uefi::Identify;
 
-pub fn test(bt: &BootServices) {
+pub fn test(st: &SystemTable<Boot>) {
+    let bt = st.boot_services();
     info!("Testing boot services");
     memory::test(bt);
-    misc::test(bt);
+    misc::test(st);
     test_locate_handle_buffer(bt);
 }
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -49,7 +49,7 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     bt.get_image_file_system(image)
         .expect("Failed to retrieve boot file system");
 
-    boot::test(bt);
+    boot::test(&st);
 
     // Test all the supported protocols.
     proto::test(image, &mut st);

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -174,7 +174,7 @@ pub struct BootServices {
         out_handle: &mut MaybeUninit<Handle>,
     ) -> Status,
     install_configuration_table:
-        extern "efiapi" fn(guid_entry: Guid, table_ptr: *const c_void) -> Status,
+        extern "efiapi" fn(guid_entry: &Guid, table_ptr: *const c_void) -> Status,
 
     // Image services
     load_image: unsafe extern "efiapi" fn(
@@ -1161,7 +1161,7 @@ impl BootServices {
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
     pub unsafe fn install_configuration_table(
         &self,
-        guid_entry: Guid,
+        guid_entry: &Guid,
         table_ptr: *const c_void,
     ) -> Result {
         (self.install_configuration_table)(guid_entry, table_ptr).to_result()


### PR DESCRIPTION
Interestingly, this crashes on aarch64 but works on x86_64. Likely,
the x86_64 calling convention used still passes the Guid struct by
pointer, while the aarch64 passes it by value (or in an unexpected
registers) causing a crash.

This also adds a test case to verify this works correctly now.

Fixes: #842
