### PR TITLE
uefi-macros: Change uefi dev-dependency from version to path

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -33,9 +33,6 @@ a new major version of that crate will have to be published, then a new version 
 `uefi` (major if the previous bump caused changes in the public API of this crate as well),
 then possibly a new version of `uefi-services`.
 
-Furthermore, `uefi-macros` has the `uefi` crate as a `dev-dependency`,
-and that will have to be updated in tandem with the major versions of the core crate.
-
 ### Updating the dependent crates
 
 Remember that if a new major version of a crate gets released, when bumping the version

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -22,4 +22,4 @@ syn = { version = "2.0.4", features = ["full"] }
 
 [dev-dependencies]
 trybuild = "1.0.61"
-uefi = { version = "0.25.0", default-features = false }
+uefi = { path = "../uefi", default-features = false }


### PR DESCRIPTION
Using a path avoids having to update the `uefi-macros` dep on `uefi` after releasing a new version of `uefi`, slightly simplifying our release process.

Prior to cargo 1.40 there was no choice but to have a version on dev-dependencies. That changed with
https://github.com/rust-lang/cargo/pull/7333, and now you can publish a crate with a path-only dev dependency.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
