### PR TITLE
uefi-services: Use "dep:" syntax

### DIFF
--- a/uefi-services/CHANGELOG.md
+++ b/uefi-services/CHANGELOG.md
@@ -1,5 +1,9 @@
 # uefi-services - [Unreleased]
 
+## Changed
+- The implicit `qemu-exit` crate feature has been removed. (Note that this is
+  different from the `qemu` crate feature, which is unchanged.)
+
 # uefi-services - 0.23.0 (2023-11-12)
 
 ## Changed

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -21,6 +21,6 @@ qemu-exit = { version = "3.0.1", optional = true }
 [features]
 default = ["panic_handler", "logger"]
 # Enable QEMU-specific functionality
-qemu = ["qemu-exit"]
+qemu = ["dep:qemu-exit"]
 panic_handler = []
 logger = ["uefi/logger"]


### PR DESCRIPTION
Use `dep:` for the optional `qemu-exit` dependency. This avoids implicitly adding a useless `qemu-exit` feature to the crate.

Doc: https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
