### PR TITLE
Fix risc target_arch cfg

### DIFF
--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -140,7 +140,7 @@ impl ExceptionType {
     pub const MAX_AARCH64_EXCEPTION: ExceptionType = ExceptionType::EXCEPT_AARCH64_SERROR;
 }
 
-#[cfg(target_arch = "riscv")]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 impl ExceptionType {
     /// Instruction misaligned
     pub const EXCEPT_RISCV_INST_MISALIGNED: ExceptionType = ExceptionType(0);


### PR DESCRIPTION
Nightly now checks if target_arch is correct, which revealed a spot where we used `riscv`, which isn't valid. Switched to test both riscv32 and riscv64.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
