### PR TITLE
boot: Add freestanding version of open_protocol

### DIFF
--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -9,7 +9,7 @@ use uefi::table::boot::{
     Tpl,
 };
 use uefi::table::{Boot, SystemTable};
-use uefi::{guid, Event, Guid, Identify};
+use uefi::{boot, guid, Event, Guid, Identify};
 
 pub fn test(st: &SystemTable<Boot>) {
     let bt = st.boot_services();
@@ -164,16 +164,15 @@ fn test_uninstall_protocol_interface(bt: &BootServices) {
         // pointer. Open the protocol to get that pointer, making sure to drop
         // the `ScopedProtocol` _before_ uninstalling the protocol interface.
         let interface_ptr: *mut TestProtocol = {
-            let mut sp = bt
-                .open_protocol::<TestProtocol>(
-                    OpenProtocolParams {
-                        handle,
-                        agent: bt.image_handle(),
-                        controller: None,
-                    },
-                    OpenProtocolAttributes::GetProtocol,
-                )
-                .unwrap();
+            let mut sp = boot::open_protocol::<TestProtocol>(
+                OpenProtocolParams {
+                    handle,
+                    agent: bt.image_handle(),
+                    controller: None,
+                },
+                OpenProtocolAttributes::GetProtocol,
+            )
+            .unwrap();
             assert_eq!(sp.data, 123);
             &mut *sp
         };

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1136,13 +1136,13 @@ impl BootServices {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it can be used to open a
-    /// protocol in ways that don't get tracked by the UEFI
-    /// implementation. This could allow the protocol to be removed from
-    /// a handle, or for the handle to be deleted entirely, while a
-    /// reference to the protocol is still active. The caller is
-    /// responsible for ensuring that the handle and protocol remain
-    /// valid until the `ScopedProtocol` is dropped.
+    /// This function is unsafe because it can be used to open a protocol in
+    /// ways that don't get tracked by the UEFI implementation. This could allow
+    /// the protocol to be removed from a handle, or for the handle to be
+    /// deleted entirely, while a reference to the protocol is still active. The
+    /// caller is responsible for ensuring that the handle and protocol remain
+    /// valid until the `ScopedProtocol` is dropped, and the caller must ensure
+    /// that there is never more than one mutable reference to the protocol.
     ///
     /// [`open_protocol`]: BootServices::open_protocol
     /// [`open_protocol_exclusive`]: BootServices::open_protocol_exclusive


### PR DESCRIPTION
This comes with its own version of the `ScopedProtocol` struct. This one has no `BootServices` reference and no lifetime param.

For test coverage, updated `test_uninstall_protocol_interface` to use `boot::open_protocol` instead of the `BootServices` method. The `BootServices` method still has plenty of coverage in the test runner since `BootServices::open_protocol_exclusive` calls `BootServices::open_protocol`, and the former is called in lots of places.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
