### PR TITLE
Fix uefi-macros trybuild test

### DIFF
--- a/uefi-macros/tests/ui/fail/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/fail/entry_bad_return_type.stderr
@@ -4,5 +4,5 @@ error[E0308]: mismatched types
 8 | fn main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Status`, found `bool`
   |
-  = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> Status`
-             found fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool`
+  = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> Status`
+             found fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> bool`

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -271,6 +271,21 @@ impl Cargo {
             }
             CargoAction::Test => {
                 action = "test";
+
+                // Ensure that uefi-macros trybuild tests work regardless of
+                // whether RUSTFLAGS is set.
+                //
+                // The trybuild tests run `rustc` with `--verbose`, which
+                // affects error output. This flag is set via
+                // `--config=build.rustflags` [1], but that will be ignored if
+                // the RUSTFLAGS env var is set. Compensate by appending
+                // `--verbose` to the var in that case.
+                //
+                // [1]: https://github.com/dtolnay/trybuild/blob/b1b7064b7ad11e0ab563e9eb843651d86e4545b7/src/cargo.rs#L44
+                if let Ok(mut rustflags) = env::var("RUSTFLAGS") {
+                    rustflags.push_str(" --verbose");
+                    cmd.env("RUSTFLAGS", rustflags);
+                }
             }
         };
         cmd.arg(action);


### PR DESCRIPTION
A difference in behavior between CI and local testing was observed for the entry_bad_return_type test. This is due to the way trybuild sets the `--verbose` flag, which is overwritten if RUSTFLAGS is set (as it always is for our CI jobs). Add code in xtask to ensure that `--verbose` still gets set correctly.

Also update entry_bad_return_type.stderr to match the expected current output.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
