### PR TITLE
uefi-services: Remove NonNull wrapper from system_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ## uefi-services - [Unreleased]
 
+### Changed
+- `uefi_services::system_table` now returns `SystemTable<Boot>` directly, rather
+  than wrapped in a `NonNull` pointer.
+
 ## uefi - 0.25.0 (2023-10-10)
 
 ### Changed

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -65,12 +65,12 @@ static mut LOGGER: Option<uefi::logger::Logger> = None;
 ///
 /// The returned pointer is only valid until boot services are exited.
 #[must_use]
-pub fn system_table() -> NonNull<SystemTable<Boot>> {
+pub fn system_table() -> SystemTable<Boot> {
     unsafe {
         let table_ref = SYSTEM_TABLE
             .as_ref()
             .expect("The system table handle is not available");
-        NonNull::new(table_ref as *const _ as *mut _).unwrap()
+        table_ref.unsafe_clone()
     }
 }
 


### PR DESCRIPTION
The `SystemTable` type is already essentially a wrapper around a pointer, so there's no need to wrap this return value in another pointer via `NonNull`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
