### PR TITLE
uefi-services: Change SYSTEM_TABLE to an atomic pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Implemented `Index`, `IndexMut`, `get`, and `get_mut` on `MemoryMap`.
+- Added `SystemTable::as_ptr`.
 
 ### Changed
 - We fixed a memory leak in `GraphicsOutput::query_mode`. As a consequence, we

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -113,6 +113,12 @@ impl<View: SystemTableView> SystemTable<View> {
             _marker: PhantomData,
         })
     }
+
+    /// Get the underlying raw pointer.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const c_void {
+        self.table.cast()
+    }
 }
 
 // These parts of the UEFI System Table interface may only be used until boot


### PR DESCRIPTION
This aligns with how the std uefi target works:
https://github.com/rust-lang/rust/blob/f654229c27267334023a22233795b88b75fc340e/library/std/src/os/uefi/env.rs#L8

And also avoids some unsafe; a static atomic be written without being `static mut`, and reads and writes are safe operations.

Also includes some related cleanups in uefi-services, and the addition of `SystemTable::as_ptr`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
