### PR TITLE
Release via Github Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+# This workflow runs when commits are pushed to main or a branch starting with
+# "version-". It checks if any packages require a new release, and if so,
+# creates the corresponding crates.io releases and git tags.
+name: Release
+on:
+  push:
+    branches:
+      - main
+      - version-*
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo xtask auto-release
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +199,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crates-index"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f3e3ef6d547bbf1213b3dabbf0b01a500fbd0924abf818b563a4bc2c85296c"
+dependencies = [
+ "hex",
+ "home",
+ "http",
+ "memchr",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smol_str",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "crc"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +267,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -260,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,10 +378,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "http"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95b9abcae896730d42b78e09c155ed4ddf82c07b4de772c64aee5b2d8b7c150"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "idna"
@@ -321,6 +426,16 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -539,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +786,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -750,6 +898,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "trybuild"
@@ -883,6 +1065,7 @@ checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
  "base64",
  "flate2",
+ "http",
  "log",
  "once_cell",
  "rustls",
@@ -1028,6 +1211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,7 +1242,9 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "clap",
+ "crates-index",
  "fatfs",
  "fs-err",
  "heck",

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,11 +1,21 @@
 # Publishing new versions of uefi-rs to Crates.io
 
-This guide documents the best practices for publishing new versions of
-the crates in this repository to [crates.io](https://crates.io/).
+This guide documents how to publish new versions of the crates in this
+repository to [crates.io](https://crates.io/).
 
 **It is mostly intended for maintainers of the uefi-rs project.**
 
-## Bumping the crate versions
+## Overview
+
+1. Create a branch that updates the versions of all packages you want to
+   release. This branch should include all related changes such as updating the
+   versions in dependent crates and updating the changelog.
+2. Create a PR of that branch. The subject of the PR must start with `release:`,
+   the rest of the message is arbitrary.
+3. Once the PR is approved and merged, a Github Actions workflow will take care
+   of creating git tags and publishing to crates.io.
+
+## Details of the release pull request
 
 For ensuring compatibility within the crates ecosystem,
 Cargo [recommends][cargo-semver] maintainers to follow the [semantic versioning][semver] guidelines.
@@ -15,58 +25,46 @@ which crates were modified and how should their version numbers be incremented.
 
 Incrementing the version number of a crate is as simple as editing
 the corresponding `Cargo.toml` file and updating the `version = ...` line,
-then committing the change (preferably on a new branch, so that all the version bumps
-can be combined in a single pull request).
+then committing the change.
 
 ### Crate dependencies
 
 The dependency graph of the published crates in this repo is:
 
-- `uefi-services` depends on `uefi` (the root project)
-- `uefi` depends on `uefi-macros`
-
-If there are breaking changes happening in the project, we should first publish
-a new version of `uefi-macros`, then of `uefi`, then of `uefi-services` and so on.
-
-For example, if the signature of a widely-used macro from `uefi-macros` is changed,
-a new major version of that crate will have to be published, then a new version of
-`uefi` (major if the previous bump caused changes in the public API of this crate as well),
-then possibly a new version of `uefi-services`.
+- `uefi-services` depends on `uefi`
+- `uefi` depends on `uefi-macros` and `uefi-raw`
 
 ### Updating the dependent crates
 
 Remember that if a new major version of a crate gets released, when bumping the version
 of it's dependents you will have to also change the dependency line for it.
 
-For example, if `uefi-macros` gets bumped from `1.1.0` to `2.0.0`,
+For example, if `uefi-macros` gets bumped from `0.5.0` to `0.6.0`,
 you will also have to update the corresponding `Cargo.toml` of `uefi` to be:
 
 ```toml
-uefi-macros = "2.0.0"
+uefi-macros = "0.6.0"
 ```
 
-The dependencies in `template/Cargo.toml` should also be updated to the new version.
+The dependencies in `template/Cargo.toml` and `book/src/tutorial/app.md` should
+also be updated to the new version.
 
 [cargo-semver]: https://doc.rust-lang.org/cargo/reference/semver.html
 [semver]: https://semver.org/
 
-## Publishing new versions of the crates
+### Updating the changelog
 
-This section is mostly a summary of the official [guide to publishing on crates.io][cargo-publishing-reference],
-with a few remarks regarding the specific of this project.
+Update the [`CHANGELOG.md`](CHANGELOG.md) file in order to move all the
+unpublished changes to their respective version, and prepare it for tracking
+further changes. The date of the release should be included next to the section
+title as done for the other releases.
 
-Start by following the steps in the guide. When running `cargo publish`,
-you will have to use a custom `--target` flag to be able to build/verify the crates:
+## Crates.io secret token
 
-```
-cargo publish --target x86_64-unknown-uefi
-```
+The release.yml workflow expects a repository secret named
+`CARGO_REGISTRY_TOKEN`. This is set in the [repository settings][secret]. The
+value must be a crates.io [API token]. The scope of the token should be
+restricted to `publish-update`.
 
-[cargo-publishing-reference]: https://doc.rust-lang.org/cargo/reference/publishing.html
-
-## Updating the changelog
-
-After bumping the crate versions, we should also update the [`CHANGELOG.md`](CHANGELOG.md) file
-in order to move all the unpublished changes to their respective version, and prepare it for
-tracking further changes. The date of the release should be included next to the section title as
-done for the other releases.
+[secret]: https://github.com/rust-osdev/uefi-rs/settings/secrets/actions
+[API token]: https://crates.io/settings/tokens

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,9 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0.51"
+cargo_metadata = "0.18.1"
 clap = { version = "4.4.0", default-features = false, features = ["derive", "help", "usage", "std"] }
+crates-index = "2.3.0"
 fatfs = { version = "0.3.6", default-features = false, features = ["alloc", "std"] }
 fs-err = "2.6.0"
 heck = "0.4.0"
@@ -24,5 +26,5 @@ sha2 = "0.10.6"
 syn = { version = "2.0.0", features = ["full"] }
 tar = "0.4.38"
 tempfile = "3.6.0"
+ureq = { version = "2.8.0", features = ["http-interop"] }
 walkdir = "2.4.0"
-ureq = "2.8.0"

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -16,7 +16,8 @@ pub enum Package {
 }
 
 impl Package {
-    fn as_str(self) -> &'static str {
+    /// Get package name.
+    pub fn name(self) -> &'static str {
         match self {
             Self::Uefi => "uefi",
             Self::UefiApp => "uefi_app",
@@ -304,7 +305,7 @@ impl Cargo {
             bail!("packages cannot be empty");
         }
         for package in &self.packages {
-            cmd.args(["--package", package.as_str()]);
+            cmd.args(["--package", package.name()]);
         }
 
         if !self.features.is_empty() {

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -29,12 +29,12 @@ impl Package {
         }
     }
 
-    /// All published packages.
+    /// All published packages, in the order that publishing should occur.
     pub fn published() -> Vec<Package> {
         vec![
-            Self::Uefi,
-            Self::UefiMacros,
             Self::UefiRaw,
+            Self::UefiMacros,
+            Self::Uefi,
             Self::UefiServices,
         ]
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ mod opt;
 mod pipe;
 mod platform;
 mod qemu;
+mod release;
 mod tpm;
 mod util;
 
@@ -314,5 +315,6 @@ fn main() -> Result<()> {
         Action::Run(qemu_opt) => run_vm_tests(qemu_opt),
         Action::Test(test_opt) => run_host_tests(test_opt),
         Action::Fmt(fmt_opt) => run_fmt_project(fmt_opt),
+        Action::AutoRelease(_) => release::auto_release(),
     }
 }

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -74,6 +74,7 @@ pub enum Action {
     Run(QemuOpt),
     Test(TestOpt),
     Fmt(FmtOpt),
+    AutoRelease(AutoReleaseOpt),
 }
 
 /// Build all the uefi packages.
@@ -202,3 +203,10 @@ pub struct FmtOpt {
     #[clap(long, action)]
     pub check: bool,
 }
+
+/// Run the auto-release process (should only be run by Github Action).
+///
+/// This is run by the `release.yml` workflow. It is not intended to be run
+/// locally, and will exit immediately if `GITHUB_SHA` is not set.
+#[derive(Debug, Parser)]
+pub struct AutoReleaseOpt {}

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,0 +1,196 @@
+use crate::cargo::Package;
+use crate::util;
+use anyhow::{Context, Result};
+use cargo_metadata::{Metadata, MetadataCommand};
+use crates_index::SparseIndex;
+use std::env;
+use std::process::Command;
+
+/// Entry point for the auto-release process. This is intended to be run from a
+/// Github Actions workflow, see `.github/workflows/release.yml`.
+pub fn auto_release() -> Result<()> {
+    let commit_sha = get_commit_sha()?;
+    let commit_message_body = get_commit_message_body(&commit_sha)?;
+
+    if !commit_message_body.starts_with("release:") {
+        println!("{commit_sha} does not contain the release trigger");
+        return Ok(());
+    }
+
+    fetch_git_tags()?;
+
+    let local_metadata = get_local_package_metadata()?;
+    let mut index = SparseIndex::new_cargo_default()?;
+
+    for package in Package::published() {
+        auto_release_package(package, &local_metadata, &mut index, &commit_sha)?;
+    }
+
+    Ok(())
+}
+
+/// Release a single package, if needed.
+///
+/// This publishes to crates.io if the corresponding version does not already
+/// exist there, and also pushes a new git tag if one doesn't exist yet.
+fn auto_release_package(
+    package: Package,
+    local_metadata: &Metadata,
+    index: &mut SparseIndex,
+    commit_sha: &str,
+) -> Result<()> {
+    let local_version = get_local_package_version(package, local_metadata)?;
+    println!("local version of {} is {local_version}", package.name());
+
+    // Create the remote git tag if it doesn't exist.
+    let tag = get_git_tag_name(package, &local_version);
+    if does_git_tag_exist(&tag)? {
+        println!("git tag {tag} already exists");
+    } else {
+        make_and_push_git_tag(&tag, commit_sha)?;
+    }
+
+    // Create the crates.io release if it doesn't exist.
+    if does_crates_io_release_exist(package, &local_version, index)? {
+        println!(
+            "{}-{local_version} has already been published",
+            package.name()
+        );
+    } else {
+        publish_package(package)?;
+    }
+
+    Ok(())
+}
+
+/// Get the commit to operate on from the `GITHUB_SHA` env var. When running in
+/// Github Actions, this will be set to the SHA of the merge commit that was
+/// pushed to the branch.
+fn get_commit_sha() -> Result<String> {
+    let commit_var_name = "GITHUB_SHA";
+    env::var(commit_var_name).context(format!("failed to get env var {commit_var_name}"))
+}
+
+/// Create a git command with the given args.
+fn get_git_command<const N: usize>(args: [&str; N]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(args);
+    cmd
+}
+
+/// Get the body of the commit message for the given commit.
+fn get_commit_message_body(commit_sha: &str) -> Result<String> {
+    let cmd = get_git_command([
+        "log",
+        "-1",
+        // Only get the body of the commit message.
+        "--format=format:%b",
+        commit_sha,
+    ]);
+    util::run_cmd_get_stdout(cmd)
+}
+
+/// Use the `cargo_metadata` crate to get local info about packages in the
+/// workspace.
+fn get_local_package_metadata() -> Result<Metadata> {
+    let mut cmd = MetadataCommand::new();
+    // Ignore deps, we only need local packages.
+    cmd.no_deps();
+    Ok(cmd.exec()?)
+}
+
+/// Fetch git tags from the remote.
+fn fetch_git_tags() -> Result<()> {
+    let cmd = get_git_command(["fetch", "--tags"]);
+    util::run_cmd(cmd)
+}
+
+/// Format a package version as a git tag.
+fn get_git_tag_name(package: Package, local_version: &str) -> String {
+    format!("{}-v{}", package.name(), local_version)
+}
+
+/// Check if a git tag exists locally.
+///
+/// All git tags were fetched at the start of auto-release, so checking locally
+/// is sufficient.
+fn does_git_tag_exist(tag: &str) -> Result<bool> {
+    let cmd = get_git_command(["tag", "--list", tag]);
+    let output = util::run_cmd_get_stdout(cmd)?;
+
+    Ok(output.lines().any(|line| line == tag))
+}
+
+/// Create a git tag locally and push it.
+fn make_and_push_git_tag(tag: &str, commit_sha: &str) -> Result<()> {
+    // Create the tag.
+    let cmd = get_git_command(["tag", tag, commit_sha]);
+    util::run_cmd(cmd)?;
+
+    // Push it.
+    let cmd = get_git_command(["push", "--tags"]);
+    util::run_cmd(cmd)
+}
+
+/// Update the local crates.io cache.
+///
+/// Based on https://github.com/frewsxcv/rust-crates-index/blob/HEAD/examples/sparse_http_ureq.rs
+fn update_index(index: &mut SparseIndex, package: Package) -> Result<()> {
+    let crate_name = package.name();
+
+    println!("fetching updates for {}", package.name());
+    let request: ureq::Request = index.make_cache_request(crate_name).unwrap().into();
+    let response = request.call()?;
+
+    index.parse_cache_response(crate_name, response.into(), true)?;
+
+    Ok(())
+}
+
+/// Check if a new release of `package` should be published.
+fn does_crates_io_release_exist(
+    package: Package,
+    local_version: &str,
+    index: &mut SparseIndex,
+) -> Result<bool> {
+    let remote_versions = get_remote_package_versions(package, index)?;
+    if remote_versions.contains(&local_version.to_string()) {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+/// Get the local version of `package`.
+fn get_local_package_version(package: Package, local_metadata: &Metadata) -> Result<String> {
+    let metadata = local_metadata
+        .packages
+        .iter()
+        .find(|pm| pm.name == package.name())
+        .context(format!(
+            "failed to find {} in local metadata",
+            package.name()
+        ))?;
+    Ok(metadata.version.to_string())
+}
+
+/// Get all remote versions of `package`.
+fn get_remote_package_versions(package: Package, index: &mut SparseIndex) -> Result<Vec<String>> {
+    // The local cache may be out of date, fetch updates from the remote.
+    update_index(index, package)?;
+
+    let cr = index.crate_from_cache(package.name())?;
+
+    Ok(cr
+        .versions()
+        .iter()
+        .map(|v| v.version().to_string())
+        .collect())
+}
+
+/// Publish `package` to crates.io.
+fn publish_package(package: Package) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["publish", "--package", package.name()]);
+    util::run_cmd(cmd)
+}

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::process::Command;
 
 /// Format a `Command` as a `String.
@@ -41,6 +41,19 @@ pub fn run_cmd(mut cmd: Command) -> Result<()> {
         Ok(())
     } else {
         bail!("command failed: {}", status);
+    }
+}
+
+/// Print a `Command` and run it, then check that it completes
+/// successfully. Return the command's stdout as a `String`.
+pub fn run_cmd_get_stdout(mut cmd: Command) -> Result<String> {
+    println!("run_cmd: '{}'", command_to_string(&cmd));
+
+    let output = cmd.output()?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).context("command output is not utf-8")
+    } else {
+        bail!("command failed: {}", output.status);
     }
 }
 


### PR DESCRIPTION
This new workflow will simplify our release process and make it more reviewable:

1. Create a branch that updates the versions of all packages you want to release. This PR should include all related changes such as updating the versions in dependent crates and updating the changelog.
2. Create a PR of that branch. The subject of the PR must start with `release:`, the rest of the message is arbitrary.
3. Once the PR is approved and merged, a Github Actions workflow will take care of creating git tags and publishing to crates.io.

Since all the changes are now part of one PR that is created before the release actually occurs, we can now review our release changes just like any other PR. And with the release happening in a github action, it avoids a lot of easy-to-make mistakes such as releasing from the wrong commit or forgetting to push tags.

Obviously it's a little tricky to test release flows, so while I've tested the git-tag portion and a dry-run of the cargo-publish step, there could certainly be some bugs to resolve.

Closes https://github.com/rust-osdev/uefi-rs/issues/325

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
