### PR TITLE
Fix versions

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,13 +1,13 @@
 # uefi-raw - [Unreleased]
 
+## Added
+- Added `ResetNotificationProtocol`.
+
 ## Changed
 - `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
 - `ResetType` now derives the `Default` trait.
 
 # uefi-raw - 0.5.2 (2024-04-19)
-
-## Added
-- Added `ResetNotificationProtocol`.
 
 ## Added
 - Added `TimestampProtocol`.

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `table::{set_system_table, system_table_boot, system_table_runtime}`.
   This provides an initial API for global tables that do not require passing
   around a reference.
+- Added `ResetNotification` protocol.
 - Added `TryFrom<&[u8]>` for `DevicePathHeader`, `DevicePathNode` and `DevicePath`.
 - Added `ByteConversionError`.
 - Re-exported `CapsuleFlags`.
@@ -32,7 +33,6 @@
 # uefi - 0.28.0 (2024-04-19)
 
 ## Added
-- Added `ResetNotification` protocol.
 - Added `Timestamp` protocol.
 - Added `UnalignedSlice::as_ptr`.
 - Added common derives for `Event` and `Handle`.


### PR DESCRIPTION
Depends on https://github.com/rust-osdev/uefi-rs/pull/1186

`uefi` 0.28 was released from commit https://github.com/rust-osdev/uefi-rs/commit/255359abeabaf26ab0c8dac2f889fa65bc38fc8e. The tree for that commit
doesn't contain `ResetNotificationProtocol`, even though the changelog
says it does. `ResetNotificationProtocol` was added in commit https://github.com/rust-osdev/uefi-rs/commit/04be50fe34f6f919aa647573d43c112363337091,
which was merged in commit `0c533bd` - both occurring after 0.28 was
released.

This commit fixes those issues, and bumps the unreleased crate versions
so that I can depend on them before this commit is released.
