### PR TITLE
Remove unused UefiRegularFileHandle type alias

### DIFF
--- a/uefi/src/fs/uefi_types.rs
+++ b/uefi/src/fs/uefi_types.rs
@@ -5,6 +5,6 @@
 pub use crate::proto::media::file::{
     Directory as UefiDirectoryHandle, File as UefiFileTrait, FileAttribute as UefiFileAttribute,
     FileHandle as UefiFileHandle, FileInfo as UefiFileInfo, FileMode as UefiFileMode,
-    FileType as UefiFileType, RegularFile as UefiRegularFileHandle,
+    FileType as UefiFileType,
 };
 pub use crate::proto::media::fs::SimpleFileSystem as SimpleFileSystemProtocol;


### PR DESCRIPTION
This alias is neither used internally nor publicly exposed.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
