### PR TITLE
Change Logger to use an atomic pointer internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   had to add `&BootServices` as additional parameter.
 - `BootServices::free_pages` and `BootServices::free_pool` are now `unsafe` to
   call, since it is possible to trigger UB by freeing memory that is still in use.
+- `Logger` no longer requires exterior mutability. `Logger::new` is now `const`,
+  takes no arguments, and creates the logger in a disabled state. Call
+  `Logger::set_output` to enable it.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -165,7 +165,10 @@ unsafe fn init_logger(st: &mut SystemTable<Boot>) {
 
     // Construct the logger.
     let logger = {
-        LOGGER = Some(uefi::logger::Logger::new(stdout));
+        let logger = uefi::logger::Logger::new();
+        logger.set_output(stdout);
+
+        LOGGER = Some(logger);
         LOGGER.as_ref().unwrap()
     };
 


### PR DESCRIPTION
Using a `Logger` no longer requires making it mutable, and it now provides a `const` `new` function. This allows creating a `static` `Logger`, rather than a `static mut` `Option<Logger>`, which allows for less `unsafe`.

Update the `LOGGER` in uefi-services accordingly.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
