### PR TITLE
proto/media: add LoadFile2Protocol

### DIFF
--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -1,0 +1,25 @@
+use crate::{guid, Guid, Status};
+use crate::protocol::device_path::DevicePathProtocol;
+use core::ffi::c_void;
+
+/// The UEFI LoadFile2 protocol.
+///
+/// This protocol has a single method to load a file according to some
+/// device path.
+///
+/// This interface is implemented by many devices, e.g. network and filesystems.
+#[derive(Debug)]
+#[repr(C)]
+pub struct LoadFile2 {
+    pub load_file: unsafe extern "efiapi" fn(
+        this: &mut LoadFile2,
+        file_path: *const DevicePathProtocol,
+        boot_policy: bool,
+        buffer_size: *mut usize,
+        buffer: *mut c_void,
+    ) -> Status,
+}
+
+impl LoadFile2 {
+    pub const GUID: Guid = guid!("4006c0c1-fcb3-403e-996d-4a6c8724e06d");
+}

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -1,0 +1,79 @@
+//! Load file support protocols.
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use crate::proto::device_path::{FfiDevicePath, DevicePath};
+use crate::proto::unsafe_protocol;
+use crate::{Result, Status};
+use core::ffi::c_void;
+use core::ptr;
+
+/// The UEFI LoadFile2 protocol.
+///
+/// This protocol has a single method to load a file according to some
+/// device path.
+///
+/// This interface is implemented by many devices, e.g. network and filesystems.
+#[derive(Debug)]
+#[repr(transparent)]
+#[unsafe_protocol(uefi_raw::protocol::media::LoadFile2::GUID)]
+pub struct LoadFile2(uefi_raw::protocol::media::LoadFile2);
+
+impl LoadFile2 {
+    /// Load file addressed by provided device path
+    pub fn load_file(&mut self,
+        file_path: &DevicePath,
+        buffer: &mut [u8]
+    ) -> Result<(), usize> {
+        let mut buffer_size = buffer.len();
+        unsafe {
+            (self.0.load_file)(self,
+                file_path,
+                false,
+                buffer_size,
+                buffer.as_mut_ptr()
+            )
+        }.to_result_with(
+            || debug_assert_eq!(buffer_size, buffer.len()),
+            |_| buffer_size
+        )
+    }
+
+    #[cfg(feature = "alloc")]
+    /// Load file addressed by the provided device path.
+    pub fn load_file_to_vec(&mut self,
+        file_path: &DevicePath,
+    ) -> Result<Vec<u8>> {
+        let mut buffer_size: usize = 0;
+        let mut status: Status;
+        unsafe {
+            status = (self.0.load_file)(self,
+                file_path.as_ffi_ptr(),
+                false,
+                ptr::addr_of_mut!(buffer_size),
+                ptr::null_mut()
+            );
+        }
+
+        if status.is_error() {
+            return Err(status.into());
+        }
+
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
+        unsafe {
+            status = (self.0.load_file)(self,
+                file_path.as_ffi_ptr(),
+                false,
+                ptr::addr_of_mut!(buffer_size),
+                buffer.as_mut_ptr() as *mut c_void
+            );
+        }
+
+        if status.is_error() {
+            return Err(status.into());
+        }
+
+        Ok(buffer)
+    }
+}

--- a/uefi/src/proto/media/mod.rs
+++ b/uefi/src/proto/media/mod.rs
@@ -10,3 +10,4 @@ pub mod block;
 pub mod disk;
 pub mod fs;
 pub mod partition;
+pub mod load_file;


### PR DESCRIPTION
The idea is to provide the LoadFile(2)Protocol family in `uefi-rs` with nice alloc helpers.

My goal is to use them as an alternative to the SimpleFilesystemProtocol when my bootloader is chained via PXE, which means that the SFS protocol is not available on the booted image handle, but… LoadFile(2)Protocol **should**, which enable me to continue downloading things like an initrd or a kernel as long as I know their exact paths.

This is a draft to open the discussion on the design.

https://uefi.org/specs/UEFI/2.10/13_Protocols_Media_Access.html#load-file-2-protocol

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
