### PR TITLE
uefi: Fix return value lifetime for register_protocol_notify

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changed
 - **Breaking:** `uefi::helpers::init` no longer takes an argument.
+- The lifetime of the `SearchType` returned from
+  `BootServices::register_protocol_notify` is now tied to the protocol GUID.
 
 
 # uefi - 0.29.0 (2024-07-02)

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -683,11 +683,11 @@ impl BootServices {
     ///
     /// * [`uefi::Status::OUT_OF_RESOURCES`]
     /// * [`uefi::Status::INVALID_PARAMETER`]
-    pub fn register_protocol_notify(
+    pub fn register_protocol_notify<'guid>(
         &self,
-        protocol: &Guid,
+        protocol: &'guid Guid,
         event: Event,
-    ) -> Result<(Event, SearchType)> {
+    ) -> Result<(Event, SearchType<'guid>)> {
         let mut key = ptr::null();
         // Safety: we clone `event` a couple times, but there will be only one left once we return.
         unsafe { (self.0.register_protocol_notify)(protocol, event.as_ptr(), &mut key) }


### PR DESCRIPTION
Due to the rules of lifetime elision
(https://doc.rust-lang.org/reference/lifetime-elision.html), the lifetime of the `SearchType` returned from `register_protocol_notify` was infered to be the lifetime of `Self`. The correct lifetime is the `protocol` reference.

In practice this isn't likely to matter much to users, but I noticed it due to a compilation error when working on https://github.com/rust-osdev/uefi-rs/issues/893

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
