### PR TITLE
Allow indexing of `MemoryMap`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## uefi - [Unreleased]
 
+### Added
+- Implemented `Index`, `IndexMut`, `get`, and `get_mut` on `MemoryMap`.
+
 ### Changed
 - We fixed a memory leak in `GraphicsOutput::query_mode`. As a consequence, we
   had to add `&BootServices` as additional parameter.


### PR DESCRIPTION
In developing a bootloader for my microkernel, I have have found that being able to index the given `MemoryMap` would reduce some complexity.