### PR TITLE
cargo: Use `[workspace.package]` to deduplicate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ members = [
     "xtask",
 ]
 
+[workspace.package]
+authors = ["The Rust OSDev team"]
+categories = ["embedded", "no-std", "api-bindings"]
+edition = "2021"
+keywords = ["uefi", "efi"]
+license = "MPL-2.0"
+repository = "https://github.com/rust-osdev/uefi-rs"
+rust-version = "1.68"
+
 [patch.crates-io]
 uefi = { path = "uefi" }
 uefi-macros = { path = "uefi-macros" }

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "uefi-macros"
 version = "0.12.0"
-authors = ["The Rust OSDev team"]
 readme = "README.md"
-edition = "2021"
 description = "Procedural macros for the `uefi` crate."
-repository = "https://github.com/rust-osdev/uefi-rs"
-keywords = ["uefi", "efi"]
-categories = ["embedded", "no-std", "api-bindings"]
-license = "MPL-2.0"
-rust-version = "1.68"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "uefi-raw"
 version = "0.2.0"
-authors = ["The Rust OSDev team"]
 readme = "README.md"
-edition = "2021"
 description = "Raw UEFI types"
-repository = "https://github.com/rust-osdev/uefi-rs"
-keywords = ["uefi", "efi"]
-categories = ["embedded", "no-std", "api-bindings"]
-license = "MPL-2.0"
-rust-version = "1.68"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bitflags = "2.0.0"

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "uefi-services"
 version = "0.20.0"
-authors = ["The Rust OSDev team"]
 readme = "README.md"
-edition = "2021"
 description = "Higher-level utilities for the `uefi` crate."
-repository = "https://github.com/rust-osdev/uefi-rs"
-keywords = ["uefi", "efi"]
-categories = ["embedded", "no-std", "api-bindings"]
-license = "MPL-2.0"
-rust-version = "1.68"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 uefi = { version = "0.23.0", features = ["global_allocator"] }

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "uefi"
 version = "0.23.0"
-authors = ["The Rust OSDev team"]
 readme = "README.md"
-edition = "2021"
 description = "Safe and easy-to-use wrapper for building UEFI apps."
-repository = "https://github.com/rust-osdev/uefi-rs"
-keywords = ["uefi", "efi"]
-categories = ["embedded", "no-std", "api-bindings"]
-license = "MPL-2.0"
-rust-version = "1.68"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["panic-on-logger-errors"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "xtask"
 version = "0.0.0"
-edition = "2021"
 publish = false
+
+edition.workspace = true
 
 [dependencies]
 anyhow = "1.0.51"


### PR DESCRIPTION
Cargo 1.64 added the ability to inherit package metadata from the root `Cargo.toml` file. Use that to deduplicate a bunch of fields.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
