### PR TITLE
template: fix build failure

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.28.0", features = ["alloc"] }
+uefi = { version = "0.28.0", features = ["panic_handler"] }


### PR DESCRIPTION
The template failed to build when built with cmds below:
```bash
cd template
cargo build --target x86_64-unknown-uefi
```

We'll get error:
```bash
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait

error: `#[panic_handler]` function required, but not found

error: could not compile `uefi_app` (bin "uefi_app") due to 2 previous errors
```

As the Rust UEFI Book shown, the template succeeds to build with uefi-rs feature `panic_handler` enabled. 