### PR TITLE
uefi: Change try_exists to return FileSystemResult<bool>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `uefi::proto::shim` is now available on 32-bit x86 targets.
 - `Parity` and `StopBits` are now a newtype-enums instead of Rust enums. Their
   members now have upper-case names.
+- `FileSystem::try_exists` now returns `FileSystemResult<bool>`.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/fs/mod.rs
+++ b/uefi-test-runner/src/fs/mod.rs
@@ -62,8 +62,7 @@ pub fn test(sfs: ScopedProtocol<SimpleFileSystem>) -> Result<(), fs::Error> {
     // test remove dir all
     fs.remove_dir_all(cstr16!("foo_dir\\1"))?;
     // file should not be available after remove all
-    let err = fs.try_exists(cstr16!("foo_dir\\1"));
-    assert!(err.is_err());
+    assert!(!fs.try_exists(cstr16!("foo_dir\\1"))?);
 
     Ok(())
 }


### PR DESCRIPTION
Returning a bool allows both "exists" and "does not exist" to be success cases, while properly propagating unexpected errors.

This makes it line up with the std `try_exists` method: https://doc.rust-lang.org/std/path/struct.Path.html#method.try_exists

Also simplified the implementation to just call `open`, no need to get metadata since `open` already returns an error if the file doesn't exist.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
