### PR TITLE
Add RuntimeServices::query_capsule_capabilities

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 - `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
+- `ResetType` now derives the `Default` trait.
 
 # uefi-raw - 0.5.2 (2024-04-19)
 

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -80,6 +80,7 @@ pub struct RuntimeServices {
 }
 
 newtype_enum! {
+    #[derive(Default)]
     /// The type of system reset.
     pub enum ResetType: u32 => {
         /// System-wide reset.

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Added `RuntimeServices::update_capsule`.
+- Added `RuntimeServices::query_capsule_capabilities`.
 
 ## Removed
 - Removed the `panic-on-logger-errors` feature of the `uefi` crate. Logger

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -308,6 +308,25 @@ impl RuntimeServices {
             .to_result()
         }
     }
+
+    /// Tests whether a capsule or capsules can be updated via [`RuntimeServices::update_capsule`].
+    ///
+    /// See [`CapsuleInfo`] for details of the information returned.
+    pub fn query_capsule_capabilities(
+        &self,
+        capsule_header_array: &[&CapsuleHeader],
+    ) -> Result<CapsuleInfo> {
+        let mut info = CapsuleInfo::default();
+        unsafe {
+            (self.0.query_capsule_capabilities)(
+                capsule_header_array.as_ptr().cast(),
+                capsule_header_array.len(),
+                &mut info.maximum_capsule_size,
+                &mut info.reset_type,
+            )
+            .to_result_with_val(|| info)
+        }
+    }
 }
 
 impl super::Table for RuntimeServices {
@@ -550,4 +569,17 @@ pub struct VariableStorageInfo {
 
     /// Maximum size of an individual variable of the specified type.
     pub maximum_variable_size: u64,
+}
+
+/// Information about UEFI variable storage space returned by
+/// [`RuntimeServices::query_capsule_capabilities`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CapsuleInfo {
+    /// The maximum size in bytes that [`RuntimeServices::update_capsule`]
+    /// can support as input. Note that the size of an update capsule is composed of
+    /// all [`CapsuleHeader`]s and [CapsuleBlockDescriptor]s.
+    pub maximum_capsule_size: u64,
+
+    /// The type of reset required for the capsule update.
+    pub reset_type: ResetType,
 }


### PR DESCRIPTION
This adds the ability to query whether an update capsule is supported by update_capsule or not.


## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
