### PR TITLE
Rework `FileSystem::copy` to operate on 1MiB chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Parity` and `StopBits` are now a newtype-enums instead of Rust enums. Their
   members now have upper-case names.
 - `FileSystem::try_exists` now returns `FileSystemResult<bool>`.
+- `FileSystem::copy` is now more efficient for large files.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -127,7 +127,7 @@ fn test_existing_file(directory: &mut Directory) {
     let mut info_buffer = vec![0; 128];
     let info = file.get_info::<FileInfo>(&mut info_buffer).unwrap();
     assert_eq!(info.file_size(), 15);
-    assert_eq!(info.physical_size(), 512);
+    assert_eq!(info.physical_size(), 1024);
     let tp = TimeParams {
         year: 2000,
         month: 1,
@@ -355,7 +355,7 @@ fn test_partition_info(bt: &BootServices, disk_handle: Handle) {
 
     assert_eq!(mbr.boot_indicator, 0);
     assert_eq!({ mbr.starting_lba }, 1);
-    assert_eq!({ mbr.size_in_lba }, 1233);
+    assert_eq!({ mbr.size_in_lba }, 20479);
     assert_eq!({ mbr.starting_chs }, [0, 0, 0]);
     assert_eq!(mbr.ending_chs, [0, 0, 0]);
     assert_eq!(mbr.os_type, MbrOsType(6));
@@ -412,9 +412,9 @@ pub fn test(bt: &BootServices) {
             .unwrap();
 
         assert!(!fs_info.read_only());
-        assert_eq!(fs_info.volume_size(), 512 * 1192);
-        assert_eq!(fs_info.free_space(), 512 * 1190);
-        assert_eq!(fs_info.block_size(), 512);
+        assert_eq!(fs_info.volume_size(), 1024 * 10183);
+        assert_eq!(fs_info.free_space(), 1024 * 10181);
+        assert_eq!(fs_info.block_size(), 1024);
         assert_eq!(fs_info.volume_label().to_string(), "MbrTestDisk");
 
         // Check that `get_boxed_info` returns the same info.

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -14,10 +14,11 @@ fn get_partition_byte_range(mbr: &MBR) -> Range<usize> {
 }
 
 pub fn create_mbr_test_disk(path: &Path) -> Result<()> {
-    let num_sectors = 1234;
+    // 10 MiB.
+    let size_in_bytes = 10 * 1024 * 1024;
 
     let partition_byte_range;
-    let mut disk = vec![0; num_sectors * SECTOR_SIZE];
+    let mut disk = vec![0; size_in_bytes];
     {
         let mut cur = std::io::Cursor::new(&mut disk);
 
@@ -104,8 +105,8 @@ fn init_fat_test_partition(disk: &mut [u8], partition_byte_range: Range<usize>) 
     let stats = fs.stats()?;
     // Assert these specific numbers here since they are checked by the
     // test-runner too.
-    assert_eq!(stats.total_clusters(), 1192);
-    assert_eq!(stats.free_clusters(), 1190);
+    assert_eq!(stats.total_clusters(), 10183);
+    assert_eq!(stats.free_clusters(), 10181);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/uefi-rs/issues/824

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
