### PR TITLE
Mark free_pages and free_pool as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Changed
 - We fixed a memory leak in `GraphicsOutput::query_mode`. As a consequence, we
   had to add `&BootServices` as additional parameter.
+- `BootServices::free_pages` and `BootServices::free_pool` are now `unsafe` to
+  call, since it is possible to trigger UB by freeing memory that is still in use.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -31,7 +31,7 @@ fn allocate_pages(bt: &BootServices) {
     buf[4095] = 0x23;
 
     // Clean up to avoid memory leaks.
-    bt.free_pages(pgs, 1).unwrap();
+    unsafe { bt.free_pages(pgs, 1) }.unwrap();
 }
 
 // Simple test to ensure our custom allocator works with the `alloc` crate.

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -90,8 +90,7 @@ impl GraphicsOutput {
 
                 // User has no benefit from propagating this error. If this
                 // fails, it is an error of the UEFI implementation.
-                bs.free_pool(info_heap_ptr)
-                    .expect("buffer should be deallocatable");
+                unsafe { bs.free_pool(info_heap_ptr) }.expect("buffer should be deallocatable");
 
                 Mode {
                     index,

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -70,9 +70,7 @@ impl<'a> Deref for PoolString<'a> {
 impl Drop for PoolString<'_> {
     fn drop(&mut self) {
         let addr = self.text as *mut u8;
-        self.boot_services
-            .free_pool(addr)
-            .expect("Failed to free pool [{addr:#?}]");
+        unsafe { self.boot_services.free_pool(addr) }.expect("Failed to free pool [{addr:#?}]");
     }
 }
 


### PR DESCRIPTION
These functions can easily be used to trigger UB from safe code by passing in an address to memory that is still in use. Fix by marking them `unsafe`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
