### PR TITLE
test-runner: Consistently use global image handle

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -55,7 +55,7 @@ fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     boot::test(&st);
 
     // Test all the supported protocols.
-    proto::test(image, &mut st);
+    proto::test(&mut st);
 
     // TODO: runtime services work before boot services are exited, but we'd
     // probably want to test them after exit_boot_services. However,

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -3,7 +3,7 @@ use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
 use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams};
 
-pub unsafe fn test(image: Handle, bt: &BootServices) {
+pub unsafe fn test(bt: &BootServices) {
     info!("Running graphics output protocol test");
     let handle = bt
         .get_handle_for_protocol::<GraphicsOutput>()
@@ -12,7 +12,7 @@ pub unsafe fn test(image: Handle, bt: &BootServices) {
         .open_protocol::<GraphicsOutput>(
             OpenProtocolParams {
                 handle,
-                agent: image,
+                agent: bt.image_handle(),
                 controller: None,
             },
             // For this test, don't open in exclusive mode. That

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,6 +1,6 @@
 use uefi::prelude::*;
 
-pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
+pub fn test(st: &mut SystemTable<Boot>) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());
@@ -8,7 +8,7 @@ pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
     let bt = st.boot_services();
     unsafe {
         serial::test(bt);
-        gop::test(image, bt);
+        gop::test(bt);
     }
     pointer::test(bt);
 }

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -5,13 +5,13 @@ use uefi::proto::device_path::text::*;
 use uefi::proto::device_path::{DevicePath, LoadedImageDevicePath};
 use uefi::proto::loaded_image::LoadedImage;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running device path protocol test");
 
     // test 1/2: test low-level API by directly opening all protocols
     {
         let loaded_image = bt
-            .open_protocol_exclusive::<LoadedImage>(image)
+            .open_protocol_exclusive::<LoadedImage>(bt.image_handle())
             .expect("Failed to open LoadedImage protocol");
 
         let device_path = bt
@@ -55,7 +55,7 @@ pub fn test(image: Handle, bt: &BootServices) {
         // Get the `LoadedImageDevicePath`. Verify it start with the same nodes as
         // `device_path`.
         let loaded_image_device_path = bt
-            .open_protocol_exclusive::<LoadedImageDevicePath>(image)
+            .open_protocol_exclusive::<LoadedImageDevicePath>(bt.image_handle())
             .expect("Failed to open LoadedImageDevicePath protocol");
 
         for (n1, n2) in device_path
@@ -69,7 +69,7 @@ pub fn test(image: Handle, bt: &BootServices) {
     // test 2/2: test high-level to-string api
     {
         let loaded_image_device_path = bt
-            .open_protocol_exclusive::<LoadedImageDevicePath>(image)
+            .open_protocol_exclusive::<LoadedImageDevicePath>(bt.image_handle())
             .expect("Failed to open LoadedImageDevicePath protocol");
         let device_path: &DevicePath = &loaded_image_device_path;
 

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -1,11 +1,11 @@
 use uefi::prelude::*;
 use uefi::proto::loaded_image::LoadedImage;
 
-pub fn test(image: Handle, bt: &BootServices) {
+pub fn test(bt: &BootServices) {
     info!("Running loaded image protocol test");
 
     let loaded_image = bt
-        .open_protocol_exclusive::<LoadedImage>(image)
+        .open_protocol_exclusive::<LoadedImage>(bt.image_handle())
         .expect("Failed to open LoadedImage protocol");
 
     let load_options = loaded_image.load_options_as_bytes();

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -2,19 +2,19 @@ use uefi::prelude::*;
 use uefi::proto::loaded_image::LoadedImage;
 use uefi::{proto, Identify};
 
-pub fn test(image: Handle, st: &mut SystemTable<Boot>) {
+pub fn test(st: &mut SystemTable<Boot>) {
     info!("Testing various protocols");
 
-    console::test(image, st);
+    console::test(st);
 
     let bt = st.boot_services();
     find_protocol(bt);
-    test_protocols_per_handle(image, bt);
+    test_protocols_per_handle(bt);
 
     debug::test(bt);
-    device_path::test(image, bt);
+    device_path::test(bt);
     driver::test(bt);
-    loaded_image::test(image, bt);
+    loaded_image::test(bt);
     media::test(bt);
     network::test(bt);
     pi::test(bt);
@@ -44,9 +44,9 @@ fn find_protocol(bt: &BootServices) {
     );
 }
 
-fn test_protocols_per_handle(image: Handle, bt: &BootServices) {
+fn test_protocols_per_handle(bt: &BootServices) {
     let pph = bt
-        .protocols_per_handle(image)
+        .protocols_per_handle(bt.image_handle())
         .expect("Failed to get protocols for image handle");
 
     info!("Image handle has {} protocols", pph.len());


### PR DESCRIPTION
Rather than passing the image handle around in function args, just use the global image handle.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
