### PR TITLE
Drop `memmove` and `set_mem` from boot services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `FileSystem::try_exists` now returns `FileSystemResult<bool>`.
 - `FileSystem::copy` is now more efficient for large files.
 
+### Removed
+- `BootServices::memmove` and `BootServices::set_mem` have been removed, use
+  standard functions like `core::ptr::copy` and `core::ptr::write_bytes` instead.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-services - [Unreleased]

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -8,7 +8,6 @@ pub fn test(bt: &BootServices) {
     allocate_pages(bt);
     vec_alloc();
     alloc_alignment();
-    memmove(bt);
 
     memory_map(bt);
 }
@@ -55,28 +54,6 @@ fn alloc_alignment() {
 
     let value = vec![Block([1; 0x100])];
     assert_eq!(value.as_ptr() as usize % 0x100, 0, "Wrong alignment");
-}
-
-// Test that the `memmove` / `set_mem` functions work.
-fn memmove(bt: &BootServices) {
-    info!("Testing the `memmove` / `set_mem` functions");
-
-    let src = [1, 2, 3, 4];
-    let mut dest = [0u8; 4];
-
-    // Fill the buffer with a value
-    unsafe {
-        bt.set_mem(dest.as_mut_ptr(), dest.len(), 1);
-    }
-
-    assert_eq!(dest, [1; 4], "Failed to set memory");
-
-    // Copy other values on it
-    unsafe {
-        bt.memmove(dest.as_mut_ptr(), src.as_ptr(), dest.len());
-    }
-
-    assert_eq!(dest, src, "Failed to copy memory");
 }
 
 fn memory_map(bt: &BootServices) {

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1320,26 +1320,6 @@ impl BootServices {
             })
     }
 
-    /// Copies memory from source to destination. The buffers can overlap.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe as it can be used to violate most safety
-    /// invariants of the Rust type system.
-    pub unsafe fn memmove(&self, dest: *mut u8, src: *const u8, size: usize) {
-        (self.0.copy_mem)(dest, src, size);
-    }
-
-    /// Sets a buffer to a certain value.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe as it can be used to violate most safety
-    /// invariants of the Rust type system.
-    pub unsafe fn set_mem(&self, buffer: *mut u8, size: usize, value: u8) {
-        (self.0.set_mem)(buffer, size, value);
-    }
-
     /// Retrieves a [`SimpleFileSystem`] protocol associated with the device the given
     /// image was loaded from.
     ///


### PR DESCRIPTION
There's no good reason to the UEFI version of these functions over core Rust functions like `core::ptr::copy` and `core::ptr::write_bytes`. The safety requirements of the `core` functions are also better documented.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
