### PR TITLE
release: uefi-raw-0.5.1, uefi-0.27.0, uefi-services-0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bitflags 2.4.2",
  "log",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitflags 2.4.2",
  "ptr_meta",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cfg-if",
  "log",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.26.0", features = ["alloc"] }
-uefi-services = "0.23.0"
+uefi = { version = "0.27.0", features = ["alloc"] }
+uefi-services = "0.24.0"

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,7 @@
 # uefi-raw - [Unreleased]
 
+# uefi-raw - 0.5.1 (2024-03-17)
+
 ## Added
 - Added `IpAddress`, `Ipv4Address`, `Ipv6Address`, and `MacAddress` types.
 - Added `ServiceBindingProtocol`, `Dhcp4Protocol`, `HttpProtocol`,

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.5.0"
+version = "0.5.1"
 readme = "README.md"
 description = "Raw UEFI types"
 

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.23.0"
+version = "0.24.0"
 readme = "README.md"
 description = "Higher-level utilities for the `uefi` crate."
 
@@ -13,7 +13,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-uefi = { version = "0.26.0", features = ["global_allocator"] }
+uefi = { version = "0.27.0", features = ["global_allocator"] }
 log.workspace = true
 cfg-if = "1.0.0"
 qemu-exit = { version = "3.0.1", optional = true }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,7 @@
 # uefi - [Unreleased]
 
+# uefi - 0.27.0 (2024-03-17)
+
 ## Added
 - Implemented `PartialEq<char>` for `Char8` and `Char16`.
 - Added `CStr16::from_char16_with_nul` and `Char16::from_char16_with_nul_unchecked`.

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.26.0"
+version = "0.27.0"
 readme = "README.md"
 description = "Safe and easy-to-use wrapper for building UEFI apps."
 
@@ -30,7 +30,7 @@ log.workspace = true
 ptr_meta.workspace = true
 ucs2 = "0.3.2"
 uefi-macros = "0.13.0"
-uefi-raw = "0.5.0"
+uefi-raw = "0.5.1"
 uguid.workspace = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Been a little while since we last released, and we've accumulated a few additions and fixes. This also serves as a test that the recent [auto-release](https://github.com/rust-osdev/uefi-rs/pull/1068) changes didn't break anything.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
