### PR TITLE
test: fix null pointer issue when DevicePath is null + integration test

### DIFF
--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -3,6 +3,7 @@ use uefi::proto::console::text::Output;
 use uefi::proto::device_path::media::FilePath;
 use uefi::proto::device_path::{DevicePath, LoadedImageDevicePath};
 use uefi::table::boot::{BootServices, LoadImageSource, SearchType};
+use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
 use uefi::table::{Boot, SystemTable};
 use uefi::{CString16, Identify};
 
@@ -85,11 +86,24 @@ fn test_load_image(bt: &BootServices) {
             buffer: image_data.as_slice(),
             file_path: None,
         };
-        let _ = bt
+        let loaded_image = bt
             .load_image(bt.image_handle(), load_source)
             .expect("should load image");
 
         log::debug!("load_image with FromBuffer strategy works");
+
+        unsafe {
+            let _ = bt
+                .open_protocol::<LoadedImageDevicePath>(
+                    OpenProtocolParams {
+                        handle: loaded_image,
+                        agent: bt.image_handle(),
+                        controller: None,
+                    },
+                    OpenProtocolAttributes::GetProtocol,
+                )
+                .expect("should open LoadedImageDevicePath protocol");
+        }
     }
     // Variant B: FromDevicePath
     {

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -296,10 +296,12 @@ pub struct DevicePath {
 
 impl ProtocolPointer for DevicePath {
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self {
+        assert!(!ptr.is_null());
         ptr_meta::from_raw_parts(ptr.cast(), Self::size_in_bytes_from_ptr(ptr))
     }
 
     unsafe fn mut_ptr_from_ffi(ptr: *mut c_void) -> *mut Self {
+        assert!(!ptr.is_null());
         ptr_meta::from_raw_parts_mut(ptr.cast(), Self::size_in_bytes_from_ptr(ptr))
     }
 }
@@ -684,10 +686,12 @@ pub struct LoadedImageDevicePath(DevicePath);
 
 impl ProtocolPointer for LoadedImageDevicePath {
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self {
+        assert!(!ptr.is_null());
         ptr_meta::from_raw_parts(ptr.cast(), DevicePath::size_in_bytes_from_ptr(ptr))
     }
 
     unsafe fn mut_ptr_from_ffi(ptr: *mut c_void) -> *mut Self {
+        assert!(!ptr.is_null());
         ptr_meta::from_raw_parts_mut(ptr.cast(), DevicePath::size_in_bytes_from_ptr(ptr))
     }
 }

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -56,10 +56,12 @@ where
     P: Protocol,
 {
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self {
+        assert!(!ptr.is_null());
         ptr.cast::<Self>()
     }
 
     unsafe fn mut_ptr_from_ffi(ptr: *mut c_void) -> *mut Self {
+        assert!(!ptr.is_null());
         ptr.cast::<Self>()
     }
 }


### PR DESCRIPTION
## About this test
This test tries to open the `LoadedImageDevicePath` on an image with Null as DevicePath. The handle to the image containing the Null pointer is created by executing the `EFI_BOOT_SERVICES.LoadImage()` to load an image from buffer. If no `DevicePath` is given, the `DevicePath` of the loaded image will be Null. This case is correctly implemented in [`LoadImageSource`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/table/boot.rs#L1704). The reverse way of using EFI protocols on an image created in this way should (in my understandig) work too. An example of a protocol which could be used on such an image is `EFI_LOADED_IMAGE_DEVICE_PATH_PROTOCOL`. The EFI specification (section 9.2.1, p. 250) states for this case:
```
It is legal to call LoadImage() for a buffer in memory with a NULL DevicePath parameter. In this case, the Loaded Image Device Path Protocol is installed with a NULL interface pointer.
```
Therefore it shouldn't be a problem working with and executing protocols on such an image handle. 

## The Problem with this test

In the current state this test will fail. This seems to be caused by [`DevicePathNode::from_ffi_ptr`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/proto/device_path/mod.rs#L137), which dereferences the Null pointer returned by EFI, which results in undefinined behavior. The [documentation of `form_ffi_ptr`](https://docs.rs/uefi/latest/uefi/proto/trait.ProtocolPointer.html#safety) states:
```
The input pointer must point to valid data.
```
I think this assumption doesn't hold in this case, as the user of the crate can not do anything against this behavior when working with a respective image (handle) returned from the UEFI implementation. 

## Suggested solution
I think the way to go would be to implement a Null pointer check in [`DevicePathNode::from_ffi_ptr`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/proto/device_path/mod.rs#L137) and to make it return an `Option` rather then the raw pointer to `Self`. As it turned out, this change would also result in more invasive changes done to other parts of the crate. A few would be:

* Change [`ProtocolPointer trait`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/proto/mod.rs#L54) to return an Option
* Implement Null pointer checks for all implementation of `ProtocolPointer trait`
* [`OpenProtocl`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/table/boot.rs#L1341) might need changes
* Maybe even [`ScopedProtocol trait`](https://github.com/rust-osdev/uefi-rs/blob/b215a92014d6f7c5ec0289b1e35380308e7a387f/uefi/src/table/boot.rs#L1828)

There might be even more spots affected by these changes, which I didn't see yet. I tried to implement the suggested changes of the first two points but found the other problems on my way. As I'm not that experienced with Rust and UEFI, I thought at this point, it would be the best to reach out to you. I already spoke to @phip1611 about this and we both think, that a few of these changes do need some proper considerations to be implemented correctly. I therefore opened this PR for tracking and discussing changes to be done and would happily implement them under your guidance.

I look forward to hear about you opinions!

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
