### PR TITLE
uefi: Stop enabling `error_in_core` feature

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -83,7 +83,6 @@
 //! [spec]: https://uefi.org/specifications
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
-#![cfg_attr(feature = "unstable", feature(error_in_core))]
 #![cfg_attr(all(feature = "unstable", feature = "alloc"), feature(allocator_api))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]


### PR DESCRIPTION
This should fix the CI errors.

This feature has been stabilized in latest nightly, so no need to enable it. All the uses of it (`impl core::error::Error for for ...`) are still gated by the `unstable` feature, so there's no change for users on the stable channel.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
