### PR TITLE
uefi: Use atomics instead of `static mut` in allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `Logger` no longer requires exterior mutability. `Logger::new` is now `const`,
   takes no arguments, and creates the logger in a disabled state. Call
   `Logger::set_output` to enable it.
+- `uefi::allocator::init` now takes a `&mut SystemTable<Boot>` instead of
+  `&BootServices`.
 
 ## uefi-macros - [Unreleased]
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -101,10 +101,10 @@ pub fn init(st: &mut SystemTable<Boot>) -> Result<Option<Event>> {
         #[cfg(feature = "logger")]
         init_logger(st);
 
-        let boot_services = st.boot_services();
-        uefi::allocator::init(boot_services);
+        uefi::allocator::init(st);
 
         // Schedule these tools to be disabled on exit from UEFI boot services
+        let boot_services = st.boot_services();
         boot_services
             .create_event(
                 EventType::SIGNAL_EXIT_BOOT_SERVICES,


### PR DESCRIPTION
This completes the transition away from any uses of `static mut`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
