### PR TITLE
Fix logger connection after opening serial protocol

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -186,12 +186,17 @@ fn shutdown(mut st: SystemTable<Boot>) -> ! {
     // Get our text output back.
     st.stdout().reset(false).unwrap();
 
-    info!("Testing complete, shutting down...");
-
     // Tell the host that tests are done. We are about to exit boot
     // services, so we can't easily communicate with the host any later
     // than this.
     send_request_to_host(st.boot_services(), HostRequest::TestsComplete);
+
+    // Send a special log to the host so that we can verify that logging works
+    // up until exiting boot services. See `reconnect_serial_to_console` for the
+    // type of regression this prevents.
+    info!("LOGGING_STILL_WORKING_RIGHT_BEFORE_EBS");
+
+    info!("Testing complete, shutting down...");
 
     // Exit boot services as a proof that it works :)
     let (st, _iter) = st.exit_boot_services(MemoryType::LOADER_DATA);

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -1,3 +1,4 @@
+use crate::reconnect_serial_to_console;
 use uefi::proto::console::serial::{ControlBits, Serial};
 use uefi::table::boot::BootServices;
 use uefi::{Result, ResultExt, Status};
@@ -66,7 +67,7 @@ pub unsafe fn test(bt: &BootServices) {
     // device, which was broken when we opened the protocol in exclusive
     // mode above.
     drop(serial);
-    let _ = bt.connect_controller(handle, None, None, true);
+    reconnect_serial_to_console(bt, handle);
 
     if let Err(err) = res {
         panic!("serial test failed: {:?}", err.status());

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Implemented `PartialEq<char>` for `Char8` and `Char16`.
 - Added `CStr16::from_char16_with_nul` and `Char16::from_char16_with_nul_unchecked`.
+- Added terminal GUID constants to `device_path::messaging::Vendor`.
 
 ## Changed
 - `DevicePath::to_string` and `DevicePathNode::to_string` now return

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -2413,6 +2413,17 @@ pub mod messaging {
 
     }
 
+    impl Vendor {
+        /// PC-ANSI terminal GUID.
+        pub const PC_ANSI: Guid = guid!("e0c14753-f9be-11d2-9a0c-0090273fc14d");
+        /// VT-100 terminal GUID.
+        pub const VT_100: Guid = guid!("dfa66065-b419-11d3-9a2d-0090273fc14d");
+        /// VT-100+ terminal GUID.
+        pub const VT_100_PLUS: Guid = guid!("7baec70b-57e0-4c76-8e87-2f9e28088343");
+        /// VT-UTF8 terminal GUID.
+        pub const VT_UTF8: Guid = guid!("ad15a0d6-8bec-4acf-a073-d01de77e2d88");
+    }
+
     newtype_enum! { # [doc = " iSCSI network protocol."] pub enum IscsiProtocol : u16 => { # [doc = " TCP."] TCP = 0x0000 , }
 
     }

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -686,6 +686,20 @@ mod messaging {
         vendor_defined_data: [u8],
     }
 
+    impl Vendor {
+        /// PC-ANSI terminal GUID.
+        pub const PC_ANSI: Guid = guid!("e0c14753-f9be-11d2-9a0c-0090273fc14d");
+
+        /// VT-100 terminal GUID.
+        pub const VT_100: Guid = guid!("dfa66065-b419-11d3-9a2d-0090273fc14d");
+
+        /// VT-100+ terminal GUID.
+        pub const VT_100_PLUS: Guid = guid!("7baec70b-57e0-4c76-8e87-2f9e28088343");
+
+        /// VT-UTF8 terminal GUID.
+        pub const VT_UTF8: Guid = guid!("ad15a0d6-8bec-4acf-a073-d01de77e2d88");
+    }
+
     // The spec defines a couple specific messaging-vendor types here,
     // one for UART and one for SAS. These are sort of subclasses of
     // `messaging::Vendor` so they don't quite fit the usual pattern of


### PR DESCRIPTION
My [recent PR](https://github.com/rust-osdev/uefi-rs/pull/1027) to upgrade the edk2 prebuilts had a bug I didn't notice: the logging output gets cut off after the serial protocol is opened in exclusive mode.

This was caused by https://github.com/tianocore/edk2/commit/cf6a0a52b07195ba278e48b89cfb7ddbad332ab1. Fix it by specifying the appropriate terminal type when calling `connect_controller`.

Since this bug has happened in various forms a couple times, also update the tests to catch it: check for a special log message right before exiting boot services, and fail the tests if that message is not received.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
