### PR TITLE
book: Publish the latest release instead of main

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,6 +2,7 @@ name: Book
 on:
   push:
     branches: [main]
+    tags: ['*']
 permissions:
   contents: write
 # Adapted from:
@@ -21,24 +22,32 @@ jobs:
           echo `pwd`/mdbook >> $GITHUB_PATH
       - name: Deploy GitHub Pages
         run: |
-          cd book
-          mdbook build
-          git worktree add gh-pages gh-pages
+          # Configure git user so that `git commit` works.
           git config user.name "Deploy from CI"
           git config user.email ""
-          cd gh-pages
+
+          # Get the highest `uefi` release tag.
+          highest_tag="$(git tag --list | grep uefi-v | sort -V | tail -1)"
+
+          # Create a worktree for the tag.
+          git worktree add wt-tag refs/tags/"${highest_tag}"
+
+          # Create a worktree for the `gh-pages` branch.
+          git worktree add wt-gh-pages gh-pages
+
           # Delete the ref to avoid keeping history.
-          git update-ref -d refs/heads/gh-pages
-          # Place the book under a "HEAD" directory so that we can later
-          # add other versions (e.g. "stable" or "v0.17") without breaking
-          # URLs.
-          rm -rf HEAD
-          mv ../book HEAD
-          git add HEAD
-          # Add an index in the root to redirect to HEAD. If we eventually
-          # serve multiple versions, this can be changed to a real index.
-          cp ../head_redirect.html index.html
-          git add index.html
+          git -C wt-gh-pages update-ref -d refs/heads/gh-pages
+
+          # Build the book for the tag. Don't use `--dest-dir` because it will
+          # delete the destination directory including the worktree checkout's
+          # ".git".
+          mdbook build wt-tag/book
+          # Copy output to the destination directory. Note the "/." is needed at
+          # the end of the source path so that hidden files are included.
+          cp -r wt-tag/book/book/. wt-gh-pages
+
           # Commit and push.
+          cd wt-gh-pages
+          git add .
           git commit -m "Deploy $GITHUB_SHA to gh-pages"
           git push --force

--- a/book/head_redirect.html
+++ b/book/head_redirect.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<head>
-<meta charset="utf-8">
-<title>Redirecting to latest documentation</title>
-<meta http-equiv="refresh" content="5; URL=HEAD">
-</head>
-
-Redirecting to <a href="HEAD">./HEAD</a>...


### PR DESCRIPTION
For https://github.com/rust-osdev/uefi-rs/issues/1222

* The book job now triggers on tag pushes in addition to pushes to `main`
* The job builds the book from the highest release tag instead of `main`
* The book output is added to the root of the `gh-pages` branch rather than a subdirectory
* Removed the now-unused redirect-to-HEAD html file

Did some testing in a fork to make sure the changes work as expected.

Note that the old `HEAD` folder will still be present on the `gh-pages` branch after running this, so it won't immediately break any links.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
