### PR TITLE
uefi-raw: Add LoadFileProtocol and LoadFile2Protocol

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `IpAddress`, `Ipv4Address`, `Ipv6Address`, and `MacAddress` types.
 - Added `ServiceBindingProtocol`, `Dhcp4Protocol`, `HttpProtocol`,
   `Ip4Config2Protocol`, `TlsConfigurationProtocol`, and related types.
+- Added `LoadFileProtocol` and `LoadFile2Protocol`.
 
 # uefi-raw - 0.5.0 (2023-11-12)
 

--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -1,0 +1,35 @@
+use crate::protocol::device_path::DevicePathProtocol;
+use crate::{guid, Guid, Status};
+use core::ffi::c_void;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct LoadFileProtocol {
+    pub load_file: unsafe extern "efiapi" fn(
+        this: *mut LoadFileProtocol,
+        file_path: *const DevicePathProtocol,
+        boot_policy: bool,
+        buffer_size: *mut usize,
+        buffer: *mut c_void,
+    ) -> Status,
+}
+
+impl LoadFileProtocol {
+    pub const GUID: Guid = guid!("56ec3091-954c-11d2-8e3f-00a0c969723b");
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct LoadFile2Protocol {
+    pub load_file: unsafe extern "efiapi" fn(
+        this: *mut LoadFile2Protocol,
+        file_path: *const DevicePathProtocol,
+        boot_policy: bool,
+        buffer_size: *mut usize,
+        buffer: *mut c_void,
+    ) -> Status,
+}
+
+impl LoadFile2Protocol {
+    pub const GUID: Guid = guid!("4006c0c1-fcb3-403e-996d-4a6c8724e06d");
+}

--- a/uefi-raw/src/protocol/mod.rs
+++ b/uefi-raw/src/protocol/mod.rs
@@ -11,6 +11,7 @@ pub mod disk;
 pub mod driver;
 pub mod file_system;
 pub mod loaded_image;
+pub mod media;
 pub mod memory_protection;
 pub mod network;
 pub mod rng;


### PR DESCRIPTION
Extracting the uefi-raw part of https://github.com/rust-osdev/uefi-rs/pull/945, and adding `LoadFileProtocol` as well.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
