### PR TITLE
Use const interface pointers in protocol management functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@
   `Logger::set_output` to enable it.
 - `uefi::allocator::init` now takes a `&mut SystemTable<Boot>` instead of
   `&BootServices`.
+- `BootServices::{install,reinstall,uninstall}_protocol_interface` now take
+  `const` interface pointers.
 
 ## uefi-macros - [Unreleased]
 
 ## uefi-raw - [Unreleased]
+
+### Changed
+- `{install,reinstall,uninstall}_protocol_interface` now take `const` interface pointers.
 
 ## uefi-services - [Unreleased]
 

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -61,18 +61,18 @@ pub struct BootServices {
         handle: *mut Handle,
         guid: *const Guid,
         interface_type: InterfaceType,
-        interface: *mut c_void,
+        interface: *const c_void,
     ) -> Status,
     pub reinstall_protocol_interface: unsafe extern "efiapi" fn(
         handle: Handle,
         protocol: *const Guid,
-        old_interface: *mut c_void,
-        new_interface: *mut c_void,
+        old_interface: *const c_void,
+        new_interface: *const c_void,
     ) -> Status,
     pub uninstall_protocol_interface: unsafe extern "efiapi" fn(
         handle: Handle,
         protocol: *const Guid,
-        interface: *mut c_void,
+        interface: *const c_void,
     ) -> Status,
     pub handle_protocol: unsafe extern "efiapi" fn(
         handle: Handle,

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -559,7 +559,7 @@ impl BootServices {
         &self,
         handle: Option<Handle>,
         protocol: &Guid,
-        interface: *mut c_void,
+        interface: *const c_void,
     ) -> Result<Handle> {
         let mut handle = Handle::opt_to_ptr(handle);
         ((self.0.install_protocol_interface)(
@@ -594,8 +594,8 @@ impl BootServices {
         &self,
         handle: Handle,
         protocol: &Guid,
-        old_interface: *mut c_void,
-        new_interface: *mut c_void,
+        old_interface: *const c_void,
+        new_interface: *const c_void,
     ) -> Result<()> {
         (self.0.reinstall_protocol_interface)(
             handle.as_ptr(),
@@ -629,7 +629,7 @@ impl BootServices {
         &self,
         handle: Handle,
         protocol: &Guid,
-        interface: *mut c_void,
+        interface: *const c_void,
     ) -> Result<()> {
         (self.0.uninstall_protocol_interface)(handle.as_ptr(), protocol, interface).to_result()
     }


### PR DESCRIPTION
A protocol's interface may mutate itself, but the void pointer passed to the `{install,reinstall,uninstall}_protocol_interface` functions is opaque to the firmware, so there's no need for it to be a mut pointer.

Note that from a Rust safety perspective there's no difference here -- mut and const pointers are interchangeable.

https://github.com/rust-osdev/uefi-rs/issues/970

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
