### PR TITLE
Fix broken UEFI spec link in uefi-raw README.md

### DIFF
--- a/uefi-raw/README.md
+++ b/uefi-raw/README.md
@@ -6,4 +6,4 @@
 This crate contains raw UEFI types that closely match the definitions in the
 [UEFI Specification].
 
-[UEFI Specification]: https://uefi.org/specifications.
+[UEFI Specification]: https://uefi.org/specifications


### PR DESCRIPTION
Removed the stray period character at the end of the link which prevented it from working