### PR TITLE
nix: update rust-toolchain in shell

### DIFF
--- a/.github/workflows/developer_productivity.yml
+++ b/.github/workflows/developer_productivity.yml
@@ -25,7 +25,7 @@ jobs:
   #
   # It only runs if the "nix-src" output of the "changes" job is true.
   nix_shell_toolchain:
-    name: "Nix toolchain: cargo xtask run works"
+    name: "Nix toolchain: `cargo xtask run` works"
     needs: changes
     if: ${{ needs.changes.outputs.nix-src == 'true' }}
     runs-on: ubuntu-latest
@@ -45,6 +45,6 @@ jobs:
         run: nix-shell --pure --run "cargo --version"
       - name: Run VM tests
         run: |
-          COMMAND="cargo +stable xtask run --target x86_64 --headless --ci --tpm=v1"
-          echo "Executing in nix shell now: $COMMAND"
+          COMMAND="cargo xtask run --target x86_64 --headless --ci --tpm=v1"
+          echo "Executing in nix shell: $COMMAND"
           nix-shell --pure --run "$COMMAND"

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,6 @@
+let
+  sources = import ./sources.nix { };
+  rust-overlay = import sources.rust-overlay;
+in
+import sources.nixpkgs { overlays = [ rust-overlay ]; }
+

--- a/nix/rust-toolchain.nix
+++ b/nix/rust-toolchain.nix
@@ -1,0 +1,10 @@
+# Returns the Rust toolchain for Nix compliant to the rust-toolchain.toml file
+# but without rustup.
+
+{
+  # Comes from rust-overlay
+  rust-bin
+}:
+
+# Includes rustc, cargo, rustfmt, etc
+rust-bin.fromRustupToolchainFile ../rust-toolchain.toml

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b0edc9c690c1d8a729f055e0d73439045cfda55",
-        "sha256": "1fdsnmkcz1h5wffjci29af4jrd68pzdvrhbs083niwqfd6ssm633",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "sha256": "1y12a4hgxx2lixrcbyhycwxvrrfik1lxjnwkprar0r6173rwy9ax",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6b0edc9c690c1d8a729f055e0d73439045cfda55.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/da4024d0ead5d7820f6bd15147d3fe2a0c0cec73.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,26 @@
 {
-  "nixpkgs": {
-    "branch": "nixos-23.05",
-    "description": "Nix Packages collection",
-    "homepage": null,
-    "owner": "NixOS",
-    "repo": "nixpkgs",
-    "rev": "6b0edc9c690c1d8a729f055e0d73439045cfda55",
-    "sha256": "1fdsnmkcz1h5wffjci29af4jrd68pzdvrhbs083niwqfd6ssm633",
-    "type": "tarball",
-    "url": "https://github.com/NixOS/nixpkgs/archive/6b0edc9c690c1d8a729f055e0d73439045cfda55.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  }
+    "nixpkgs": {
+        "branch": "nixos-23.05",
+        "description": "Nix Packages collection",
+        "homepage": null,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b0edc9c690c1d8a729f055e0d73439045cfda55",
+        "sha256": "1fdsnmkcz1h5wffjci29af4jrd68pzdvrhbs083niwqfd6ssm633",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6b0edc9c690c1d8a729f055e0d73439045cfda55.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "rust-overlay": {
+        "branch": "master",
+        "description": "Pure and reproducible nix overlay of binary distributed rust toolchains",
+        "homepage": "",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e485313fc485700a9f1f9b8b272ddc0621d08357",
+        "sha256": "1v1gq022rnni6mm42pxmw6c5yy9il4jb2l92irh154ax616x2rzd",
+        "type": "tarball",
+        "url": "https://github.com/oxalica/rust-overlay/archive/e485313fc485700a9f1f9b8b272ddc0621d08357.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
+channel = "stable"
+# cargo, clippy, rustc, rust-docs, rustfmt, rust-std
+profile = "default"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/shell.nix
+++ b/shell.nix
@@ -2,10 +2,11 @@
 # "cargo xtask run|test|clippy". It uses rustup rather than a pinned rust
 # toolchain.
 
-{ sources ? import ./nix/sources.nix { }
-, pkgs ? import sources.nixpkgs { }
-}:
-
+let
+  sources = import ./nix/sources.nix;
+  pkgs = import ./nix/nixpkgs.nix;
+  rustToolchain = pkgs.callPackage ./nix/rust-toolchain.nix {};
+in
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     # nix related stuff (such as dependency management)
@@ -17,7 +18,7 @@ pkgs.mkShell {
     qemu
 
     # Rust toolchain
-    rustup
+    rustToolchain
 
     # Other
     yamlfmt


### PR DESCRIPTION
This changes the rust-toolchain from `rustup` to `rust-bin.fromRustupToolchainFile` coming from https://github.com/oxalica/rust-overlay. This supersedes #994.

TL;DR: `nix-shell --pure --run "rustc --version"` is now `1.73`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
