### PR TITLE
Add UEFI 2.0 Capsule Services to RuntimeServices

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 - `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
+- `ResetType` now implements the `Default` trait.
 
 # uefi-raw - 0.5.2 (2024-04-19)
 

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,7 @@
 # uefi-raw - [Unreleased]
 
+## Changed
+- `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
 
 # uefi-raw - 0.5.2 (2024-04-19)
 

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -66,7 +66,7 @@ pub struct RuntimeServices {
     pub query_capsule_capabilities: unsafe extern "efiapi" fn(
         capsule_header_array: *const *const CapsuleHeader,
         capsule_count: usize,
-        maximum_capsule_size: *mut usize,
+        maximum_capsule_size: *mut u64,
         reset_type: *mut ResetType,
     ) -> Status,
 

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -80,6 +80,7 @@ pub struct RuntimeServices {
 }
 
 newtype_enum! {
+    #[derive(Default)]
     /// The type of system reset.
     pub enum ResetType: u32 => {
         /// System-wide reset.

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,7 +1,7 @@
 # uefi - [Unreleased]
 
 ## Added
-- Added `RuntimeServices::update_capsule`.
+- Added `RuntimeServices::update_capsule` and `RuntimeServices::query_capsule_capabilities`.
 
 ## Removed
 - Removed the `panic-on-logger-errors` feature of the `uefi` crate. Logger

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+## Added
+- Added `RuntimeServices::update_capsule`.
+
 ## Removed
 - Removed the `panic-on-logger-errors` feature of the `uefi` crate. Logger
   errors are now silently ignored.

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -309,6 +309,25 @@ impl RuntimeServices {
             .to_result()
         }
     }
+
+    /// Tests whether a capsule or capsules can be updated via UpdateCapsule().
+    ///
+    /// See [`CapsuleInfo`] for details of the information returned.
+    pub fn query_capsule_capabilities(
+        &self,
+        capsule_header_array: &[&CapsuleHeader],
+    ) -> Result<CapsuleInfo> {
+        let mut info = CapsuleInfo::default();
+        unsafe {
+            (self.0.query_capsule_capabilities)(
+                capsule_header_array.as_ptr().cast(),
+                capsule_header_array.len(),
+                &mut info.maximum_capsule_size,
+                &mut info.efi_reset_type,
+            )
+            .to_result_with_val(|| info)
+        }
+    }
 }
 
 impl super::Table for RuntimeServices {
@@ -551,4 +570,18 @@ pub struct VariableStorageInfo {
 
     /// Maximum size of an individual variable of the specified type.
     pub maximum_variable_size: u64,
+}
+
+/// Information about UEFI variable storage space returned by
+/// [`RuntimeServices::query_capsule_capabilities`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CapsuleInfo {
+    /// The maximum size in bytes that UpdateCapsule()
+    /// can support as input. Note that UpdateCasule takes
+    /// in an entire capsule as input, which is composed of
+    /// the CapsuleHeaders + CapsuleBlockDescriptors.
+    pub maximum_capsule_size: u64,
+
+    /// The type of reset required for the capsule update.
+    pub efi_reset_type: ResetType,
 }

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -7,10 +7,12 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::mem::MaybeUninit;
 use core::ptr;
 
+pub use uefi_raw::capsule::{CapsuleBlockDescriptor, CapsuleHeader};
 pub use uefi_raw::table::runtime::{
     ResetType, TimeCapabilities, VariableAttributes, VariableVendor,
 };
 pub use uefi_raw::time::Daylight;
+pub use uefi_raw::PhysicalAddress;
 
 #[cfg(feature = "alloc")]
 use {
@@ -289,6 +291,23 @@ impl RuntimeServices {
         virtual_map: *mut MemoryDescriptor,
     ) -> Status {
         (self.0.set_virtual_address_map)(map_size, desc_size, desc_version, virtual_map)
+    }
+
+    /// Passes capsules to the firmware. Capsules are most commonly used to update the firmware
+    /// or for by the operating system to have information persist across a system reset.
+    pub fn update_capsule(
+        &self,
+        capsule_header_array: &[&CapsuleHeader],
+        capsule_block_descriptors: &[CapsuleBlockDescriptor],
+    ) -> Result {
+        unsafe {
+            (self.0.update_capsule)(
+                capsule_header_array.as_ptr().cast(),
+                capsule_header_array.len(),
+                capsule_block_descriptors.as_ptr() as PhysicalAddress,
+            )
+            .to_result()
+        }
     }
 }
 


### PR DESCRIPTION
This contains implementations of rust-y wrappers for the UEFI Capsule Services defined in uefi-raw. 

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
