### PR TITLE
release: uefi-raw-0.5.2, uefi-0.28.0, uefi-services-0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bitflags 2.5.0",
  "ptr_meta",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "uefi",
 ]

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.27.0", features = ["alloc"] }
+uefi = { version = "0.28.0", features = ["alloc"] }

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,8 +1,12 @@
 # uefi-raw - [Unreleased]
 
+
+# uefi-raw - 0.5.2 (2024-04-19)
+
 ## Added
 - Added `TimestampProtocol`.
 - Added `DevicePathToTextProtocol` and `DevicePathFromTextProtocol`.
+
 
 # uefi-raw - 0.5.1 (2024-03-17)
 
@@ -12,6 +16,7 @@
   `Ip4Config2Protocol`, `TlsConfigurationProtocol`, and related types.
 - Added `LoadFileProtocol` and `LoadFile2Protocol`.
 - Added `firmware_storage` module.
+
 
 # uefi-raw - 0.5.0 (2023-11-12)
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.5.1"
+version = "0.5.2"
 readme = "README.md"
 description = "Raw UEFI types"
 

--- a/uefi-services/CHANGELOG.md
+++ b/uefi-services/CHANGELOG.md
@@ -1,8 +1,18 @@
 # uefi-services - [Unreleased]
 
+
+# uefi-services - 0.25.0 (2023-11-12)
+
 ## Changed
 - `uefi-services` is deprecated and should be removed. All functionality was
-  moved to `uefi::helpers::init()`
+moved to `uefi::helpers::init()`
+
+
+# uefi-services - 0.24.0 (2023-03-17)
+
+## Changed
+- Updated to latest version of `uefi`.
+
 
 # uefi-services - 0.23.0 (2023-11-12)
 
@@ -10,30 +20,36 @@
 - `uefi_services::system_table` now returns `SystemTable<Boot>` directly, rather
   than wrapped in a `NonNull` pointer.
 
+
 # uefi-services - 0.22.0 (2023-10-11)
 
 ## Changed
 - Updated to latest version of `uefi`.
+
 
 # uefi-services - 0.21.0 (2023-06-20)
 
 ## Changed
 - Updated to latest version of `uefi`.
 
+
 # uefi-services - 0.20.0 (2023-06-04)
 
 ## Changed
 - Updated to latest version of `uefi`.
+
 
 # uefi-services - 0.19.0 (2023-06-01)
 
 ## Changed
 - Internal updates for changes in `uefi`.
 
+
 # uefi-services - 0.18.0 (2023-05-15)
 
 ## Changed
 - Internal updates for changes in `uefi`.
+
 
 # uefi-services - 0.17.0 (2023-03-19)
 
