### PR TITLE
uefi: Check for null pointer in config_table

### DIFF
--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -77,7 +77,14 @@ impl<View: SystemTableView> SystemTable<View> {
     #[allow(clippy::missing_const_for_fn)] // Required until we bump the MSRV.
     #[must_use]
     pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
-        unsafe { slice::from_raw_parts((*self.table).cfg_table, (*self.table).nr_cfg) }
+        unsafe {
+            let table = &*self.table;
+            table
+                .cfg_table
+                .as_ref()
+                .map(|ptr| slice::from_raw_parts(ptr, table.nr_cfg))
+                .unwrap_or(&[])
+        }
     }
 
     /// Creates a new `SystemTable<View>` from a raw address. The address might


### PR DESCRIPTION
`slice::from_raw_parts` requires a valid pointer even if the slice length is zero, so avoid calling it if the configuration table pointer is null.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
