### PR TITLE
uefi/gop: fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## uefi - [Unreleased]
 
+### Changed
+- We fixed a memory leak in `GraphicsOutput::query_mode`. As a consequence, we
+  had to add `&BootServices` as additional parameter.
+
 ## uefi-macros - [Unreleased]
 
 ## uefi-raw - [Unreleased]

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -22,7 +22,7 @@ pub unsafe fn test(image: Handle, bt: &BootServices) {
         )
         .expect("failed to open Graphics Output Protocol");
 
-    set_graphics_mode(gop);
+    set_graphics_mode(gop, bt);
     fill_color(gop);
     draw_fb(gop);
 
@@ -33,10 +33,10 @@ pub unsafe fn test(image: Handle, bt: &BootServices) {
 }
 
 // Set a larger graphics mode.
-fn set_graphics_mode(gop: &mut GraphicsOutput) {
+fn set_graphics_mode(gop: &mut GraphicsOutput, bs: &BootServices) {
     // We know for sure QEMU has a 1024x768 mode.
     let mode = gop
-        .modes()
+        .modes(bs)
         .find(|mode| {
             let info = mode.info();
             info.resolution() == (1024, 768)


### PR DESCRIPTION
This fixes the memory leak reported in #968. This comes with a breaking change.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
