### PR TITLE
ci: Fix developer_productivity push error

### DIFF
--- a/.github/workflows/developer_productivity.yml
+++ b/.github/workflows/developer_productivity.yml
@@ -12,6 +12,8 @@ jobs:
     outputs:
       nix-src: ${{ steps.filter.outputs.nix-src }}
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
This is a speculative fix, I think the CI works for the `pull_request` trigger but fails on the `push` trigger. Seems like maybe a checkout action will fix it.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
