### PR TITLE
Fix various CI failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Install QEMU
-        run: choco install qemu
+        run: choco install qemu --version 2023.4.24
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -68,7 +68,7 @@ trait InfoInternal: Align + ptr_meta::Pointee<Metadata = usize> {
     {
         // Calculate the final size of the struct.
         let name_length_ucs2 = name.as_slice_with_nul().len();
-        let name_size = name_length_ucs2 * mem::size_of::<Char16>();
+        let name_size = mem::size_of_val(name.as_slice_with_nul());
         let info_size = Self::name_offset() + name_size;
         let info_size = Self::round_up_to_alignment(info_size);
 

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -680,7 +680,7 @@ impl DiscoverInfo {
         let required_size = core::mem::size_of::<bool>() * 4
             + core::mem::size_of::<IpAddress>()
             + core::mem::size_of::<u16>()
-            + core::mem::size_of::<Server>() * server_count;
+            + core::mem::size_of_val(srv_list);
 
         if buffer.len() < required_size {
             return Err(Status::BUFFER_TOO_SMALL.into());

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -17,7 +17,7 @@ impl Rng {
         &mut self,
         algorithm_list: &'buf mut [RngAlgorithmType],
     ) -> Result<&'buf [RngAlgorithmType], Option<usize>> {
-        let mut algorithm_list_size = algorithm_list.len() * mem::size_of::<RngAlgorithmType>();
+        let mut algorithm_list_size = mem::size_of_val(algorithm_list);
 
         unsafe {
             (self.0.get_info)(

--- a/uefi/src/result/mod.rs
+++ b/uefi/src/result/mod.rs
@@ -1,4 +1,5 @@
-///! Facilities for dealing with UEFI operation results.
+//! Facilities for dealing with UEFI operation results.
+
 use core::fmt::Debug;
 
 /// The error type that we use, essentially a status code + optional additional data


### PR DESCRIPTION
* Windows CI: there are issues with the May 2023 releases of QEMU, pin to a known-working version.

I cherry-picked in two fixes from https://github.com/rust-osdev/uefi-rs/pull/843 as well.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
