### PR TITLE
uefi: Add TryFrom u8 slice to DevicePathNode

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added `table::{set_system_table, system_table_boot, system_table_runtime}`.
   This provides an initial API for global tables that do not require passing
   around a reference.
-- Added `TryFrom<&[u8]>` for `DevicePathHeader`.
+- Added `TryFrom<&[u8]>` for `DevicePathHeader` and `DevicePathNode`.
 - Added `ByteConversionError`.
 
 ## Changed


### PR DESCRIPTION
Adds the capability to convert a byte slice to a DevicePathNode. This will be used to convert a byte slice to a DevicePath in a followup PR, which allows easier interaction with the data returned from UEFI variable services.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
