### PR TITLE
Fix target_arch name: i386 -> x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `LoadedImage::device` now returns an `Option<Handle>` and is no longer `const`.
 - `BootServices::get_image_file_system` now returns
   `ScopedProtocol<SimpleFileSystem>` instead of `fs::FileSystem`.
+- `uefi::proto::shim` is now available on 32-bit x86 targets.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -23,7 +23,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     string::test(bt);
 
     #[cfg(any(
-        target_arch = "i386",
+        target_arch = "x86",
         target_arch = "x86_64",
         target_arch = "arm",
         target_arch = "aarch64"
@@ -64,7 +64,7 @@ mod network;
 mod pi;
 mod rng;
 #[cfg(any(
-    target_arch = "i386",
+    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64"

--- a/uefi/src/proto/shim/mod.rs
+++ b/uefi/src/proto/shim/mod.rs
@@ -1,7 +1,7 @@
 //! Shim lock protocol.
 
 #![cfg(any(
-    target_arch = "i386",
+    target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "arm",
     target_arch = "aarch64"
@@ -45,7 +45,7 @@ pub struct Hashes {
 
 // These macros set the correct calling convention for the Shim protocol methods.
 
-#[cfg(any(target_arch = "i386", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! shim_function {
     (fn $args:tt -> $return_type:ty) => (extern "sysv64" fn $args -> $return_type)
 }


### PR DESCRIPTION
`x86` is what will be set on the `i686-unknown-uefi` target, not `i386`.

See also https://doc.rust-lang.org/reference/conditional-compilation.html.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
