### PR TITLE
uefi-raw: make padding more explicit

### DIFF
--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -304,6 +304,8 @@ bitflags! {
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
     pub ty: MemoryType,
+    /// Padding. Zero.
+    pub _padding: u32,
     /// Starting physical address.
     pub phys_start: PhysicalAddress,
     /// Starting virtual address.
@@ -317,12 +319,37 @@ pub struct MemoryDescriptor {
 impl MemoryDescriptor {
     /// Memory descriptor version number.
     pub const VERSION: u32 = 1;
+
+    /// Constructor for a memory descriptor.
+    pub const fn new(
+        ty: MemoryType,
+        phys_start: PhysicalAddress,
+        virt_start: VirtualAddress,
+        page_count: u64,
+        att: MemoryAttribute,
+    ) -> Self {
+        Self {
+            ty,
+            _padding: 0,
+            phys_start,
+            virt_start,
+            page_count,
+            att,
+        }
+    }
+
+    /// The size in bytes of the memory region.
+    pub fn size(&self) -> u64 {
+        // Spec says this is number of 4KiB pages.
+        self.page_count * 4096
+    }
 }
 
 impl Default for MemoryDescriptor {
     fn default() -> MemoryDescriptor {
         MemoryDescriptor {
             ty: MemoryType::RESERVED,
+            _padding: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -2177,13 +2177,7 @@ mod tests {
         // Doesn't matter what type it is.
         const TY: MemoryType = MemoryType::RESERVED;
 
-        const BASE: MemoryDescriptor = MemoryDescriptor {
-            ty: TY,
-            phys_start: 0,
-            virt_start: 0,
-            page_count: 0,
-            att: MemoryAttribute::empty(),
-        };
+        const BASE: MemoryDescriptor = MemoryDescriptor::new(TY, 0, 0, 0, MemoryAttribute::empty());
 
         let mut buffer = [
             MemoryDescriptor {


### PR DESCRIPTION
Make the padding more explicit.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
