### PR TITLE
Minor import/export cleanups

### DIFF
--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -138,23 +138,23 @@ pub trait Align {
 }
 
 mod guid;
-pub use self::guid::{Guid, Identify};
+pub use guid::{Guid, Identify};
 
 pub mod chars;
-pub use self::chars::{Char16, Char8};
+pub use chars::{Char16, Char8};
 
 #[macro_use]
 mod opaque;
 
 mod strs;
-pub use self::strs::{
+pub use strs::{
     CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16Error,
 };
 
 #[cfg(feature = "alloc")]
 mod owned_strs;
 #[cfg(feature = "alloc")]
-pub use self::owned_strs::{CString16, FromStrError};
+pub use owned_strs::{CString16, FromStrError};
 
 mod unaligned_slice;
 pub use unaligned_slice::UnalignedSlice;

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -620,8 +620,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{cstr16, cstr8};
     use alloc::string::String;
-    use uefi_macros::{cstr16, cstr8};
 
     // Tests if our CStr8 type can be constructed from a valid core::ffi::CStr
     #[test]

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -1,9 +1,8 @@
 //! Module for directory iteration. See [`UefiDirectoryIter`].
 
 use super::*;
-use crate::{CStr16, Result};
+use crate::{cstr16, CStr16, Result};
 use alloc::boxed::Box;
-use uefi_macros::cstr16;
 
 /// Common skip dirs in UEFI/FAT-style file systems.
 pub const COMMON_SKIP_DIRS: &[&CStr16] = &[cstr16!("."), cstr16!("..")];

--- a/uefi/src/fs/mod.rs
+++ b/uefi/src/fs/mod.rs
@@ -47,7 +47,7 @@
 //! There is no automatic synchronization of the file system for concurrent
 //! accesses. This is in the responsibility of the user.
 //!
-//! [`cstr16!`]: uefi_macros::cstr16
+//! [`cstr16!`]: crate::cstr16
 
 mod dir_entry_iter;
 mod file_system;

--- a/uefi/src/fs/path/mod.rs
+++ b/uefi/src/fs/path/mod.rs
@@ -21,7 +21,7 @@ pub use path::{Components, Path};
 pub use pathbuf::PathBuf;
 
 use crate::data_types::chars::NUL_16;
-use crate::{CStr16, Char16};
+use crate::{cstr16, CStr16, Char16};
 pub(super) use validation::validate_path;
 pub use validation::PathError;
 
@@ -29,7 +29,7 @@ pub use validation::PathError;
 pub const SEPARATOR: Char16 = unsafe { Char16::from_u16_unchecked('\\' as u16) };
 
 /// Stringified version of [`SEPARATOR`].
-pub const SEPARATOR_STR: &CStr16 = uefi_macros::cstr16!("\\");
+pub const SEPARATOR_STR: &CStr16 = cstr16!("\\");
 
 /// Deny list of characters for path components. UEFI supports FAT-like file
 /// systems. According to <https://en.wikipedia.org/wiki/Comparison_of_file_systems>,

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -198,8 +198,8 @@ mod convenience_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cstr16;
     use alloc::vec::Vec;
-    use uefi_macros::cstr16;
 
     #[test]
     fn from_cstr16() {

--- a/uefi/src/fs/path/pathbuf.rs
+++ b/uefi/src/fs/path/pathbuf.rs
@@ -120,8 +120,8 @@ mod convenience_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cstr16;
     use alloc::string::ToString;
-    use uefi_macros::cstr16;
 
     #[test]
     fn from_cstr16() {

--- a/uefi/src/fs/path/validation.rs
+++ b/uefi/src/fs/path/validation.rs
@@ -67,8 +67,7 @@ pub fn validate_path<P: AsRef<Path>>(path: P) -> Result<(), PathError> {
 mod tests {
     use super::*;
     use crate::fs::PathBuf;
-    use crate::CString16;
-    use uefi_macros::cstr16;
+    use crate::{cstr16, CString16};
 
     #[test]
     fn test_validate_path() {

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -92,7 +92,7 @@ pub fn init(st: &mut SystemTable<Boot>) -> Result<()> {
 
     #[cfg(feature = "global_allocator")]
     unsafe {
-        uefi::allocator::init(st);
+        crate::allocator::init(st);
     }
 
     Ok(())
@@ -111,5 +111,5 @@ pub(crate) fn exit() {
     logger::disable();
 
     #[cfg(feature = "global_allocator")]
-    uefi::allocator::exit_boot_services();
+    crate::allocator::exit_boot_services();
 }

--- a/uefi/src/helpers/panic_handler.rs
+++ b/uefi/src/helpers/panic_handler.rs
@@ -29,9 +29,9 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         } else {
             // If the system table is available, use UEFI's standard shutdown mechanism
             if let Some(st) = system_table_opt() {
-                use uefi::table::runtime::ResetType;
+                use crate::table::runtime::ResetType;
                 st.runtime_services()
-                    .reset(ResetType::SHUTDOWN, uefi::Status::ABORTED, None);
+                    .reset(ResetType::SHUTDOWN, crate::Status::ABORTED, None);
             }
 
             // If we don't have any shutdown mechanism handy, the best we can do is loop

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -106,13 +106,13 @@ extern crate uefi_raw;
 #[macro_use]
 pub mod data_types;
 #[cfg(feature = "alloc")]
-pub use self::data_types::CString16;
-pub use self::data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle, Identify};
+pub use data_types::CString16;
+pub use data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle, Identify};
 pub use uefi_macros::{cstr16, cstr8, entry};
 pub use uguid::guid;
 
 mod result;
-pub use self::result::{Error, Result, ResultExt, Status, StatusExt};
+pub use result::{Error, Result, ResultExt, Status, StatusExt};
 
 pub mod table;
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -139,7 +139,7 @@ mod util;
 // Crates that create procedural macros can't unit test the macros they export.
 // Therefore, we do some tests here.
 mod macro_tests {
-    use uefi_macros::{cstr16, cstr8};
+    use crate::{cstr16, cstr8};
 
     #[test]
     fn cstr8_macro_literal() {

--- a/uefi/src/prelude.rs
+++ b/uefi/src/prelude.rs
@@ -2,12 +2,9 @@
 //!
 //! This includes the system table types, `Status` codes, etc.
 
-pub use crate::{Handle, ResultExt, Status, StatusExt};
+pub use crate::{cstr16, cstr8, entry, Handle, ResultExt, Status, StatusExt};
 
 // Import the basic table types.
 pub use crate::table::boot::BootServices;
 pub use crate::table::runtime::RuntimeServices;
 pub use crate::table::{Boot, SystemTable};
-
-// Import the macro for creating the custom entry point, as well as the cstr macros.
-pub use uefi_macros::{cstr16, cstr8, entry};

--- a/uefi/src/proto/console/text/mod.rs
+++ b/uefi/src/proto/console/text/mod.rs
@@ -1,7 +1,7 @@
 //! Text I/O.
 
 mod input;
-pub use self::input::{Input, Key, ScanCode};
+pub use input::{Input, Key, ScanCode};
 
 mod output;
-pub use self::output::{Color, Output, OutputMode};
+pub use output::{Color, Output, OutputMode};

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -15,8 +15,8 @@ use crate::proto::unsafe_protocol;
 use crate::{Result, Status, StatusExt};
 
 // re-export for ease of use
-pub use self::context::SystemContext;
-pub use self::exception::ExceptionType;
+pub use context::SystemContext;
+pub use exception::ExceptionType;
 
 mod context;
 mod exception;

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -22,12 +22,12 @@ use {alloc::alloc::Global, core::alloc::Allocator};
 #[cfg(feature = "alloc")]
 use {crate::mem::make_boxed, alloc::boxed::Box};
 
-pub use self::dir::Directory;
-pub use self::info::{
+pub use dir::Directory;
+pub use info::{
     FileInfo, FileInfoCreationError, FileProtocolInfo, FileSystemInfo, FileSystemVolumeLabel,
     FromUefi,
 };
-pub use self::regular::RegularFile;
+pub use regular::RegularFile;
 pub use uefi_raw::protocol::file_system::FileAttribute;
 
 /// Common interface to `FileHandle`, `RegularFile`, and `Directory`.

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -15,10 +15,12 @@ use core::ffi::c_void;
 use core::fmt::Debug;
 use core::{mem, ptr};
 use uefi_raw::protocol::file_system::FileProtocolV1;
+
 #[cfg(all(feature = "unstable", feature = "alloc"))]
 use {alloc::alloc::Global, core::alloc::Allocator};
+
 #[cfg(feature = "alloc")]
-use {alloc::boxed::Box, uefi::mem::make_boxed};
+use {crate::mem::make_boxed, alloc::boxed::Box};
 
 pub use self::dir::Directory;
 pub use self::info::{

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -9,12 +9,12 @@
 
 use super::{IpAddress, MacAddress};
 use crate::data_types::Event;
+use crate::proto::unsafe_protocol;
 use crate::{Result, Status, StatusExt};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::ptr;
 use core::ptr::NonNull;
-use uefi_macros::unsafe_protocol;
 
 /// The Simple Network Protocol
 #[derive(Debug)]

--- a/uefi/src/result/mod.rs
+++ b/uefi/src/result/mod.rs
@@ -4,11 +4,11 @@ use core::fmt::Debug;
 
 /// The error type that we use, essentially a status code + optional additional data
 mod error;
-pub use self::error::Error;
+pub use error::Error;
 
 /// Definition of UEFI's standard status codes
 mod status;
-pub use self::status::{Status, StatusExt};
+pub use status::{Status, StatusExt};
 
 /// Return type of most UEFI functions. Both success and error payloads are optional.
 ///

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -95,9 +95,9 @@ impl BootServices {
     /// Update the global image [`Handle`].
     ///
     /// This is called automatically in the `main` entry point as part
-    /// of [`uefi_macros::entry`]. It should not be called at any other
+    /// of [`uefi::entry`]. It should not be called at any other
     /// point in time, unless the executable does not use
-    /// [`uefi_macros::entry`], in which case it should be called once
+    /// [`uefi::entry`], in which case it should be called once
     /// before calling other `BootServices` functions.
     ///
     /// # Safety

--- a/uefi/src/table/mod.rs
+++ b/uefi/src/table/mod.rs
@@ -8,10 +8,10 @@ pub trait Table {
 }
 
 mod header;
-pub use self::header::Header;
+pub use header::Header;
 
 mod system;
-pub use self::system::{Boot, Runtime, SystemTable};
+pub use system::{Boot, Runtime, SystemTable};
 
 pub mod boot;
 pub mod runtime;


### PR DESCRIPTION
* All of the macros from uefi_macros are imported into the uefi crate. Consistently use those imports everywhere, rather than reimporting from `uefi_macros`.
* Consistently import items in the `uefi` crate with `crate::` instead of `uefi::`.
* Clean up unnecessary uses of `self::`.

Should be no change to the public API from this.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
