### PR TITLE
boot: Always impl Drop for MemoryMapBackingMemory

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1737,8 +1737,6 @@ impl MemoryMapBackingMemory {
     }
 }
 
-// Don't drop when we use this in unit tests.
-#[cfg(not(test))]
 impl Drop for MemoryMapBackingMemory {
     fn drop(&mut self) {
         if let Some(bs) = system_table_boot() {
@@ -1747,7 +1745,7 @@ impl Drop for MemoryMapBackingMemory {
                 log::error!("Failed to deallocate memory map: {e:?}");
             }
         } else {
-            log::debug!("Boot services are excited. Memory map won't be freed using the UEFI boot services allocator.");
+            log::debug!("Boot services are exited. Memory map won't be freed using the UEFI boot services allocator.");
         }
     }
 }


### PR DESCRIPTION
Gating this on `cfg(not(test))` isn't necessary; during unit tests `system_table_boot()` will return `None` and so the drop won't do anything anyway.

Also fix a typo, excited -> exited.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
