### PR TITLE
uefi-raw: Add more MemoryType constants

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,9 @@
 # uefi-raw - [Unreleased]
 
+## Added
+- New `MemoryType` constants: `UNACCEPTED`, `MAX`, `RESERVED_FOR_OEM`, and
+  `RESERVED_FOR_OS_LOADER`.
+
 
 # uefi-raw - 0.6.0 (2024-07-02)
 


### PR DESCRIPTION
Unaccepted memory was added in UEFI 2.9. Also add the max constant and two range constants, and tweaked a few docs.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
