### PR TITLE
uefi: Fix warnings when compiling without the alloc feature

### DIFF
--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -81,20 +81,23 @@ pub use device_path_gen::{
     acpi, bios_boot_spec, end, hardware, media, messaging, DevicePathNodeEnum,
 };
 
+use crate::proto::{unsafe_protocol, ProtocolPointer};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::mem;
 use core::ops::Deref;
 use ptr_meta::Pointee;
-use uefi::table::boot::ScopedProtocol;
-#[cfg(feature = "alloc")]
-use {alloc::borrow::ToOwned, alloc::boxed::Box, uefi::CString16};
 
-use crate::prelude::BootServices;
-use crate::proto::device_path::text::{AllowShortcuts, DevicePathToText, DisplayOnly};
-use crate::proto::{unsafe_protocol, ProtocolPointer};
-use crate::table::boot::{OpenProtocolAttributes, OpenProtocolParams, SearchType};
-use crate::Identify;
+#[cfg(feature = "alloc")]
+use {
+    crate::proto::device_path::text::{AllowShortcuts, DevicePathToText, DisplayOnly},
+    crate::table::boot::{
+        BootServices, OpenProtocolAttributes, OpenProtocolParams, ScopedProtocol, SearchType,
+    },
+    crate::{CString16, Identify},
+    alloc::borrow::ToOwned,
+    alloc::boxed::Box,
+};
 
 opaque_type! {
     /// Opaque type that should be used to represent a pointer to a
@@ -807,6 +810,7 @@ impl core::error::Error for DevicePathToTextError {
 
 /// Helper function to open the [`DevicePathToText`] protocol using the boot
 /// services.
+#[cfg(feature = "alloc")]
 fn open_text_protocol(
     bs: &BootServices,
 ) -> Result<ScopedProtocol<DevicePathToText>, DevicePathToTextError> {

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -2,7 +2,7 @@
 
 use super::Revision;
 use crate::table::boot::MemoryDescriptor;
-use crate::{CStr16, Error, Guid, Result, Status, StatusExt};
+use crate::{CStr16, Error, Result, Status, StatusExt};
 use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::{fmt, ptr};
@@ -15,6 +15,7 @@ pub use uefi_raw::time::Daylight;
 #[cfg(feature = "alloc")]
 use {
     crate::data_types::FromSliceWithNulError,
+    crate::Guid,
     alloc::boxed::Box,
     alloc::{vec, vec::Vec},
     core::mem,


### PR DESCRIPTION
<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
