### PR TITLE
uefi: BootServices::allocate_pool now returns NonZero<u8> instead of *mut u8

### DIFF
--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -121,7 +121,8 @@ fn test_install_protocol_interface(bt: &BootServices) {
             mem::size_of::<TestProtocol>(),
         )
         .unwrap()
-        .cast();
+        .cast()
+        .as_ptr();
     unsafe { alloc.write(TestProtocol { data: 123 }) };
 
     let _ = unsafe {
@@ -187,7 +188,8 @@ fn test_install_configuration_table(st: &SystemTable<Boot>) {
     let config = st
         .boot_services()
         .allocate_pool(MemoryType::ACPI_RECLAIM, 1)
-        .expect("Failed to allocate config table");
+        .expect("Failed to allocate config table")
+        .as_ptr();
     unsafe { config.write(42) };
 
     let count = st.config_table().len();

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -15,6 +15,8 @@
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's
   documentation for details of obligations for callers.
+- `BootServices::allocate_pool` now returns `NonZero<u8>` instead of
+  `*mut u8`.
 
 ## Removed
 - Removed the `panic-on-logger-errors` feature of the `uefi` crate. Logger

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -86,7 +86,7 @@ unsafe impl GlobalAlloc for Allocator {
             // within the allocation.
             let full_alloc_ptr =
                 if let Ok(ptr) = boot_services.allocate_pool(memory_type, size + align) {
-                    ptr
+                    ptr.as_ptr()
                 } else {
                     return ptr::null_mut();
                 };
@@ -116,6 +116,7 @@ unsafe impl GlobalAlloc for Allocator {
             // use `allocate_pool` directly.
             boot_services
                 .allocate_pool(memory_type, size)
+                .map(|ptr| ptr.as_ptr())
                 .unwrap_or(ptr::null_mut())
         }
     }

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -271,9 +271,13 @@ impl BootServices {
     ///
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
-    pub fn allocate_pool(&self, mem_ty: MemoryType, size: usize) -> Result<*mut u8> {
+    pub fn allocate_pool(&self, mem_ty: MemoryType, size: usize) -> Result<NonNull<u8>> {
         let mut buffer = ptr::null_mut();
-        unsafe { (self.0.allocate_pool)(mem_ty, size, &mut buffer) }.to_result_with_val(|| buffer)
+        let ptr = unsafe { (self.0.allocate_pool)(mem_ty, size, &mut buffer) }
+            .to_result_with_val(|| buffer)?;
+
+        Ok(NonNull::new(ptr)
+            .expect("UEFI should return error if an allocation failed but never a null pointer"))
     }
 
     /// Frees memory allocated from a pool.

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -265,7 +265,7 @@ impl SystemTable<Boot> {
         // Allocate a byte slice to hold the memory map. If the
         // allocation fails treat it as an unrecoverable error.
         let buf: *mut u8 = match boot_services.allocate_pool(memory_type, buf_size) {
-            Ok(buf) => buf,
+            Ok(buf) => buf.as_ptr(),
             Err(err) => reset(err.status()),
         };
 


### PR DESCRIPTION
This is safe as each null pointer (=failed allocation) is already returned as non-successful status code by UEFI.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
