### PR TITLE
uefi: re-export CapsuleFlags

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -13,6 +13,7 @@
   around a reference.
 - Added `TryFrom<&[u8]>` for `DevicePathHeader`, `DevicePathNode` and `DevicePath`.
 - Added `ByteConversionError`.
+- Re-exported `CapsuleFlags`.
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -7,7 +7,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::mem::MaybeUninit;
 use core::ptr;
 
-pub use uefi_raw::capsule::{CapsuleBlockDescriptor, CapsuleHeader};
+pub use uefi_raw::capsule::{CapsuleBlockDescriptor, CapsuleFlags, CapsuleHeader};
 pub use uefi_raw::table::runtime::{
     ResetType, TimeCapabilities, VariableAttributes, VariableVendor,
 };


### PR DESCRIPTION
Users of the UpdateCapsule runtime service need to create a `CapsuleFlags` to create a `CapsuleHeader`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
