### PR TITLE
uefi: Add TryFrom u8 slice to DevicePathHeader 

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added `table::{set_system_table, system_table_boot, system_table_runtime}`.
   This provides an initial API for global tables that do not require passing
   around a reference.
+- Added `TryFrom<&[u8]>` for `DevicePathHeader`.
+- Added `ByteConversionError`.
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -119,6 +119,19 @@ pub struct DevicePathHeader {
     pub length: u16,
 }
 
+impl<'a> TryFrom<&[u8]> for &'a DevicePathHeader {
+    type Error = ByteConversionError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if mem::size_of::<DevicePathHeader>() <= bytes.len() {
+            unsafe {
+                return Ok(&*bytes.as_ptr().cast::<DevicePathHeader>());
+            }
+        }
+        Err(ByteConversionError::InvalidLength)
+    }
+}
+
 /// A single node within a [`DevicePath`].
 ///
 /// Each node starts with a [`DevicePathHeader`]. The rest of the data
@@ -727,6 +740,14 @@ impl DeviceSubType {
     pub const END_INSTANCE: DeviceSubType = DeviceSubType(0x01);
     /// End entire Device Path.
     pub const END_ENTIRE: DeviceSubType = DeviceSubType(0xff);
+}
+
+/// Error returned when attempting to convert from a `&[u8]` to a
+/// [`DevicePath`] type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ByteConversionError {
+    /// The length of the given slice is not valid for its [`DevicePath`] type.
+    InvalidLength,
 }
 
 /// Error returned when converting from a [`DevicePathNode`] to a more


### PR DESCRIPTION
Allows for making a `DevicePathHeader` from a byte splice, used primarily to verify whether the byte splice can also contain `DevicePathHeader.length` bytes.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
