### PR TITLE
ci: Temporarily turn off warnings-as-errors for nightly CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,6 +123,11 @@ jobs:
   build_feature_permutations:
     name: Build (feature permutations)
     runs-on: ubuntu-latest
+    env:
+      # TODO: temporarily allow warnings to not be errors on nightly due to
+      # incorrect dead_code lint.
+      # https://github.com/rust-osdev/uefi-rs/issues/1205
+      RUSTFLAGS: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -134,6 +139,11 @@ jobs:
   nightly_channel:
     name: Build (nightly + unstable feature)
     runs-on: ubuntu-latest
+    env:
+      # TODO: temporarily allow warnings to not be errors on nightly due to
+      # incorrect dead_code lint.
+      # https://github.com/rust-osdev/uefi-rs/issues/1205
+      RUSTFLAGS: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The dead_code lint on nightly is currently incorrectly flagging a lot of structs as unused.

https://github.com/rust-osdev/uefi-rs/issues/1205

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
