### PR TITLE
uefi-raw: Fill in [un]install_multiple_protocol_interfaces pointers

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -6,3 +6,7 @@
 
 ## Changed
 - `{install,reinstall,uninstall}_protocol_interface` now take `const` interface pointers.
+- `{un}install_multiple_protocol_interfaces` are now defined as c-variadic
+  function pointers. The ABI is `extern "C"` until such time as
+  [`extended_varargs_abi_support`](https://github.com/rust-lang/rust/issues/100189)
+  is stabilized.

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -188,11 +188,28 @@ pub struct BootServices {
         out_proto: *mut *mut c_void,
     ) -> Status,
 
-    // These two function pointers require the `c_variadic` feature, which is
-    // not yet available in stable Rust:
-    // https://github.com/rust-lang/rust/issues/44930
-    pub install_multiple_protocol_interfaces: usize,
-    pub uninstall_multiple_protocol_interfaces: usize,
+    /// Warning: this function pointer is declared as `extern "C"` rather than
+    /// `extern "efiapi". That means it will work correctly when called from a
+    /// UEFI target (`*-unknown-uefi`), but will not work when called from a
+    /// target with a different calling convention such as
+    /// `x86_64-unknown-linux-gnu`.
+    ///
+    /// Support for C-variadics with `efiapi` requires the unstable
+    /// [`extended_varargs_abi_support`](https://github.com/rust-lang/rust/issues/100189)
+    /// feature.
+    pub install_multiple_protocol_interfaces:
+        unsafe extern "C" fn(handle: *mut Handle, ...) -> Status,
+
+    /// Warning: this function pointer is declared as `extern "C"` rather than
+    /// `extern "efiapi". That means it will work correctly when called from a
+    /// UEFI target (`*-unknown-uefi`), but will not work when called from a
+    /// target with a different calling convention such as
+    /// `x86_64-unknown-linux-gnu`.
+    ///
+    /// Support for C-variadics with `efiapi` requires the unstable
+    /// [`extended_varargs_abi_support`](https://github.com/rust-lang/rust/issues/100189)
+    /// feature.
+    pub uninstall_multiple_protocol_interfaces: unsafe extern "C" fn(handle: Handle, ...) -> Status,
 
     // CRC services
     pub calculate_crc32:

--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -208,8 +208,8 @@ fn check_type(ty: &Type, src: &Path) -> Result<(), Error> {
 
 /// Validate a function pointer.
 fn check_fn_ptr(f: &TypeBareFn, src: &Path) -> Result<(), Error> {
-    // Require `extern efiapi`.
-    if !is_efiapi(f) {
+    // Require `extern efiapi`, except for c-variadics.
+    if !is_efiapi(f) && f.variadic.is_none() {
         return Err(Error::new(ErrorKind::ForbiddenAbi, src, f));
     }
 
@@ -428,6 +428,15 @@ mod tests {
         assert!(check_fn_ptr(
             &parse_quote! {
                 unsafe extern "efiapi" fn()
+            },
+            src(),
+        )
+        .is_ok());
+
+        // Valid fn ptr with c-variadics.
+        assert!(check_fn_ptr(
+            &parse_quote! {
+                unsafe extern "C" fn(usize, ...)
             },
             src(),
         )


### PR DESCRIPTION
The existing comment there said the unstable `c-variadic` feature was required, but that was incorrect. While defining c-variadic functions is unstable in Rust, c-variadic function pointers are stable (calling c-variadics is also stable).

We still can't quite define these two function pointers correctly because they should be `extern "efiapi"`, which requires the unstable `extended_varargs_abi_support` feature. However, as long as your code is compiled for a UEFI target, `extern "C"` gives you the correct ABI. Since these function pointers are `unsafe` to call, we can expose them in the raw interface and leave it up to the caller to ensure they are used correctly.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
