### PR TITLE
ci: Add merge_group trigger

### DIFF
--- a/.github/workflows/developer_productivity.yml
+++ b/.github/workflows/developer_productivity.yml
@@ -1,5 +1,6 @@
 name: Developer Productivity
 on:
+  merge_group:
   push:
   pull_request:
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,5 +1,5 @@
 name: QA
-on: [push, pull_request]
+on: [merge_group, push, pull_request]
 jobs:
   spellcheck:
     name: Spellcheck

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,6 @@
 name: Rust
 on:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
This is required for using [Github's merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues). However, note that this change does not actually enable merge queues (that's done through the branch protection settings).

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
