### PR TITLE
Fix some warnings, and ensure CI catches them in the future

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ on:
       - version-*
   schedule:
     - cron: '0 0 * * 0-6'
+env:
+  RUSTFLAGS: -D warnings
 jobs:
   test_aarch64:
     name: Integration Test (AArch64)

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -83,13 +83,15 @@ pub fn init(st: &mut SystemTable<Boot>) -> Result<()> {
     // Setup the system table singleton
     SYSTEM_TABLE.store(st.as_ptr().cast_mut(), Ordering::Release);
 
+    // Setup logging and memory allocation
+
+    #[cfg(feature = "logger")]
     unsafe {
-        // Setup logging and memory allocation
-
-        #[cfg(feature = "logger")]
         logger::init(st);
+    }
 
-        #[cfg(feature = "global_allocator")]
+    #[cfg(feature = "global_allocator")]
+    unsafe {
         uefi::allocator::init(st);
     }
 

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1949,8 +1949,6 @@ mod tests {
     use super::{MemoryDescriptor, MemoryMapIter};
 
     fn buffer_to_map(buffer: &mut [MemoryDescriptor]) -> MemoryMap {
-        let desc_count = buffer.len();
-
         let byte_buffer = {
             unsafe {
                 core::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, size_of_val(buffer))


### PR DESCRIPTION
Set `RUSTFLAGS="-D warnings"` for all jobs so that errors are treated as warnings for build/test.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
