### PR TITLE
uefi-macros: Allow zero-param function in the entry macro

### DIFF
--- a/uefi-macros/CHANGELOG.md
+++ b/uefi-macros/CHANGELOG.md
@@ -1,5 +1,10 @@
 # uefi-macros - [Unreleased]
 
+## Changed
+
+- The `entry` macro now accepts a function with zero arguments in addition to
+  the two-argument form.
+
 
 # uefi-macros - 0.14.0 (2024-07-02)
 

--- a/uefi-macros/tests/ui/pass/entry_no_args.rs
+++ b/uefi-macros/tests/ui/pass/entry_no_args.rs
@@ -1,0 +1,9 @@
+use uefi::{entry, Status};
+
+#[entry]
+fn efi_main() -> Status {
+    Status::SUCCESS
+}
+
+// trybuild requires a `main` function.
+fn main() {}


### PR DESCRIPTION
For https://github.com/rust-osdev/uefi-rs/issues/893

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
