### PR TITLE
uefi: Add raw pointer Event/Handle methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `DevicePath::to_boxed`, `DevicePath::to_owned`, and `DevicePath::as_bytes`
 - `DevicePathInstance::to_boxed`, `DevicePathInstance::to_owned`, and `DevicePathInstance::as_bytes`
 - `DevicePathNode::data`
+- Added `Event::from_ptr`, `Event::as_ptr`, and `Handle::as_ptr`.
 
 ### Changed
 - Renamed `LoadImageSource::FromFilePath` to `LoadImageSource::FromDevicePath`

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -36,6 +36,12 @@ impl Handle {
         // shorthand for "|ptr| Self(ptr)"
         NonNull::new(ptr).map(Self)
     }
+
+    /// Get the underlying raw pointer.
+    #[must_use]
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0.as_ptr()
+    }
 }
 
 /// Handle to an event structure, guaranteed to be non-null.
@@ -55,6 +61,21 @@ impl Event {
     #[must_use]
     pub const unsafe fn unsafe_clone(&self) -> Self {
         Self(self.0)
+    }
+
+    /// Create an `Event` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointer is valid.
+    pub unsafe fn from_ptr(ptr: *mut c_void) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    /// Get the underlying raw pointer.
+    #[must_use]
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.0.as_ptr()
     }
 }
 


### PR DESCRIPTION
Allow round-tripping from raw pointer to `Event` and `Handle` via `from_ptr` and `as_ptr` methods.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
