### PR TITLE
xtask: Temporarily disable a false-positive clippy lint

### DIFF
--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -93,6 +93,7 @@ fn windows_open_pipe(path: &Path) -> Result<File> {
         match OpenOptions::new().read(true).write(true).open(path) {
             Ok(file) => return Ok(file),
             Err(err) => {
+                #[allow(clippy::needless_return_with_question_mark)]
                 if attempt >= max_attempts {
                     return Err(err)?;
                 } else {


### PR DESCRIPTION
`clippy::needless_return_with_question_mark` is incorrectly firing here in 1.73.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
