### PR TITLE
Derive `Debug` in more places (requires Rust 1.70)

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68"
+channel = "1.70"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## uefi - [Unreleased]
 
 ### Changed
+- MSRV bumped to 1.70.
 - `Input::wait_for_key_event` now returns an `Option<Event>`, and is no longer `const`.
 - `Protocol::wait_for_input_event` now returns an `Option<Event>`, and is no longer `const`.
 - `LoadedImage::device` now returns an `Option<Handle>` and is no longer `const`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 keywords = ["uefi", "efi"]
 license = "MPL-2.0"
 repository = "https://github.com/rust-osdev/uefi-rs"
-rust-version = "1.68"
+rust-version = "1.70"
 
 [workspace.dependencies]
 bitflags = "2.0.0"

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -82,12 +82,6 @@ pub fn unsafe_protocol(args: TokenStream, input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
 
     quote! {
-        // Disable this lint for now. It doesn't account for the fact that
-        // currently it doesn't work to `derive(Debug)` on structs that have
-        // `extern "efiapi" fn` fields, which most protocol structs have. The
-        // derive _does_ work in current nightly (1.70.0) though, so hopefully
-        // in a couple Rust releases we can drop this.
-        #[allow(missing_debug_implementations)]
         #item_struct
 
         unsafe impl #impl_generics ::uefi::Identify for #ident #ty_generics #where_clause {

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![deny(missing_debug_implementations)]
 #![deny(clippy::all)]
 #![deny(clippy::ptr_as_ptr, unused)]
 #![deny(clippy::must_use_candidate)]

--- a/uefi-raw/src/protocol/block.rs
+++ b/uefi-raw/src/protocol/block.rs
@@ -26,6 +26,7 @@ pub struct BlockIoMedia {
     pub optimal_transfer_length_granularity: u32,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct BlockIoProtocol {
     pub revision: u64,

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -10,6 +10,7 @@ pub struct InputKey {
     pub unicode_char: Char16,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextInputProtocol {
     pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
@@ -32,6 +33,7 @@ pub struct SimpleTextOutputMode {
     pub cursor_visible: bool,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextOutputProtocol {
     pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended: bool) -> Status,
@@ -76,6 +78,7 @@ pub struct SimplePointerState {
     pub right_button: u8,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct SimplePointerProtocol {
     pub reset: unsafe extern "efiapi" fn(
@@ -94,6 +97,7 @@ impl SimplePointerProtocol {
     pub const GUID: Guid = guid!("31878c87-0b75-11d5-9a4f-0090273fc14d");
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct GraphicsOutputProtocol {
     pub query_mode: unsafe extern "efiapi" fn(

--- a/uefi-raw/src/protocol/console/serial.rs
+++ b/uefi-raw/src/protocol/console/serial.rs
@@ -75,6 +75,7 @@ pub struct SerialIoMode {
     pub stop_bits: StopBits,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct SerialIoProtocol {
     pub revision: u32,

--- a/uefi-raw/src/protocol/disk.rs
+++ b/uefi-raw/src/protocol/disk.rs
@@ -1,6 +1,7 @@
 use crate::{guid, Event, Guid, Status};
 use core::ffi::c_void;
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct DiskIoProtocol {
     pub revision: u64,
@@ -32,6 +33,7 @@ pub struct DiskIo2Token {
     pub transaction_status: Status,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct DiskIo2Protocol {
     pub revision: u64,

--- a/uefi-raw/src/protocol/driver.rs
+++ b/uefi-raw/src/protocol/driver.rs
@@ -1,5 +1,6 @@
 use crate::{guid, Guid, Handle, Status};
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct ComponentName2Protocol {
     pub get_driver_name: unsafe extern "efiapi" fn(

--- a/uefi-raw/src/protocol/loaded_image.rs
+++ b/uefi-raw/src/protocol/loaded_image.rs
@@ -4,7 +4,7 @@ use crate::table::system::SystemTable;
 use crate::{guid, Guid, Handle, Status};
 use core::ffi::c_void;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct LoadedImageProtocol {
     pub revision: u32,

--- a/uefi-raw/src/protocol/memory_protection.rs
+++ b/uefi-raw/src/protocol/memory_protection.rs
@@ -1,6 +1,7 @@
 use crate::table::boot::MemoryAttribute;
 use crate::{guid, Guid, PhysicalAddress, Status};
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct MemoryAttributeProtocol {
     pub get_memory_attributes: unsafe extern "efiapi" fn(

--- a/uefi-raw/src/protocol/rng.rs
+++ b/uefi-raw/src/protocol/rng.rs
@@ -33,6 +33,7 @@ newtype_enum! {
 }
 
 /// Rng protocol.
+#[derive(Debug)]
 #[repr(C)]
 pub struct RngProtocol {
     pub get_info: unsafe extern "efiapi" fn(

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -7,6 +7,7 @@ use bitflags::bitflags;
 use core::ffi::c_void;
 
 /// Table of pointers to all the boot services.
+#[derive(Debug)]
 #[repr(C)]
 pub struct BootServices {
     pub header: Header,
@@ -397,6 +398,7 @@ impl MemoryType {
     }
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct OpenProtocolInformationEntry {
     pub agent_handle: Handle,

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -12,6 +12,7 @@ use core::ffi::c_void;
 ///
 /// This table, and the function pointers it contains are valid even after the
 /// UEFI OS loader and OS have taken control of the platform.
+#[derive(Debug)]
 #[repr(C)]
 pub struct RuntimeServices {
     pub header: Header,

--- a/uefi/README.md
+++ b/uefi/README.md
@@ -49,8 +49,7 @@ For additional information, refer to the [UEFI specification][spec].
 
 ## MSRV
 
-The minimum supported Rust version is currently 1.68, which is the first Rust
-release that fully supports all necessary features on the stable channel.
+The minimum supported Rust version is currently 1.70.
 
 Our policy is to support at least the past two stable releases.
 

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -67,6 +67,7 @@ pub use uefi_raw::protocol::console::PixelBitmask;
 ///
 /// The GOP can be used to set the properties of the frame buffer,
 /// and also allows the app to access the in-memory buffer.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(GraphicsOutputProtocol::GUID)]
 pub struct GraphicsOutput(GraphicsOutputProtocol);

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -5,6 +5,7 @@ use crate::{Event, Result, Status, StatusExt};
 use uefi_raw::protocol::console::SimplePointerProtocol;
 
 /// Provides information about a pointer device.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(SimplePointerProtocol::GUID)]
 pub struct Pointer(SimplePointerProtocol);

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -15,6 +15,7 @@ pub use uefi_raw::protocol::console::serial::{ControlBits, Parity, StopBits};
 ///
 /// Since UEFI drivers are implemented through polling, if you fail to regularly
 /// check for input/output, some data might be lost.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(SerialIoProtocol::GUID)]
 pub struct Serial(SerialIoProtocol);

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -4,6 +4,7 @@ use core::mem::MaybeUninit;
 use uefi_raw::protocol::console::{InputKey, SimpleTextInputProtocol};
 
 /// Interface for text-based input devices.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(SimpleTextInputProtocol::GUID)]
 pub struct Input(SimpleTextInputProtocol);

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -1,7 +1,6 @@
 use crate::proto::unsafe_protocol;
 use crate::{CStr16, Result, ResultExt, Status, StatusExt};
 use core::fmt;
-use core::fmt::{Debug, Formatter};
 use uefi_raw::protocol::console::{SimpleTextOutputMode, SimpleTextOutputProtocol};
 
 /// Interface for text-based output devices.
@@ -21,6 +20,7 @@ use uefi_raw::protocol::console::{SimpleTextOutputMode, SimpleTextOutputProtocol
 /// [`SystemTable::stdout`]: crate::table::SystemTable::stdout
 /// [`SystemTable::stderr`]: crate::table::SystemTable::stderr
 /// [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(SimpleTextOutputProtocol::GUID)]
 pub struct Output(SimpleTextOutputProtocol);
@@ -214,38 +214,6 @@ impl fmt::Write for Output {
 
         // Flush the remainder of the buffer
         flush_buffer(&mut buf, &mut i)
-    }
-}
-
-impl Debug for Output {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Output")
-            .field("reset (fn ptr)", &(self.0.reset as *const u64))
-            .field(
-                "output_string (fn ptr)",
-                &(self.0.output_string as *const u64),
-            )
-            .field("test_string (fn ptr)", &(self.0.test_string as *const u64))
-            .field("query_mode (fn ptr)", &(self.0.query_mode as *const u64))
-            .field("set_mode (fn ptr)", &(self.0.set_mode as *const u64))
-            .field(
-                "set_attribute (fn ptr)",
-                &(self.0.set_attribute as *const u64),
-            )
-            .field(
-                "clear_screen (fn ptr)",
-                &(self.0.clear_screen as *const u64),
-            )
-            .field(
-                "set_cursor_position (fn ptr)",
-                &(self.0.set_cursor_position as *const u64),
-            )
-            .field(
-                "enable_cursor (fn ptr)",
-                &(self.0.enable_cursor as *const u64),
-            )
-            .field("data", &self.0.mode)
-            .finish()
     }
 }
 

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -29,6 +29,7 @@ mod exception;
 /// one for any given instruction set.
 ///
 /// NOTE: OVMF only implements this protocol interface for the virtual EBC processor
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("2755590c-6f3c-42fa-9ea4-a3ba543cda25")]
 pub struct DebugSupport {
@@ -174,6 +175,7 @@ pub enum ProcessorArch: u32 => {
 
 /// The debug port protocol abstracts the underlying debug port
 /// hardware, whether it is a regular Serial port or something else.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("eba4e8d2-3858-41ec-a281-2647ba9660d0")]
 pub struct DebugPort {

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -754,7 +754,7 @@ pub enum NodeConversionError {
 /// [`load_image`]: crate::table::boot::BootServices::load_image
 #[repr(transparent)]
 #[unsafe_protocol("bc62157e-3e33-4fec-9920-2d3b36d750df")]
-#[derive(Pointee)]
+#[derive(Debug, Pointee)]
 pub struct LoadedImageDevicePath(DevicePath);
 
 impl ProtocolPointer for LoadedImageDevicePath {

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -80,6 +80,7 @@ impl Drop for PoolString<'_> {
 ///
 /// This protocol provides common utility functions for converting device
 /// nodes and device paths to a text representation.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("8b843e20-8132-4852-90cc-551a4e4a7f1c")]
 pub struct DevicePathToText {
@@ -147,6 +148,7 @@ impl DevicePathToText {
 ///
 /// This protocol provides common utilities for converting text to
 /// device paths and device nodes.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("05c99a21-c70f-4ad2-8a5f-35df3343f51e")]
 pub struct DevicePathFromText {

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -27,6 +27,7 @@ use uefi_raw::protocol::driver::ComponentName2Protocol;
 /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
 #[deprecated = "deprecated in UEFI 2.1; use ComponentName2 where possible"]
 #[unsafe_protocol(ComponentName2Protocol::DEPRECATED_COMPONENT_NAME_GUID)]
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct ComponentName1(
     // The layout of the protocol is the same as ComponentName2, only the format
@@ -97,6 +98,7 @@ impl ComponentName1 {
 /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
 /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
 #[unsafe_protocol(ComponentName2Protocol::GUID)]
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct ComponentName2(ComponentName2Protocol);
 

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -11,6 +11,7 @@ use core::{mem, slice};
 use uefi_raw::protocol::loaded_image::LoadedImageProtocol;
 
 /// The LoadedImage protocol. This can be opened on any image handle using the `HandleProtocol` boot service.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(LoadedImageProtocol::GUID)]
 pub struct LoadedImage(LoadedImageProtocol);

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -6,6 +6,7 @@ use crate::{Result, StatusExt};
 pub use uefi_raw::protocol::block::{BlockIoProtocol, Lba};
 
 /// The Block I/O protocol.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(BlockIoProtocol::GUID)]
 pub struct BlockIO(BlockIoProtocol);

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -12,6 +12,7 @@ use uefi_raw::protocol::disk::{DiskIo2Protocol, DiskIoProtocol};
 /// protocol to a more general offset-length protocol. Firmware is
 /// responsible for adding this protocol to any block I/O interface that
 /// appears in the system that does not already have a disk I/O protocol.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(DiskIoProtocol::GUID)]
 pub struct DiskIo(DiskIoProtocol);
@@ -87,6 +88,7 @@ pub struct DiskIo2Token {
 ///
 /// This protocol provides an extension to the disk I/O protocol to enable
 /// non-blocking / asynchronous byte-oriented disk operation.
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(DiskIo2Protocol::GUID)]
 pub struct DiskIo2(DiskIo2Protocol);

--- a/uefi/src/proto/media/fs.rs
+++ b/uefi/src/proto/media/fs.rs
@@ -19,6 +19,7 @@ use core::ptr;
 ///
 /// [`BootServices::get_image_file_system`]: crate::table::boot::BootServices::get_image_file_system
 /// [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("964e5b22-6459-11d2-8e39-00a0c969723b")]
 pub struct SimpleFileSystem {

--- a/uefi/src/proto/media/partition.rs
+++ b/uefi/src/proto/media/partition.rs
@@ -220,6 +220,7 @@ newtype_enum! {
 }
 
 /// Protocol for accessing partition information.
+#[allow(missing_debug_implementations)]
 #[repr(C)]
 #[repr(packed)]
 #[unsafe_protocol("8cf2f62c-bc9b-4821-808d-ec9ec421a1a0")]

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -17,6 +17,7 @@ use crate::{CStr8, Char8, Result, Status, StatusExt};
 use super::{IpAddress, MacAddress};
 
 /// PXE Base Code protocol
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("03c4e603-ac28-11d3-9a2d-0090273fc14d")]
 #[allow(clippy::type_complexity)]

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -17,6 +17,7 @@ use core::ptr::NonNull;
 use uefi_macros::unsafe_protocol;
 
 /// The Simple Network Protocol
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("a19832b9-ac25-11d3-9a2d-0090273fc14d")]
 pub struct SimpleNetwork {

--- a/uefi/src/proto/pi/mp.rs
+++ b/uefi/src/proto/pi/mp.rs
@@ -93,6 +93,7 @@ pub struct CpuPhysicalLocation {
 }
 
 /// Protocol that provides services needed for multi-processor management.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("3fdda605-a76e-4f46-ad29-12f4531b3d08")]
 pub struct MpServices {

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -7,6 +7,7 @@ use core::{mem, ptr};
 pub use uefi_raw::protocol::rng::RngAlgorithmType;
 
 /// Rng protocol
+#[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(uefi_raw::protocol::rng::RngProtocol::GUID)]
 pub struct Rng(uefi_raw::protocol::rng::RngProtocol);

--- a/uefi/src/proto/security/memory_protection.rs
+++ b/uefi/src/proto/security/memory_protection.rs
@@ -9,6 +9,7 @@ use uefi_raw::protocol::memory_protection::MemoryAttributeProtocol;
 ///
 /// Corresponds to the C type `EFI_MEMORY_ATTRIBUTE_PROTOCOL`.
 #[repr(transparent)]
+#[derive(Debug)]
 #[unsafe_protocol(MemoryAttributeProtocol::GUID)]
 pub struct MemoryProtection(MemoryAttributeProtocol);
 

--- a/uefi/src/proto/shim/mod.rs
+++ b/uefi/src/proto/shim/mod.rs
@@ -65,6 +65,7 @@ macro_rules! shim_function {
 /// application may itself be a bootloader that needs to validate
 /// another EFI application before running it, and the shim lock
 /// protocol exists to support that.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("605dab50-e046-4300-abb6-3dd810dd8b23")]
 pub struct ShimLock {

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -11,6 +11,7 @@ use core::fmt::{self, Display, Formatter};
 /// The Unicode Collation Protocol.
 ///
 /// Used to perform case-insensitive comparisons of strings.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("a4c751fc-23ae-4c3e-92e9-4964cf63f349")]
 pub struct UnicodeCollation {

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -325,6 +325,7 @@ impl<'a> Iterator for EventLogIter<'a> {
 /// Protocol for interacting with TPM 1.1 and 1.2 devices.
 ///
 /// The corresponding C type is `EFI_TCG_PROTOCOL`.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("f541796d-a62e-4954-a775-9584f61b9cdd")]
 pub struct Tcg {

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -563,6 +563,7 @@ impl<'a> Iterator for EventLogIter<'a> {
 /// devices, but most firmware only uses it for TPM 2.0.
 ///
 /// The corresponding C type is `EFI_TCG2_PROTOCOL`.
+#[derive(Debug)]
 #[repr(C)]
 #[unsafe_protocol("607f766c-7455-42be-930b-e4d76db2720f")]
 pub struct Tcg {

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -10,7 +10,6 @@ use crate::util::opt_nonnull_to_ptr;
 use crate::{Char16, Error, Event, Guid, Handle, Result, Status, StatusExt};
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
-use core::fmt::{Debug, Formatter};
 use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
@@ -89,6 +88,7 @@ pub const PAGE_SIZE: usize = 4096;
 ///
 /// [`Output`]: crate::proto::console::text::Output
 /// [`open_protocol`]: BootServices::open_protocol
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct BootServices(uefi_raw::table::boot::BootServices);
 
@@ -1388,139 +1388,6 @@ impl BootServices {
 
 impl super::Table for BootServices {
     const SIGNATURE: u64 = 0x5652_4553_544f_4f42;
-}
-
-impl Debug for BootServices {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        #[allow(deprecated)]
-        f.debug_struct("BootServices")
-            .field("header", &self.0.header)
-            .field("raise_tpl (fn ptr)", &(self.0.raise_tpl as *const usize))
-            .field(
-                "restore_tpl (fn ptr)",
-                &(self.0.restore_tpl as *const usize),
-            )
-            .field(
-                "allocate_pages (fn ptr)",
-                &(self.0.allocate_pages as *const usize),
-            )
-            .field("free_pages (fn ptr)", &(self.0.free_pages as *const usize))
-            .field(
-                "get_memory_map (fn ptr)",
-                &(self.0.get_memory_map as *const usize),
-            )
-            .field(
-                "allocate_pool (fn ptr)",
-                &(self.0.allocate_pool as *const usize),
-            )
-            .field("free_pool (fn ptr)", &(self.0.free_pool as *const usize))
-            .field(
-                "create_event (fn ptr)",
-                &(self.0.create_event as *const usize),
-            )
-            .field("set_timer (fn ptr)", &(self.0.set_timer as *const usize))
-            .field(
-                "wait_for_event (fn ptr)",
-                &(self.0.wait_for_event as *const usize),
-            )
-            .field("signal_event", &(self.0.signal_event as *const usize))
-            .field("close_event", &(self.0.close_event as *const usize))
-            .field("check_event", &(self.0.check_event as *const usize))
-            .field(
-                "install_protocol_interface",
-                &(self.0.install_protocol_interface as *const usize),
-            )
-            .field(
-                "reinstall_protocol_interface",
-                &(self.0.reinstall_protocol_interface as *const usize),
-            )
-            .field(
-                "uninstall_protocol_interface",
-                &(self.0.uninstall_protocol_interface as *const usize),
-            )
-            .field(
-                "handle_protocol (fn ptr)",
-                &(self.0.handle_protocol as *const usize),
-            )
-            .field(
-                "register_protocol_notify",
-                &(self.0.register_protocol_notify as *const usize),
-            )
-            .field(
-                "locate_handle (fn ptr)",
-                &(self.0.locate_handle as *const usize),
-            )
-            .field(
-                "locate_device_path (fn ptr)",
-                &(self.0.locate_device_path as *const usize),
-            )
-            .field(
-                "install_configuration_table (fn ptr)",
-                &(self.0.install_configuration_table as *const usize),
-            )
-            .field("load_image (fn ptr)", &(self.0.load_image as *const usize))
-            .field(
-                "start_image (fn ptr)",
-                &(self.0.start_image as *const usize),
-            )
-            .field("exit", &(self.0.exit as *const usize))
-            .field(
-                "unload_image (fn ptr)",
-                &(self.0.unload_image as *const usize),
-            )
-            .field(
-                "exit_boot_services (fn ptr)",
-                &(self.0.exit_boot_services as *const usize),
-            )
-            .field(
-                "get_next_monotonic_count",
-                &(self.0.get_next_monotonic_count as *const usize),
-            )
-            .field("stall (fn ptr)", &(self.0.stall as *const usize))
-            .field(
-                "set_watchdog_timer (fn ptr)",
-                &(self.0.set_watchdog_timer as *const usize),
-            )
-            .field(
-                "connect_controller",
-                &(self.0.connect_controller as *const usize),
-            )
-            .field(
-                "disconnect_controller",
-                &(self.0.disconnect_controller as *const usize),
-            )
-            .field("open_protocol", &(self.0.open_protocol as *const usize))
-            .field("close_protocol", &(self.0.close_protocol as *const usize))
-            .field(
-                "open_protocol_information",
-                &(self.0.open_protocol_information as *const usize),
-            )
-            .field(
-                "protocols_per_handle",
-                &(self.0.protocols_per_handle as *const usize),
-            )
-            .field(
-                "locate_handle_buffer",
-                &(self.0.locate_handle_buffer as *const usize),
-            )
-            .field(
-                "locate_protocol (fn ptr)",
-                &(self.0.locate_protocol as *const usize),
-            )
-            .field(
-                "install_multiple_protocol_interfaces",
-                &(self.0.install_multiple_protocol_interfaces as *const usize),
-            )
-            .field(
-                "uninstall_multiple_protocol_interfaces",
-                &(self.0.uninstall_multiple_protocol_interfaces as *const usize),
-            )
-            .field("calculate_crc32", &(self.0.calculate_crc32 as *const usize))
-            .field("copy_mem (fn ptr)", &(self.0.copy_mem as *const usize))
-            .field("set_mem (fn ptr)", &(self.0.set_mem as *const usize))
-            .field("create_event_ex", &(self.0.create_event_ex as *const usize))
-            .finish()
-    }
 }
 
 /// Used as a parameter of [`BootServices::load_image`] to provide the

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -31,6 +31,7 @@ use {
 /// A reference to `RuntimeServices` can only be accessed by calling [`SystemTable::runtime_services`].
 ///
 /// [`SystemTable::runtime_services`]: crate::table::SystemTable::runtime_services
+#[derive(Debug)]
 #[repr(C)]
 pub struct RuntimeServices(uefi_raw::table::runtime::RuntimeServices);
 
@@ -295,21 +296,6 @@ impl super::Table for RuntimeServices {
     const SIGNATURE: u64 = 0x5652_4553_544e_5552;
 }
 
-impl Debug for RuntimeServices {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RuntimeServices")
-            .field("header", &self.0.header)
-            .field("get_time", &(self.0.get_time as *const u64))
-            .field("set_time", &(self.0.set_time as *const u64))
-            .field(
-                "set_virtual_address_map",
-                &(self.0.set_virtual_address_map as *const u64),
-            )
-            .field("reset", &(self.0.reset_system as *const u64))
-            .finish()
-    }
-}
-
 /// Date and time representation.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
@@ -464,8 +450,8 @@ impl Time {
     }
 }
 
-impl fmt::Debug for Time {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Debug for Time {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "{:04}-{:02}-{:02} ",
@@ -485,7 +471,7 @@ impl fmt::Debug for Time {
     }
 }
 
-impl fmt::Display for Time {
+impl Display for Time {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -509,8 +495,8 @@ impl VariableKey {
 }
 
 #[cfg(feature = "alloc")]
-impl fmt::Display for VariableKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for VariableKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "VariableKey {{ name: ")?;
 
         match self.name() {

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -1,5 +1,4 @@
 use core::ffi::c_void;
-use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::slice;
@@ -45,6 +44,7 @@ impl SystemTableView for Runtime {}
 /// table will be destroyed (which conveniently invalidates all references to
 /// UEFI boot services in the eye of the Rust borrow checker) and a runtime view
 /// will be provided to replace it.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct SystemTable<View: SystemTableView> {
     table: *const uefi_raw::table::system::SystemTable,
@@ -278,12 +278,6 @@ impl SystemTable<Boot> {
             table: self.table,
             _marker: PhantomData,
         }
-    }
-}
-
-impl Debug for SystemTable<Boot> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        unsafe { &*self.table }.fmt(f)
     }
 }
 


### PR DESCRIPTION
As of Rust 1.70, deriving `Debug` on `efiapi` function pointers is supported. That means we can derive `Debug` in a lot more places (tables and protocols).

This requires an MSRV bump to 1.70, so per https://github.com/rust-osdev/uefi-rs/blob/main/uefi/README.md#msrv we should wait until Rust 1.72 is released to merge this.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
