### PR TITLE
uefi: Improve support for null protocol interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 - `DevicePathInstance::to_boxed`, `DevicePathInstance::to_owned`, and `DevicePathInstance::as_bytes`
 - `DevicePathNode::data`
 - Added `Event::from_ptr`, `Event::as_ptr`, and `Handle::as_ptr`.
+- Added `ScopedProtocol::get` and `ScopedProtocol::get_mut` to access
+  potentially-null interfaces without panicking.
 
 ### Changed
 - Renamed `LoadImageSource::FromFilePath` to `LoadImageSource::FromDevicePath`
+- The `Deref` and `DerefMut` impls for `ScopedProtocol` will now panic if the
+  interface pointer is null.
 
 ### Removed
 

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -85,11 +85,18 @@ fn test_load_image(bt: &BootServices) {
             buffer: image_data.as_slice(),
             file_path: None,
         };
-        let _ = bt
+        let loaded_image = bt
             .load_image(bt.image_handle(), load_source)
             .expect("should load image");
 
         log::debug!("load_image with FromBuffer strategy works");
+
+        // Check that the `LoadedImageDevicePath` protocol can be opened and
+        // that the interface data is `None`.
+        let loaded_image_device_path = bt
+            .open_protocol_exclusive::<LoadedImageDevicePath>(loaded_image)
+            .expect("should open LoadedImageDevicePath protocol");
+        assert!(loaded_image_device_path.get().is_none());
     }
     // Variant B: FromDevicePath
     {


### PR DESCRIPTION
Modify `ScopedProtocol` to check if the interface pointer is null. If it is, then `Deref` and `DerefMut` will now panic. They are also now marked `#[track_caller]` so that the panic location points to the caller.
    
Also added `get` and `get_mut` methods to get potentially-null interface data without panicking.

---

This is a minimal fix for the issue described in https://github.com/rust-osdev/uefi-rs/pull/859. I'm not sure if it's the best long-term fix, but I'm wary of doing anything too invasive until we have better Miri coverage of protocols.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
