### PR TITLE
memory map: improvements to fight pitfalls (MemoryMap now owns the memory)

### DIFF
--- a/uefi-services/README.md
+++ b/uefi-services/README.md
@@ -1,4 +1,4 @@
 # uefi-services
 
 WARNING: `uefi-services` is deprecated. Functionality was moved to
-`uefi::helpers::init` in `uefi` ´v0.28.0`.
+`uefi::helpers::init` in `uefi@v0.28.0`.

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -67,7 +67,7 @@ fn memory_map(bt: &BootServices) {
     let sizes = bt.memory_map_size();
 
     // 2 extra descriptors should be enough.
-    let buf_sz = sizes.map_size + 2 * sizes.entry_size;
+    let buf_sz = sizes.map_size + 2 * sizes.desc_size;
 
     // We will use vectors for convenience.
     let mut buffer = vec![0_u8; buf_sz];

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -63,36 +63,41 @@ fn alloc_alignment() {
 fn memory_map(bt: &BootServices) {
     info!("Testing memory map functions");
 
-    let mut memory_map = bt
-        .memory_map(MemoryType::LOADER_DATA)
-        .expect("Failed to retrieve UEFI memory map");
+    // Ensure that the memory map is freed after each iteration (on drop).
+    // Otherwise, we will have an OOM.
+    for _ in 0..200000 {
+        let mut memory_map = bt
+            .memory_map(MemoryType::LOADER_DATA)
+            .expect("Failed to retrieve UEFI memory map");
 
-    memory_map.sort();
+        memory_map.sort();
 
-    // Collect the descriptors into a vector
-    let descriptors = memory_map.entries().copied().collect::<Vec<_>>();
+        // Collect the descriptors into a vector
+        let descriptors = memory_map.entries().copied().collect::<Vec<_>>();
 
-    // Ensured we have at least one entry.
-    // Real memory maps usually have dozens of entries.
-    assert!(!descriptors.is_empty(), "Memory map is empty");
+        // Ensured we have at least one entry.
+        // Real memory maps usually have dozens of entries.
+        assert!(!descriptors.is_empty(), "Memory map is empty");
 
-    let mut curr_value = descriptors[0];
+        let mut curr_value = descriptors[0];
 
-    for value in descriptors.iter().skip(1) {
-        if value.phys_start <= curr_value.phys_start {
-            panic!("memory map sorting failed");
+        for value in descriptors.iter().skip(1) {
+            if value.phys_start <= curr_value.phys_start {
+                panic!("memory map sorting failed");
+            }
+            curr_value = *value;
         }
-        curr_value = *value;
-    }
 
-    // This is pretty much a sanity test to ensure returned memory isn't filled with random values.
-    let first_desc = descriptors[0];
+        // This is pretty much a basic sanity test to ensure returned memory
+        // isn't filled with random values.
+        let first_desc = descriptors[0];
 
-    #[cfg(target_arch = "x86_64")]
-    {
-        let phys_start = first_desc.phys_start;
-        assert_eq!(phys_start, 0, "Memory does not start at address 0");
+        #[cfg(target_arch = "x86_64")]
+        {
+            let phys_start = first_desc.phys_start;
+            assert_eq!(phys_start, 0, "Memory does not start at address 0");
+        }
+        let page_count = first_desc.page_count;
+        assert!(page_count != 0, "Memory map entry has size zero");
     }
-    let page_count = first_desc.page_count;
-    assert!(page_count != 0, "Memory map entry has zero size");
 }

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -63,17 +63,8 @@ fn alloc_alignment() {
 fn memory_map(bt: &BootServices) {
     info!("Testing memory map functions");
 
-    // Get the memory descriptor size and an estimate of the memory map size
-    let sizes = bt.memory_map_size();
-
-    // 2 extra descriptors should be enough.
-    let buf_sz = sizes.map_size + 2 * sizes.desc_size;
-
-    // We will use vectors for convenience.
-    let mut buffer = vec![0_u8; buf_sz];
-
     let mut memory_map = bt
-        .memory_map(&mut buffer)
+        .memory_map(MemoryType::LOADER_DATA)
         .expect("Failed to retrieve UEFI memory map");
 
     memory_map.sort();

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Added `ByteConversionError`.
 - Re-exported `CapsuleFlags`.
 - One can now specify in `TimeError` what fields of `Time` are outside its valid
-  range. `Time::is_valid` has been updated accordingly. 
+  range. `Time::is_valid` has been updated accordingly.
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's
@@ -24,6 +24,14 @@
 - `BootServices::allocate_pool` now returns `NonZero<u8>` instead of
   `*mut u8`.
 - `helpers::system_table` is deprecated, use `table::system_table_boot` instead.
+- `BootServices::memory_map` changed its signature from \
+  `pub fn memory_map<'buf>(&self, buffer: &'buf mut [u8]) -> Result<MemoryMap<'buf>> {` \
+  to \
+  `pub fn memory_map(&self, mt: MemoryType) -> Result<MemoryMap>`
+  - Allocations now happen automatically internally on the UEFI heap. Also, the
+    returned type is automatically freed on the UEFI heap, as long as boot
+    services are not excited. By removing the need for that explicit buffer and
+    the lifetime, the API is simpler.
 
 ## Removed
 - Removed the `panic-on-logger-errors` feature of the `uefi` crate. Logger

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Re-exported `CapsuleFlags`.
 - One can now specify in `TimeError` what fields of `Time` are outside its valid
   range. `Time::is_valid` has been updated accordingly.
+- `MemoryMap::as_raw` which provides raw access to the memory map. This is for
+  example useful if you create your own Multiboot2 bootloader that embeds the
+  EFI mmap in a Multiboot2 boot information structure.
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -48,7 +48,8 @@
 //!   the Rust standard library. For example, methods that return a
 //!   `Vec` rather than filling a statically-sized array. This requires
 //!   a global allocator; you can use the `global_allocator` feature or
