### PR TITLE
xtask: Improve an error location in check-raw

### DIFF
--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -256,7 +256,7 @@ fn check_fields(fields: &Punctuated<Field, Comma>, src: &Path) -> Result<(), Err
 /// Validate a struct.
 fn check_struct(item: &ItemStruct, src: &Path) -> Result<(), Error> {
     if !is_pub(&item.vis) {
-        return Err(Error::new(ErrorKind::MissingPub, src, &item.vis));
+        return Err(Error::new(ErrorKind::MissingPub, src, &item.struct_token));
     }
 
     let attrs = parse_attrs(&item.attrs, src)?;


### PR DESCRIPTION
This fixes a case where `check-raw` can incorrectly report an error as being the first line of a file.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
