### PR TITLE
Release uefi-0.23.0 and uefi-services-0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ## uefi-services - [Unreleased]
 
+## uefi - 0.23.0 (2023-06-04)
+
+### Changed
+
+- Fixed function signature bug in `BootServices::install_configuration_table`.
+
+## uefi-services - 0.20.0 (2023-06-04)
+
+### Changed
+
+- Updated to latest version of `uefi`.
+
 ## uefi - 0.22.0 (2023-06-01)
 
 ### Added
@@ -25,6 +37,8 @@
   firmware. This fix also applies to `fs::FileSystem::read`.
 
 ## uefi-services - 0.19.0 (2023-06-01)
+
+### Changed
 
 - Internal updates for changes in `uefi`.
 
@@ -104,6 +118,8 @@
 - The `entry` macro now works correctly with docstrings.
 
 ## uefi-services - 0.18.0 (2023-05-15)
+
+### Changed
 
 - Internal updates for changes in `uefi`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,21 @@ dependencies = [
 [[package]]
 name = "uefi"
 version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b5a986a0a287cb6d48ed113002d9f807d371513f30db7fbd7fbf87ec5c3f5b8"
+dependencies = [
+ "bitflags 2.3.1",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi"
+version = "0.23.0"
 dependencies = [
  "bitflags 2.3.1",
  "log",
@@ -835,7 +850,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi",
+ "uefi 0.22.0",
 ]
 
 [[package]]
@@ -854,7 +869,7 @@ dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.22.0",
 ]
 
 [[package]]
@@ -863,7 +878,7 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.23.0",
  "uefi-services",
 ]
 
@@ -871,7 +886,7 @@ dependencies = [
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi",
+ "uefi 0.22.0",
  "uefi-services",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,21 +816,6 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5a986a0a287cb6d48ed113002d9f807d371513f30db7fbd7fbf87ec5c3f5b8"
-dependencies = [
- "bitflags 2.3.1",
- "log",
- "ptr_meta",
- "ucs2",
- "uefi-macros",
- "uefi-raw",
- "uguid",
-]
-
-[[package]]
-name = "uefi"
 version = "0.23.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -850,7 +835,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi 0.22.0",
+ "uefi",
 ]
 
 [[package]]
@@ -869,7 +854,7 @@ dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi 0.22.0",
+ "uefi",
 ]
 
 [[package]]
@@ -878,7 +863,7 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi 0.23.0",
+ "uefi",
  "uefi-services",
 ]
 
@@ -886,7 +871,7 @@ dependencies = [
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi 0.22.0",
+ "uefi",
  "uefi-services",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,21 +816,6 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5a986a0a287cb6d48ed113002d9f807d371513f30db7fbd7fbf87ec5c3f5b8"
-dependencies = [
- "bitflags 2.3.1",
- "log",
- "ptr_meta",
- "ucs2",
- "uefi-macros",
- "uefi-raw",
- "uguid",
-]
-
-[[package]]
-name = "uefi"
 version = "0.23.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -850,7 +835,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi 0.23.0",
+ "uefi",
 ]
 
 [[package]]
@@ -864,23 +849,12 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033fe0196c749908abc54642a8a04e5d2b5bfe4d3d0a58c7777aea75636e8027"
-dependencies = [
- "cfg-if",
- "log",
- "uefi 0.22.0",
-]
-
-[[package]]
-name = "uefi-services"
 version = "0.20.0"
 dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi 0.23.0",
+ "uefi",
 ]
 
 [[package]]
@@ -889,16 +863,16 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi 0.23.0",
- "uefi-services 0.20.0",
+ "uefi",
+ "uefi-services",
 ]
 
 [[package]]
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi 0.23.0",
- "uefi-services 0.19.0",
+ "uefi",
+ "uefi-services",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,21 @@ dependencies = [
 
 [[package]]
 name = "uefi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b5a986a0a287cb6d48ed113002d9f807d371513f30db7fbd7fbf87ec5c3f5b8"
+dependencies = [
+ "bitflags 2.3.1",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi"
 version = "0.23.0"
 dependencies = [
  "bitflags 2.3.1",
@@ -835,7 +850,7 @@ dependencies = [
  "quote",
  "syn 2.0.15",
  "trybuild",
- "uefi",
+ "uefi 0.23.0",
 ]
 
 [[package]]
@@ -850,11 +865,22 @@ dependencies = [
 [[package]]
 name = "uefi-services"
 version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033fe0196c749908abc54642a8a04e5d2b5bfe4d3d0a58c7777aea75636e8027"
+dependencies = [
+ "cfg-if",
+ "log",
+ "uefi 0.22.0",
+]
+
+[[package]]
+name = "uefi-services"
+version = "0.20.0"
 dependencies = [
  "cfg-if",
  "log",
  "qemu-exit",
- "uefi",
+ "uefi 0.23.0",
 ]
 
 [[package]]
@@ -863,16 +889,16 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
- "uefi",
- "uefi-services",
+ "uefi 0.23.0",
+ "uefi-services 0.20.0",
 ]
 
 [[package]]
 name = "uefi_app"
 version = "0.1.0"
 dependencies = [
- "uefi",
- "uefi-services",
+ "uefi 0.23.0",
+ "uefi-services 0.19.0",
 ]
 
 [[package]]

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -19,7 +19,7 @@ In `cargo.toml`, add a few dependencies:
 [dependencies]
 log = "0.4"
 uefi = "0.23"
-uefi-services = "0.19"
+uefi-services = "0.20"
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -18,7 +18,7 @@ In `cargo.toml`, add a few dependencies:
 ```toml
 [dependencies]
 log = "0.4"
-uefi = "0.22"
+uefi = "0.23"
 uefi-services = "0.19"
 ```
 

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.22.0", features = ["alloc"] }
+uefi = { version = "0.23.0", features = ["alloc"] }
 uefi-services = "0.19.0"

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 uefi = { version = "0.23.0", features = ["alloc"] }
-uefi-services = "0.19.0"
+uefi-services = "0.20.0"

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -21,4 +21,4 @@ syn = { version = "2.0.4", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.61"
-uefi = { version = "0.22.0", default-features = false }
+uefi = { version = "0.23.0", default-features = false }

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["The Rust OSDev team"]
 readme = "README.md"
 edition = "2021"

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 rust-version = "1.68"
 
 [dependencies]
-uefi = { version = "0.22.0", features = ["global_allocator"] }
+uefi = { version = "0.23.0", features = ["global_allocator"] }
 log = { version = "0.4.5", default-features = false }
 cfg-if = "1.0.0"
 qemu-exit = { version = "3.0.1", optional = true }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["The Rust OSDev team"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
Closes https://github.com/rust-osdev/uefi-rs/issues/845

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
