### PR TITLE
Simplify DevicePath to_string return type

### DIFF
--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -77,7 +77,7 @@ pub fn test(image: Handle, bt: &BootServices) {
         let path_components = device_path
             .node_iter()
             .map(|node| node.to_string(bt, DisplayOnly(false), AllowShortcuts(false)))
-            .map(|str| str.unwrap().unwrap().to_string())
+            .map(|str| str.unwrap().to_string())
             .collect::<Vec<_>>();
 
         let expected_device_path_str_components = &[
@@ -103,7 +103,6 @@ pub fn test(image: Handle, bt: &BootServices) {
         // Test that to_string works for device_paths
         let path = device_path
             .to_string(bt, DisplayOnly(false), AllowShortcuts(false))
-            .unwrap()
             .unwrap()
             .to_string();
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Implemented `PartialEq<char>` for `Char8` and `Char16`.
 - Added `CStr16::from_char16_with_nul` and `Char16::from_char16_with_nul_unchecked`.
 
+## Changed
+- `DevicePath::to_string` and `DevicePathNode::to_string` now return
+  out-of-memory errors as part of the error type rather than with an `Option`.
+
 # uefi - 0.26.0 (2023-11-12)
 
 ## Added


### PR DESCRIPTION
Instead of returning `None` for out of memory, add a new variant to `DevicePathToTextError` and return that. That allows the return type to be a plain `Result` rather than `Result<Option>`, simplifying usage.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
