### PR TITLE
release: uefi-macros-0.14.0, uefi-raw-0.6.0, uefi-0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.6.0",
  "ptr_meta",

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -24,7 +24,7 @@ to your `Cargo.toml`. The resulting `Cargo.toml` should look like that:
 ```toml
 [dependencies]
 log = "0.4.21"
-uefi = { version = "0.28.0", features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.29.0", features = [ "panic_handler", "logger" ] }
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.28.0", features = ["panic_handler"] }
+uefi = { version = "0.29.0", features = ["panic_handler"] }

--- a/uefi-macros/CHANGELOG.md
+++ b/uefi-macros/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi-macros - [Unreleased]
 
+
+# uefi-macros - 0.14.0 (2024-07-02)
+
 ## Changed
 - The `entry` macro now sets the global system table pointer with `uefi::set_system_table`.
 

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-macros"
-version = "0.13.0"
+version = "0.14.0"
 readme = "README.md"
 description = "Procedural macros for the `uefi` crate."
 

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi-raw - [Unreleased]
 
+
+# uefi-raw - 0.6.0 (2024-07-02)
+
 ## Added
 - Added `ResetNotificationProtocol`.
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.5.2"
+version = "0.6.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+
+# uefi - 0.29.0 (2024-07-02)
+
 ## Added
 - Added `RuntimeServices::update_capsule`.
 - Added `RuntimeServices::query_capsule_capabilities`.
@@ -21,7 +24,7 @@
   example useful if you create your own Multiboot2 bootloader that embeds the
   EFI mmap in a Multiboot2 boot information structure.
 - `Mode` is now `Copy` and `Clone`.
-- Added `TryFrom<&[u8]>` for `Time`. 
+- Added `TryFrom<&[u8]>` for `Time`.
 
 ## Changed
 - `SystemTable::exit_boot_services` is now `unsafe`. See that method's

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.28.0"
+version = "0.29.0"
 readme = "README.md"
 description = "Safe and easy-to-use wrapper for building UEFI apps."
 
@@ -25,7 +25,7 @@ global_allocator = []
 panic_handler = []
 # Some convenience when running inside QEMU.
 # - dependency log-debugcon: logical, not technical
-# - dependency panic_handler: logical, not technical 
+# - dependency panic_handler: logical, not technical
 qemu = ["dep:qemu-exit", "panic_handler", "log-debugcon"]
 # Whether the internal logger from the helpers module should also log to
 # the debugcon device (QEMU) and debug-console (cloud-hypervisor). Only works
@@ -39,8 +39,8 @@ ptr_meta.workspace = true
 uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
-uefi-macros = "0.13.0"
-uefi-raw = "0.5.2"
+uefi-macros = "0.14.0"
+uefi-raw = "0.6.0"
 qemu-exit = { version = "3.0.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Last release was in April, we've accumulated a good number of changes since then.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