@@ -42,10 +58,12 @@
   [`default_alloc_error_handler`](https://github.com/rust-lang/rust/pull/102318)
   instead.
 
+
 # uefi-services - 0.16.0 (2023-01-16)
 
 ## Changed
 - Bumped `uefi` dependency to latest version.
+
 
 # uefi-services - 0.15.0 (2022-11-15)
 
@@ -57,6 +75,7 @@
   This allows using both crates while disabling `logger` in `uefi`,
   which was previously impossible.
 
+
 # uefi-services - 0.14.0 (2022-09-09)
 
 ## Added
@@ -66,16 +85,19 @@
 - The `no_panic_handler` feature has been replaced with an additive
   `panic_handler` feature. The new feature is enabled by default.
 
+
 # uefi-services - 0.13.1 (2022-08-26)
 
 ## Changed
 - Relaxed the version requirements for the `log` dependency to allow
   earlier patch versions.
 
+
 # uefi-services - 0.13.0 (2022-05-16)
 
 ## Changed
 - Bumped `uefi` dependency to latest version.
+
 
 # uefi-services - 0.12.1 (2022-03-15)
 

--- a/uefi-services/Cargo.toml
+++ b/uefi-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-services"
-version = "0.24.0"
+version = "0.25.0"
 readme = "README.md"
 description = "Deprecated. Please migrate to `uefi::helpers`."
 
@@ -13,7 +13,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-uefi = { version = "0.27.0", features = ["global_allocator"] }
+uefi = { version = "0.28.0", features = ["global_allocator"] }
 
 [features]
 default = ["panic_handler", "logger"]

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,14 +1,18 @@
 # uefi - [Unreleased]
 
+
+# uefi - 0.28.0 (2024-04-19)
+
 ## Added
 - Added `Timestamp` protocol.
 - Added `UnalignedSlice::as_ptr`.
 - Added common derives for `Event` and `Handle`.
 - `uefi::helpers::init` with the functionality that used to be in
-  `uefi::services`. With that, new features were added:
-  - `global_allocator`
-  - `panic_handler`
-  - `qemu`
+`uefi::services`. With that, new features were added:
+- `global_allocator`
+- `panic_handler`
+- `qemu`
+
 
 # uefi - 0.27.0 (2024-03-17)
 
@@ -22,6 +26,7 @@
 ## Changed
 - `DevicePath::to_string` and `DevicePathNode::to_string` now return
   out-of-memory errors as part of the error type rather than with an `Option`.
+
 
 # uefi - 0.26.0 (2023-11-12)
 
@@ -41,6 +46,7 @@
   `&BootServices`.
 - `BootServices::{install,reinstall,uninstall}_protocol_interface` now take
   `const` interface pointers.
+
 
 # uefi - 0.25.0 (2023-10-10)
 
@@ -67,6 +73,7 @@
 - `BootServices::memmove` and `BootServices::set_mem` have been removed, use
   standard functions like `core::ptr::copy` and `core::ptr::write_bytes` instead.
 
+
 # uefi - 0.24.0 (2023-06-20)
 
 ## Added
@@ -83,10 +90,12 @@
 - The `Deref` and `DerefMut` impls for `ScopedProtocol` will now panic if the
   interface pointer is null.
 
+
 # uefi - 0.23.0 (2023-06-04)
 
 ## Changed
 - Fixed function signature bug in `BootServices::install_configuration_table`.
+
 
 # uefi - 0.22.0 (2023-06-01)
 
@@ -103,6 +112,7 @@
   `BUFFER_TOO_SMALL` error can only occur when reading a directory, not a file.
 - `RegularFile::read` now reads in 1 MiB chunks to avoid a bug in some
   firmware. This fix also applies to `fs::FileSystem::read`.
+
 
 # uefi - 0.21.0 (2023-05-15)
 
@@ -165,6 +175,7 @@
   - `GptPartitionAttributes` now has 16 additional `TYPE_SPECIFIC_BIT_<N>`
     constants.
 
+
 # uefi - 0.20.0 (2023-03-19)
 
 As of this release, the UEFI crates work on the stable channel. This requires
@@ -202,6 +213,7 @@ Rust 1.68 or higher.
     available since EFI 1.10 (2002).
   - `ScopedProtocol::interface` is not public anymore. Use the `Deref` trait.
 
+
 # uefi - 0.19.1 (2023-02-04)
 
 ## Added
@@ -214,6 +226,7 @@ Rust 1.68 or higher.
   `BootServices::find_handles`, and `SearchType::from_proto`.
 - Fixed a warning printed when using `uefi` as a dependency: "the following
   packages contain code that will be rejected by a future version".
+
 
 # uefi - 0.19.0 (2023-01-16)
 
@@ -246,6 +259,7 @@ Rust 1.68 or higher.
   `MaybeUninit<u8>` slice of appropriate length.
 - Redundant private field used for padding in `MemoryDescriptor` structure was removed. Now all
   fields of this struct are public.
+
 
 # uefi - 0.18.0 (2022-11-15)
 
@@ -299,6 +313,7 @@ Rust 1.68 or higher.
   `proto::device_path::acpi::Acpi` and
   `proto::device_path::media::HardDrive` instead.  `
 
+
 # uefi - 0.17.0 (2022-09-09)
 
 ## Added
@@ -350,6 +365,7 @@ Rust 1.68 or higher.
   can be replaced by calling `status.into()`, or `Result::from(status)`
   in cases where the compiler needs a type hint.
 
+
 # uefi - 0.16.1
 
 ## Added
@@ -369,6 +385,7 @@ Rust 1.68 or higher.
   dependencies to allow earlier patch versions.
 - Enabled `doc_auto_cfg` on docs.rs to show badges on items that are
   gated behind a feature.
+
 
 # uefi - 0.16.0 (2022-05-16)
 
@@ -399,6 +416,7 @@ Rust 1.68 or higher.
 ## Fixed
 
 - Fixed undefined behavior in `proto::media::file::File::get_boxed_info`.
+
 
 # uefi - 0.15.2 (2022-03-15)
 

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.27.0"
+version = "0.28.0"
 readme = "README.md"
 description = "Safe and easy-to-use wrapper for building UEFI apps."
 
@@ -37,7 +37,7 @@ uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.2"
 uefi-macros = "0.13.0"
-uefi-raw = "0.5.1"
+uefi-raw = "0.5.2"
 qemu-exit = { version = "3.0.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

Fixes #1138 #1139

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
