### PR TITLE
mem: introduce traits MemoryMap and MemoryMapMut

### DIFF
--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -1,4 +1,4 @@
-use uefi::table::boot::{AllocateType, BootServices, MemoryType};
+use uefi::table::boot::{AllocateType, BootServices, MemoryMap, MemoryMapMut, MemoryType};
 
 use alloc::vec::Vec;
 

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -12,7 +12,7 @@ use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
 use uefi::proto::device_path::build::{self, DevicePathBuilder};
 use uefi::proto::device_path::messaging::Vendor;
-use uefi::table::boot::MemoryType;
+use uefi::table::boot::{MemoryMap, MemoryType};
 use uefi::{print, println, Result};
 
 mod boot;

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -4,6 +4,11 @@
 - **Breaking:** `uefi::helpers::init` no longer takes an argument.
 - The lifetime of the `SearchType` returned from
   `BootServices::register_protocol_notify` is now tied to the protocol GUID.
+- The traits `MemoryMap` and `MemoryMapMut` have been introduced together with
+  the implementations `MemoryMapRef`, `MemoryMapRefMut`, and `MemoryMapOwned`.
+  The old `MemoryMap` was renamed to `MemoryMapOwned`.
+  - `pub fn memory_map(&self, mt: MemoryType) -> Result<MemoryMap>` now returns
+     a `MemoryMapOwned`.
 
 
 # uefi - 0.29.0 (2024-07-02)

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1921,6 +1921,14 @@ impl<'a> MemoryMap for MemoryMapRef<'a> {
     }
 }
 
+impl Index<usize> for MemoryMapRef<'_> {
+    type Output = MemoryDescriptor;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
 /// Implementation of [`MemoryMapMut`] for the given buffer.
 #[derive(Debug)]
 pub struct MemoryMapRefMut<'a> {
@@ -2031,6 +2039,20 @@ impl<'a> MemoryMapRefMut<'a> {
     }
 }
 
+impl Index<usize> for MemoryMapRefMut<'_> {
+    type Output = MemoryDescriptor;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+impl IndexMut<usize> for MemoryMapRefMut<'_> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
+    }
+}
+
 /// Implementation of [`MemoryMapMut`] that owns the buffer on the UEFI heap.
 #[derive(Debug)]
 pub struct MemoryMapOwned {
@@ -2108,6 +2130,20 @@ impl MemoryMapMut for MemoryMapOwned {
 
     unsafe fn buffer_mut(&mut self) -> &mut [u8] {
         self.buf.as_mut_slice()
+    }
+}
+
+impl Index<usize> for MemoryMapOwned {
+    type Output = MemoryDescriptor;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+impl IndexMut<usize> for MemoryMapOwned {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
     }
 }
 
@@ -2355,7 +2391,10 @@ mod tests_mmap_artificial {
         let mut mem_map = buffer_to_map(&mut buffer);
 
         for index in 0..3 {
-            assert_eq!(mem_map.get(index), BUFFER.get(index))
+            assert_eq!(mem_map.get(index), BUFFER.get(index));
+
+            // Test Index impl
+            assert_eq!(Some(&mem_map[index]), BUFFER.get(index));
         }
 
         let mut_desc = mem_map.get_mut(2).unwrap();

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1793,15 +1793,22 @@ impl MemoryMapMeta {
     }
 }
 
-/// An accessory to the UEFI memory map that can be either iterated or indexed
-/// like an array.
+/// An accessory to the UEFI memory map and associated metadata that can be
+/// either iterated or indexed like an array.
 ///
 /// A [`MemoryMap`] is always associated with the unique [`MemoryMapKey`]
-/// bundled with the ma.
+/// bundled with the map.
 ///
 /// To iterate over the entries, call [`MemoryMap::entries`].
 ///
 /// ## UEFI pitfalls
+/// Note that a MemoryMap can quickly become outdated, as soon as any explicit
+/// or hidden allocation happens.
+///
+/// As soon as boot services are excited, all previous obtained memory maps must
+/// be considered as outdated, except if the [`MemoryMapKey`] equals the one
+/// returned by `exit_boot_services()`.
+///
 /// **Please note** that when working with memory maps, the `entry_size` is
 /// usually larger than `size_of::<MemoryDescriptor` [[0]]. So to be safe,
 /// always use `entry_size` as step-size when interfacing with the memory map on
@@ -2455,7 +2462,7 @@ mod tests_mmap_real {
         7, 1048576, 0, 1792, 15, 0, 10, 8388608, 0, 8, 15, 0, 7, 8421376, 0, 3, 15, 0, 10, 8433664,
         0, 1, 15, 0, 7, 8437760, 0, 4, 15, 0, 10, 8454144, 0, 240, 15, 0,
     ];
-    
+
     #[test]
     fn basic_functionality() {
         let mut buf = MMAP_RAW;

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -11,7 +11,7 @@ use crate::{Char16, Error, Event, Guid, Handle, Result, Status, StatusExt};
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::mem::{self, MaybeUninit};
-use core::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicPtr, Ordering};
 use core::{ptr, slice};
@@ -1802,6 +1802,101 @@ impl MemoryMapMeta {
         const ONE_GB: usize = 1024 * 1024 * 1024;
         assert!(self.map_size <= ONE_GB);
     }
+}
+
+/// An accessory to the UEFI memory map that can be either iterated or indexed
+/// like an array.
+///
+/// A [`MemoryMap`] is always associated with the unique [`MemoryMapKey`]
+/// bundled with the ma.
+///
+/// To iterate over the entries, call [`MemoryMap::entries`].
+///
+/// ## UEFI pitfalls
+/// **Please note** that when working with memory maps, the `entry_size` is
+/// usually larger than `size_of::<MemoryDescriptor` [[0]]. So to be safe,
+/// always use `entry_size` as step-size when interfacing with the memory map on
+/// a low level.
+///
+/// [0]: https://github.com/tianocore/edk2/blob/7142e648416ff5d3eac6c6d607874805f5de0ca8/MdeModulePkg/Core/PiSmmCore/Page.c#L1059
+pub trait MemoryMap: Index<usize, Output = MemoryDescriptor> {
+    // TODO also require IntoIterator?! :)
+
+    /// Returns the associated [`MemoryMapMeta`].
+    #[must_use]
+    fn meta(&self) -> MemoryMapMeta;
+
+    /// Returns the associated [`MemoryMapKey`].
+    #[must_use]
+    fn key(&self) -> MemoryMapKey;
+
+    /// Returns the number of keys in the map.
+    #[must_use]
+    fn len(&self) -> usize;
+
+    /// Returns if the memory map is empty.
+    #[must_use]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a reference to the [`MemoryDescriptor`] at the given index, if
+    /// present.
+    #[must_use]
+    fn get(&self, index: usize) -> Option<&MemoryDescriptor> {
+        if index >= self.len() {
+            None
+        } else {
+            let offset = index * self.meta().desc_size;
+            unsafe {
+                self.buffer()
+                    .as_ptr()
+                    .add(offset)
+                    .cast::<MemoryDescriptor>()
+                    .as_ref()
+            }
+        }
+    }
+
+    /// Returns a reference to the underlying memory.
+    fn buffer(&self) -> &[u8];
+
+    /// Returns an Iterator of type [`MemoryMapIter`].
+    fn entries(&self) -> MemoryMapIter<'_>;
+}
+
+/// Extension to [`MemoryMap`] that adds mutable operations. This also includes
+/// the ability to sort the memory map.
+pub trait MemoryMapMut: MemoryMap + IndexMut<usize> {
+    /// Returns a mutable reference to the [`MemoryDescriptor`] at the given
+    /// index, if present.
+    #[must_use]
+    fn get_mut(&mut self, index: usize) -> Option<&mut MemoryDescriptor> {
+        if index >= self.len() {
+            None
+        } else {
+            let offset = index * self.meta().desc_size;
+            unsafe {
+                self.buffer_mut()
+                    .as_mut_ptr()
+                    .add(offset)
+                    .cast::<MemoryDescriptor>()
+                    .as_mut()
+            }
+        }
+    }
+
+    /// Sorts the memory map by physical address in place. This operation is
+    /// optional and should be invoked only once.
+    #[must_use]
+    fn sort(&mut self);
+
+    /// Returns a reference to the underlying memory.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe as there is a potential to create invalid entries.
+    unsafe fn buffer_mut(&self) -> &mut [u8];
 }
 
 /// An accessory to the memory map that can be either iterated or

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -2455,7 +2455,7 @@ mod tests_mmap_real {
         7, 1048576, 0, 1792, 15, 0, 10, 8388608, 0, 8, 15, 0, 7, 8421376, 0, 3, 15, 0, 10, 8433664,
         0, 1, 15, 0, 7, 8437760, 0, 4, 15, 0, 10, 8454144, 0, 240, 15, 0,
     ];
