### PR TITLE
renovate: Change stategy to update-lockfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "automerge": true
   },
-  "rangeStrategy": "replace",
+  "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
       "matchPackageNames": ["crate-ci/typos"],


### PR DESCRIPTION
Support for this strategy (with cargo) was added recently:
https://github.com/renovatebot/renovate/issues/22820. It seems that at the same time the behavior of the "replace" strategy changed, causing PRs to be opened with unnecessary changes to Cargo.toml.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
