### PR TITLE
Add PcrEvent::new_in_box/PcrEventInputs::new_in_box

### DIFF
--- a/uefi-test-runner/src/proto/tcg.rs
+++ b/uefi-test-runner/src/proto/tcg.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use core::mem::MaybeUninit;
 use uefi::proto::tcg::{v1, v2, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
 use uefi::table::boot::BootServices;
 
@@ -63,7 +62,7 @@ fn test_tcg_v1(bt: &BootServices) {
 
     let pcr_index = PcrIndex(8);
 
-    let mut event_buf = [MaybeUninit::uninit(); 256];
+    let mut event_buf = [0; 256];
     let event = v1::PcrEvent::new_in_buffer(
         &mut event_buf,
         pcr_index,
@@ -279,7 +278,7 @@ pub fn test_tcg_v2(bt: &BootServices) {
 
     // Create a PCR event.
     let pcr_index = PcrIndex(8);
-    let mut event_buf = [MaybeUninit::uninit(); 256];
+    let mut event_buf = [0; 256];
     let event_data = [0x12, 0x13, 0x14, 0x15];
     let data_to_hash = b"some-data";
     let event =

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -4,6 +4,8 @@
 - `uefi::system` is a new module that provides freestanding functions for
   accessing fields of the global system table.
 - Add standard derives for `ConfigTableEntry`.
+- `PcrEvent`/`PcrEventInputs` impl `Align`, `Eq`, and `PartialEq`.
+- Added `PcrEvent::new_in_box` and `PcrEventInputs::new_in_box`.
 
 ## Changed
 - **Breaking:** `uefi::helpers::init` no longer takes an argument.
@@ -14,6 +16,9 @@
   The old `MemoryMap` was renamed to `MemoryMapOwned`.
   - `pub fn memory_map(&self, mt: MemoryType) -> Result<MemoryMap>` now returns
      a `MemoryMapOwned`.
+- **Breaking:** `PcrEvent::new_in_buffer` and `PcrEventInputs::new_in_buffer`
+  now take an initialized buffer (`[u8`] instead of `[MaybeUninit<u8>]`), and if
+  the buffer is too small the required size is returned in the error data.
 
 
 # uefi - 0.29.0 (2024-07-02)

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -9,7 +9,7 @@
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
 use super::{AlgorithmId, EventType, HashAlgorithm, PcrIndex};
-use crate::data_types::PhysicalAddress;
+use crate::data_types::{Align, PhysicalAddress};
 use crate::polyfill::maybe_uninit_slice_as_mut_ptr;
 use crate::proto::unsafe_protocol;
 use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
@@ -197,6 +197,12 @@ impl PcrEvent {
     #[must_use]
     pub fn digest(&self) -> Sha1Digest {
         self.digest
+    }
+}
+
+impl Align for PcrEvent {
+    fn alignment() -> usize {
+        1
     }
 }
 

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -157,7 +157,7 @@ struct EventHeader {
 /// `TCG_PCR_EVENT2` for reading events. To help clarify the usage, our
 /// API renames these types to `PcrEventInputs` and `PcrEvent`,
 /// respectively.
-#[derive(Pointee)]
+#[derive(Eq, Pointee)]
 #[repr(C, packed)]
 pub struct PcrEventInputs {
     size: u32,
@@ -225,6 +225,15 @@ impl Debug for PcrEventInputs {
             .field("event_header", &self.event_header)
             .field("event", &"<binary data>")
             .finish()
+    }
+}
+
+// Manual `PartialEq` implementation since it can't be derived for a packed DST.
+impl PartialEq for PcrEventInputs {
+    fn eq(&self, other: &PcrEventInputs) -> bool {
+        self.size == other.size
+            && self.event_header == other.event_header
+            && self.event == other.event
     }
 }
 

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -18,7 +18,6 @@ use crate::{Error, Result, Status, StatusExt};
 use bitflags::bitflags;
 use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
-use core::mem::MaybeUninit;
 use core::{mem, ptr, slice};
 use ptr_meta::{Pointee, PtrExt};
 
@@ -177,7 +176,7 @@ impl PcrEventInputs {
     /// Returns [`Status::INVALID_PARAMETER`] if the `event_data` size is too
     /// large.
     pub fn new_in_buffer<'buf>(
-        buffer: &'buf mut [MaybeUninit<u8>],
+        buffer: &'buf mut [u8],
         pcr_index: PcrIndex,
         event_type: EventType,
         event_data: &[u8],
@@ -791,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_new_event() {
-        let mut buf = [MaybeUninit::uninit(); 22];
+        let mut buf = [0; 22];
         let event_data = [0x12, 0x13, 0x14, 0x15];
         let event =
             PcrEventInputs::new_in_buffer(&mut buf, PcrIndex(4), EventType::IPL, &event_data)

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -180,7 +180,7 @@ impl PcrEventInputs {
         pcr_index: PcrIndex,
         event_type: EventType,
         event_data: &[u8],
-    ) -> Result<&'buf Self, Option<usize>> {
+    ) -> Result<&'buf mut Self, Option<usize>> {
         let required_size =
             mem::size_of::<u32>() + mem::size_of::<EventHeader>() + event_data.len();
 
@@ -205,9 +205,9 @@ impl PcrEventInputs {
             );
             ptr::copy(event_data.as_ptr(), ptr, event_data.len());
 
-            let ptr: *const PcrEventInputs =
-                ptr_meta::from_raw_parts(buffer.as_ptr().cast(), event_data.len());
-            Ok(&*ptr)
+            let ptr: *mut PcrEventInputs =
+                ptr_meta::from_raw_parts_mut(buffer.as_mut_ptr().cast(), event_data.len());
+            Ok(&mut *ptr)
         }
     }
 }

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -11,7 +11,7 @@
 //! [TPM]: https://en.wikipedia.org/wiki/Trusted_Platform_Module
 
 use super::{v1, AlgorithmId, EventType, HashAlgorithm, PcrIndex};
-use crate::data_types::{PhysicalAddress, UnalignedSlice};
+use crate::data_types::{Align, PhysicalAddress, UnalignedSlice};
 use crate::proto::unsafe_protocol;
 use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
 use crate::{Error, Result, Status, StatusExt};
@@ -210,6 +210,12 @@ impl PcrEventInputs {
                 ptr_meta::from_raw_parts(buffer.as_ptr().cast(), event_data.len());
             Ok(&*ptr)
         }
+    }
+}
+
+impl Align for PcrEventInputs {
+    fn alignment() -> usize {
+        1
     }
 }
 

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -172,7 +172,7 @@ impl PcrEventInputs {
     /// # Errors
     ///
     /// Returns [`Status::BUFFER_TOO_SMALL`] if the `buffer` is not large
-    /// enough.
+    /// enough. The required size will be returned in the error data.
     ///
     /// Returns [`Status::INVALID_PARAMETER`] if the `event_data` size is too
     /// large.
@@ -181,15 +181,15 @@ impl PcrEventInputs {
         pcr_index: PcrIndex,
         event_type: EventType,
         event_data: &[u8],
-    ) -> Result<&'buf Self> {
+    ) -> Result<&'buf Self, Option<usize>> {
         let required_size =
             mem::size_of::<u32>() + mem::size_of::<EventHeader>() + event_data.len();
 
         if buffer.len() < required_size {
-            return Err(Status::BUFFER_TOO_SMALL.into());
+            return Err(Error::new(Status::BUFFER_TOO_SMALL, Some(required_size)));
         }
-        let size_field =
-            u32::try_from(required_size).map_err(|_| Error::from(Status::INVALID_PARAMETER))?;
+        let size_field = u32::try_from(required_size)
+            .map_err(|_| Error::new(Status::INVALID_PARAMETER, None))?;
 
         let mut ptr: *mut u8 = buffer.as_mut_ptr().cast();
 


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/uefi-rs/issues/780

The initial commits are modifying the structs so that the `make_boxed` utility can be used.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
