### PR TITLE
Drop SystemTable arg from uefi::helpers::init

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -4,8 +4,8 @@
 use uefi::prelude::*;
 
 #[entry]
-fn main(_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
-    uefi::helpers::init(&mut system_table).unwrap();
+fn main(_handle: Handle, system_table: SystemTable<Boot>) -> Status {
+    uefi::helpers::init().unwrap();
 
     Status::SUCCESS
 }

--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -11,10 +11,10 @@ use uefi::prelude::*;
 
 // ANCHOR: entry
 #[entry]
-fn main(_image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
+fn main(_image_handle: Handle, system_table: SystemTable<Boot>) -> Status {
     // ANCHOR_END: entry
     // ANCHOR: services
-    uefi::helpers::init(&mut system_table).unwrap();
+    uefi::helpers::init().unwrap();
     // ANCHOR_END: services
     // ANCHOR: log
     info!("Hello world!");

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -13,8 +13,8 @@ use uefi::{Identify, Result};
 
 // ANCHOR: main
 #[entry]
-fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
-    uefi::helpers::init(&mut system_table).unwrap();
+fn main(image_handle: Handle, system_table: SystemTable<Boot>) -> Status {
+    uefi::helpers::init().unwrap();
     let boot_services = system_table.boot_services();
 
     print_image_path(boot_services).unwrap();

--- a/uefi-test-runner/examples/shell_params.rs
+++ b/uefi-test-runner/examples/shell_params.rs
@@ -17,10 +17,10 @@ use alloc::vec::Vec;
 
 // ANCHOR: entry
 #[entry]
-fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
+fn main(image_handle: Handle, system_table: SystemTable<Boot>) -> Status {
     // ANCHOR_END: entry
     // ANCHOR: services
-    uefi::helpers::init(&mut system_table).unwrap();
+    uefi::helpers::init().unwrap();
     let boot_services = system_table.boot_services();
     // ANCHOR_END: services
 

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -144,8 +144,8 @@ fn draw_sierpinski(bt: &BootServices) -> Result {
 }
 
 #[entry]
-fn main(_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
-    uefi::helpers::init(&mut system_table).unwrap();
+fn main(_handle: Handle, system_table: SystemTable<Boot>) -> Status {
+    uefi::helpers::init().unwrap();
     let bt = system_table.boot_services();
     draw_sierpinski(bt).unwrap();
     Status::SUCCESS

--- a/uefi-test-runner/examples/timestamp.rs
+++ b/uefi-test-runner/examples/timestamp.rs
@@ -16,10 +16,10 @@ use uefi::proto::misc::Timestamp;
 
 // ANCHOR: entry
 #[entry]
-fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
+fn main(image_handle: Handle, system_table: SystemTable<Boot>) -> Status {
     // ANCHOR_END: entry
     // ANCHOR: services
-    uefi::helpers::init(&mut system_table).unwrap();
+    uefi::helpers::init().unwrap();
     let boot_services = system_table.boot_services();
     // ANCHOR_END: services
 

--- a/uefi-test-runner/src/bin/shell_launcher.rs
+++ b/uefi-test-runner/src/bin/shell_launcher.rs
@@ -45,8 +45,8 @@ fn get_shell_app_device_path<'a>(
 }
 
 #[entry]
-fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
-    uefi::helpers::init(&mut st).unwrap();
+fn efi_main(image: Handle, st: SystemTable<Boot>) -> Status {
+    uefi::helpers::init().unwrap();
     let boot_services = st.boot_services();
 
     let mut storage = Vec::new();

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -23,7 +23,7 @@ mod runtime;
 #[entry]
 fn efi_main(image: Handle, mut st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
-    uefi::helpers::init(&mut st).expect("Failed to initialize utilities");
+    uefi::helpers::init().expect("Failed to initialize utilities");
 
     // unit tests here
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+## Changed
+- **Breaking:** `uefi::helpers::init` no longer takes an argument.
+
 
 # uefi - 0.29.0 (2024-07-02)
 

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -54,18 +54,19 @@ pub fn system_table() -> SystemTable<Boot> {
 /// **PLEASE NOTE** that these helpers are meant for the pre exit boot service
 /// epoch. Limited functionality might work after exiting them, such as logging
 /// to the debugcon device.
-#[allow(unused_variables)] // `st` is unused if logger and allocator are disabled
-pub fn init(st: &mut SystemTable<Boot>) -> Result<()> {
+pub fn init() -> Result<()> {
     // Setup logging and memory allocation
 
     #[cfg(feature = "logger")]
     unsafe {
-        logger::init(st);
+        let mut st = table::system_table_boot().expect("boot services are not active");
+        logger::init(&mut st);
     }
 
     #[cfg(feature = "global_allocator")]
     unsafe {
-        crate::allocator::init(st);
+        let mut st = table::system_table_boot().expect("boot services are not active");
+        crate::allocator::init(&mut st);
     }
 
     Ok(())


### PR DESCRIPTION
Use the global system table pointer instead.

Cleanup for https://github.com/rust-osdev/uefi-rs/issues/893

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
