### PR TITLE
Replace `cstr8!` with a declarative macro

### DIFF
--- a/uefi-macros/CHANGELOG.md
+++ b/uefi-macros/CHANGELOG.md
@@ -1,8 +1,8 @@
 # uefi-macros - [Unreleased]
 
 ## Removed
-- Removed the `cstr16` macro. Use the `cstr16` declarative macro exported by the
-  `uefi` crate instead.
+- Removed the `cstr8` and `cstr16` macros. Use the declarative macros of the
+  same names exported by the `uefi` crate as a replacement.
 
 # uefi-macros - 0.13.0 (2023-11-12)
 

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -151,6 +151,10 @@ pub use strs::{
     CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16Error,
 };
 
+/// These functions are used in the implementation of the [`cstr8`] macro.
+#[doc(hidden)]
+pub use strs::{str_num_latin1_chars, str_to_latin1};
+
 #[cfg(feature = "alloc")]
 mod owned_strs;
 #[cfg(feature = "alloc")]

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -113,7 +113,7 @@ pub mod data_types;
 #[cfg(feature = "alloc")]
 pub use data_types::CString16;
 pub use data_types::{CStr16, CStr8, Char16, Char8, Event, Guid, Handle, Identify};
-pub use uefi_macros::{cstr8, entry};
+pub use uefi_macros::entry;
 pub use uguid::guid;
 
 mod result;
@@ -140,17 +140,3 @@ pub mod helpers;
 
 mod macros;
 mod util;
-
-#[cfg(test)]
-// Crates that create procedural macros can't unit test the macros they export.
-// Therefore, we do some tests here.
-mod macro_tests {
-    use crate::cstr8;
-
-    #[test]
-    fn cstr8_macro_literal() {
-        let _empty1 = cstr8!();
-        let _empty2 = cstr8!("");
-        let _regular = cstr8!("foobar");
-    }
-}

--- a/uefi/src/macros.rs
+++ b/uefi/src/macros.rs
@@ -1,3 +1,47 @@
+/// Encode a string literal as a [`&CStr8`].
+///
+/// The encoding is done at compile time, so the result can be used in a
+/// `const` item.
+///
+/// An empty string containing just a null character can be created with either
+/// `cstr8!()` or `cstr8!("")`.
+///
+/// # Example
+///
+/// ```
+/// use uefi::{CStr8, cstr8};
+///
+/// const S: &CStr8 = cstr8!("abÿ");
+/// assert_eq!(S.as_bytes(), [97, 98, 255, 0]);
+///
+/// const EMPTY: &CStr8 = cstr8!();
+/// assert_eq!(EMPTY.as_bytes(), [0]);
+/// assert_eq!(cstr8!(""), EMPTY);
+/// ```
+///
+/// [`&CStr8`]: crate::CStr8
+#[macro_export]
+macro_rules! cstr8 {
+    () => {{
+        const S: &[u8] = &[0];
+        // SAFETY: `S` is a trivially correct Latin-1 C string.
+        unsafe { $crate::CStr8::from_bytes_with_nul_unchecked(S) }
+    }};
+    ($s:literal) => {{
+        // Use `const` values here to force errors to happen at compile
+        // time.
+
+        // Add one for the null char.
+        const NUM_CHARS: usize = $crate::data_types::str_num_latin1_chars($s) + 1;
+
+        const VAL: [u8; NUM_CHARS] = $crate::data_types::str_to_latin1($s);
+
+        // SAFETY: the `str_to_latin1` function always produces a valid Latin-1
+        // string with a trailing null character.
+        unsafe { $crate::CStr8::from_bytes_with_nul_unchecked(&VAL) }
+    }};
+}
+
 /// Encode a string literal as a [`&CStr16`].
 ///
 /// The encoding is done at compile time, so the result can be used in a


### PR DESCRIPTION
The implementation is similar to `cstr16`, except that since we don't have the equivalent of the `ucs2` crate for latin-1, the internals are implemented directly in this crate.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
