### PR TITLE
device_path: add more convenience (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## uefi - [Unreleased]
 
+### Added
+- `DevicePath::to_boxed`, `DevicePath::to_owned`, and `DevicePath::as_bytes`
+- `DevicePathInstance::to_boxed`, `DevicePathInstance::to_owned`, and `DevicePathInstance::as_bytes`
+- `DevicePathNode::data`
+
+### Changed
+
+### Removed
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/uefi/src/fs/file_system/error.rs
+++ b/uefi/src/fs/file_system/error.rs
@@ -1,7 +1,6 @@
 use crate::fs::{PathBuf, PathError};
 use alloc::string::FromUtf8Error;
-use core::fmt::Debug;
-use core::fmt::{self, Display, Formatter};
+use core::fmt::{self, Debug, Display, Formatter};
 
 /// All errors that can happen when working with the [`FileSystem`].
 ///


### PR DESCRIPTION
To enable a faster merge, this is a split from #827. It adds more convenience for device paths.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
