### PR TITLE
Match MaximumCapsuleSize to UEFI spec

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,7 @@
 # uefi-raw - [Unreleased]
 
+## Changed
+- `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
 
 # uefi-raw - 0.5.2 (2024-04-19)
 

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -66,7 +66,7 @@ pub struct RuntimeServices {
     pub query_capsule_capabilities: unsafe extern "efiapi" fn(
         capsule_header_array: *const *const CapsuleHeader,
         capsule_count: usize,
-        maximum_capsule_size: *mut usize,
+        maximum_capsule_size: *mut u64,
         reset_type: *mut ResetType,
     ) -> Status,
 


### PR DESCRIPTION
Per section 8.5.3.4 of the latest UEFI spec [1], `QueryCapsuleCapabilities` uses a uint64 for MaximumCapsuleSize, not a usize.

[1]:https://uefi.org/sites/default/files/resources/UEFI_Spec_2_10_Aug29.pdf

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
