### PR TITLE
uefi: Add TryFrom<&[u8]> for Time

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -20,7 +20,8 @@
 - `MemoryMap::as_raw` which provides raw access to the memory map. This is for
   example useful if you create your own Multiboot2 bootloader that embeds the
   EFI mmap in a Multiboot2 boot information structure.
-- `Mode` is now `Copy` and `Clone`
+- `Mode` is now `Copy` and `Clone`.
+- Added `TryFrom<&[u8]>` for `Time`. 
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's


### PR DESCRIPTION
I am implementing a UEFI application which needs to convert part of a byte splice (returned by the variable runtime service) into a `Time`. I wanted to see if it was worth upstreaming, in case others might also need of it.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
