### PR TITLE
Return a SimpleFileSystem from BootServices::get_image_file_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 - `Input::wait_for_key_event` now returns an `Option<Event>`, and is no longer `const`.
 - `LoadedImage::device` now returns an `Option<Handle>` and is no longer `const`.
+- `BootServices::get_image_file_system` now returns
+  `ScopedProtocol<SimpleFileSystem>` instead of `fs::FileSystem`.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -1,4 +1,5 @@
 use alloc::string::ToString;
+use uefi::fs::FileSystem;
 use uefi::proto::console::text::Output;
 use uefi::proto::device_path::media::FilePath;
 use uefi::proto::device_path::{DevicePath, LoadedImageDevicePath};
@@ -76,11 +77,13 @@ fn test_load_image(bt: &BootServices) {
 
     // Variant A: FromBuffer
     {
-        let mut fs = bt
+        let fs = bt
             .get_image_file_system(bt.image_handle())
             .expect("should open file system");
         let path = CString16::try_from(image_device_path_file_path.as_str()).unwrap();
-        let image_data = fs.read(&*path).expect("should read file content");
+        let image_data = FileSystem::new(fs)
+            .read(&*path)
+            .expect("should read file content");
         let load_source = LoadImageSource::FromBuffer {
             buffer: image_data.as_slice(),
             file_path: None,


### PR DESCRIPTION
This reverts a small change from: https://github.com/rust-osdev/uefi-rs/pull/472

If using the library without the `alloc` feature enabled, `FileSystem` isn't available, but you might still want access to the image's file system via the underlying protocol.

The high-level API is still easily accessible via `FileSystem::new`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