-//!   provide your own.
+//!   provide your own. This is independent of internal direct usages of the
+//!   UEFI boot service allocator which may happen anyway, where necessary.
 //! - `global_allocator`: Set [`allocator::Allocator`] as the global Rust
 //!   allocator. This is a simple allocator that relies on the UEFI pool
 //!   allocator. You can choose to provide your own allocator instead of

--- a/uefi/src/mem.rs
+++ b/uefi/src/mem.rs
@@ -23,10 +23,14 @@ use {core::alloc::Allocator, core::ptr::NonNull};
 ///   success.
 ///
 /// # Feature `unstable` / `allocator_api`
-/// By default, this function works with Rust's default allocation mechanism. If you activate the
-/// `unstable`-feature, it uses the `allocator_api` instead. In that case, the function takes an
-/// additional parameter describing the specific [`Allocator`]. You can use [`alloc::alloc::Global`]
-/// as default.
+/// By default, this function works with the allocator that is set as
+/// `#[global_allocator]`. This might be UEFI allocator but depends on your
+/// use case and how you set up the environment.
+///
+/// If you activate the `unstable`-feature, all allocations uses the provided
+/// allocator (via `allocator_api`) instead. In that case, the function takes an
+/// additional parameter describing the specific [`Allocator`]. You can use
+/// [`alloc::alloc::Global`] which defaults to the `#[global_allocator]`.
 ///
 /// [`Allocator`]: https://doc.rust-lang.org/alloc/alloc/trait.Allocator.html
 /// [`alloc::alloc::Global`]: https://doc.rust-lang.org/alloc/alloc/struct.Global.html

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -224,6 +224,12 @@ impl BootServices {
     /// Stores the current UEFI memory map in an UEFI-heap allocated buffer
     /// and returns a [`MemoryMap`].
     ///
+    /// # Parameters
+    ///
+    /// - `mt`: The memory type for the backing memory on the UEFI heap.
+    ///   Usually, this is [`MemoryType::LOADER_DATA`]. You can also use a
+    ///   custom type.
+    ///
     /// # Errors
     ///
     /// See section `EFI_BOOT_SERVICES.GetMemoryMap()` in the UEFI Specification

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1729,6 +1729,12 @@ impl MemoryMapBackingMemory {
         self.0.as_ptr().cast()
     }
 
+    /// Returns a slice to the underlying memory.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { self.0.as_ref() }
+    }
+
     /// Returns a mutable slice to the underlying memory.
     #[must_use]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
@@ -1971,6 +1977,15 @@ impl MemoryMap {
         };
 
         Some(desc)
+    }
+
+    /// Provides access to the raw memory map.
+    ///
+    /// This is for example useful if you want to embed the memory map into
+    /// another data structure, such as a Multiboot2 boot information.
+    #[must_use]
+    pub fn as_raw(&self) -> (&[u8], MemoryMapMeta) {
+        (self.buf.as_slice(), self.meta)
     }
 }
 

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -216,8 +216,8 @@ impl BootServices {
     ///
     /// The buffer must be aligned like a `MemoryDescriptor`.
     ///
-    /// The returned key is a unique identifier of the current configuration of memory.
-    /// Any allocations or such will change the memory map's key.
+    /// The returned key is a unique identifier of the current configuration of
+    /// memory. Any allocations or such will change the memory map's key.
     ///
     /// If you want to store the resulting memory map without having to keep
     /// the buffer around, you can use `.copied().collect()` on the iterator.
@@ -1628,7 +1628,7 @@ pub struct MemoryMapSize {
 /// map, you manually have to call [`MemoryMap::sort`] first.
 ///
 /// ## UEFI pitfalls
-/// **Please note that when working with memory maps, the `entry_size` is
+/// **Please note** that when working with memory maps, the `entry_size` is
 /// usually larger than `size_of::<MemoryDescriptor` [[0]]. So to be safe,
 /// always use `entry_size` as step-size when interfacing with the memory map on
 /// a low level.


### PR DESCRIPTION
Follow-up of #1174 that improves the MemoryMap abstraction.

- rename `entry_size` -> `desc_size`
- better documentation
- unify usage of common constructor with sane assertions
- **removed lifetime/reference, type now owns the memory (which makes much more sense IMHO)**


This is an attempt to simplify the overall complex handling of obtaining the UEFI memory
map. We have the following pre-requisites and use-cases all to keep in mind when
designing the functions and associated helper types:
- the memory map itself needs memory; typically on the UEFI heap
- acquiring that memory and storing the memory map inside it are two distinct steps
- the memory map is not just a slice of [MemoryDescriptor] (desc_size is bigger than
  size_of)
- the required map size can be obtained by a call to a boot service function
- the needed memory might change due to hidden or asynchronous allocations
  between the allocation of a buffer and storing the memory map inside it
- when boot services are excited, best practise has shown (looking at linux code)
  that one should use the same buffer (with some extra capacity) and call
  exit_boot_services with that buffer at most two times in a loop

This makes it hard to come up with an ergonomic solution such as using a Box
or any other high-level Rust type.

The main simplification of my design is that the MemoryMap type now doesn't
has a reference to memory anymore but actually owns it. This also models the
real world use case where one typically obtains the memory map once when
boot services are exited. A &'static [u8] on the MemoryMap just creates more
confusion that it brings any benefit.

The MemoryMap now knows whether boot services are still active and frees
that memory, or it doesn't if the boot services are exited. This means
less fiddling with life-times and less cognitive overhead when
- reading the code
- calling BootService::memory_map independently of exit_boot_services

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
