### PR TITLE
uefi-raw: derive all the things

### DIFF
--- a/uefi-raw/src/capsule.rs
+++ b/uefi-raw/src/capsule.rs
@@ -8,7 +8,7 @@ use bitflags::bitflags;
 
 /// Descriptor that defines a scatter-gather list for passing a set of capsules
 /// to the firmware.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct CapsuleBlockDescriptor {
     /// Size in bytes of the data block. If zero, the block is treated as a
@@ -30,7 +30,7 @@ bitflags! {
     /// Capsule update flags.
     ///
     /// The meaning of bits `0..=15` are defined by the capsule GUID.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct CapsuleFlags: u32 {
         /// The meaning of this bit depends on the capsule GUID.
@@ -104,7 +104,7 @@ bitflags! {
 }
 
 /// Common header at the start of a capsule.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct CapsuleHeader {
     /// GUID that defines the type of data in the capsule.

--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -7,11 +7,13 @@ use crate::{guid, Guid};
 ///
 /// Note that the fields in this struct define the header at the start of each
 /// node; a device path is typically larger than these four bytes.
+#[derive(Debug)]
 #[repr(C)]
 pub struct DevicePathProtocol {
     pub major_type: u8,
     pub sub_type: u8,
     pub length: [u8; 2],
+    // followed by payload (dynamically sized)
 }
 
 impl DevicePathProtocol {

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -214,8 +214,8 @@ pub struct BootServices {
 
 bitflags! {
     /// Flags describing the type of an UEFI event and its attributes.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct EventType: u32 {
         /// The event is a timer event and may be passed to `BootServices::set_timer()`
         /// Note that timers only function during boot services time.
@@ -260,7 +260,7 @@ pub type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: *mut c
 bitflags! {
     /// Flags describing the capabilities of a memory range.
     #[repr(transparent)]
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct MemoryAttribute: u64 {
         /// Supports marking as uncacheable.
         const UNCACHEABLE = 0x1;
@@ -309,7 +309,7 @@ bitflags! {
 }
 
 /// A structure describing a region of memory.
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
@@ -348,6 +348,7 @@ newtype_enum! {
 /// in the 0x70000000..0xFFFFFFFF range. Therefore, we don't know the full set
 /// of memory types at compile time, and it is _not_ safe to model this C enum
 /// as a Rust enum.
+#[derive(PartialOrd, Ord, Hash)]
 pub enum MemoryType: u32 => {
     /// This enum variant is not used.
     RESERVED                =  0,

--- a/uefi-raw/src/table/header.rs
+++ b/uefi-raw/src/table/header.rs
@@ -1,7 +1,7 @@
 use super::Revision;
 
 /// The common header that all UEFI tables begin with.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct Header {
     /// Unique identifier for this table.

--- a/uefi-raw/src/table/revision.rs
+++ b/uefi-raw/src/table/revision.rs
@@ -30,7 +30,7 @@ use core::fmt;
 /// assert_eq!(Revision::EFI_2_31.to_string(), "2.3.1");
 /// assert_eq!(Revision::EFI_2_100.to_string(), "2.10");
 /// ```
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Revision(pub u32);
 

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -101,7 +101,7 @@ newtype_enum! {
 }
 
 /// Real time clock capabilities.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct TimeCapabilities {
     /// Reporting resolution of the clock in counts per second. 1 for a normal
@@ -119,7 +119,7 @@ pub struct TimeCapabilities {
 bitflags! {
     /// Flags describing the attributes of a variable.
     #[repr(transparent)]
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct VariableAttributes: u32 {
         /// Variable is maintained across a power cycle.
         const NON_VOLATILE = 0x01;


### PR DESCRIPTION
This adds all possible derives to the important structs. Compile time overhead is negligible, but I'd like to refrain from limiting higher-level APIs in the lowest possible API.

For example, users should be able to create a HashSet of MemoryAttribute.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