-    extern crate std;
+    
     #[test]
     fn basic_functionality() {
         let mut buf = MMAP_RAW;

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -7,7 +7,7 @@ use uefi::table::boot::{MemoryMapBackingMemory, MemoryMapMeta};
 use crate::proto::console::text;
 use crate::{CStr16, Result, Status, StatusExt};
 
-use super::boot::{BootServices, MemoryDescriptor, MemoryMap, MemoryType};
+use super::boot::{BootServices, MemoryDescriptor, MemoryMapOwned, MemoryType};
 use super::runtime::{ResetType, RuntimeServices};
 use super::{cfg, Revision};
 
@@ -230,7 +230,7 @@ impl SystemTable<Boot> {
     pub unsafe fn exit_boot_services(
         self,
         memory_type: MemoryType,
-    ) -> (SystemTable<Runtime>, MemoryMap) {
+    ) -> (SystemTable<Runtime>, MemoryMapOwned) {
         crate::helpers::exit();
 
         // Reboot the device.
@@ -255,7 +255,7 @@ impl SystemTable<Boot> {
                         table: self.table,
                         _marker: PhantomData,
                     };
-                    return (st, MemoryMap::from_initialized_mem(buf, memory_map));
+                    return (st, MemoryMapOwned::from_initialized_mem(buf, memory_map));
                 }
                 Err(err) => {
                     log::error!("Error retrieving the memory map for exiting the boot services");


### PR DESCRIPTION
In #1175 we lost the flexibility to use the memory map on any buffer. However, if you write a kernel and get the raw memory map from your bootloader, one has to parse the memory map from this raw memory. To solve this (leveraging the `uefi` crate), I introduced: 
- the traits `MemoryMap` and `MemoryMapMut`, where `MemoryMapMut` extends `MemoryMap`
- the types `MemoryMapRef`, `MemoryMapRefMut`, and `MemoryMapOwned`, where the latter two implement `MemoryMapMut` 

This helps to have a common API for all these use-cases. However, there are the
following open questions:

- There is still code repetition. Especially for the implementations of `Index` and `IndexMut` which I have to provide 3 times. Any idea for improvement? Just use a macro?
- I didn't manage to make the traits directly dependent on `Index` and `IndexMut` - I gave up after many compiler warnings.
- What do you think about this in general?

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
