### PR TITLE
clippy: add use_self and const fn

### DIFF
--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -10,10 +10,15 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(missing_debug_implementations)]
-#![deny(clippy::all)]
-#![deny(clippy::ptr_as_ptr, unused)]
-#![deny(clippy::must_use_candidate)]
+#![deny(
+    clippy::all,
+    clippy::missing_const_for_fn,
+    clippy::must_use_candidate,
+    clippy::ptr_as_ptr,
+    clippy::use_self,
+    missing_debug_implementations,
+    unused
+)]
 
 #[macro_use]
 mod enums;

--- a/uefi-raw/src/status.rs
+++ b/uefi-raw/src/status.rs
@@ -104,14 +104,14 @@ impl Status {
     #[inline]
     #[must_use]
     pub fn is_success(self) -> bool {
-        self == Status::SUCCESS
+        self == Self::SUCCESS
     }
 
     /// Returns true if status code indicates a warning.
     #[inline]
     #[must_use]
     pub fn is_warning(self) -> bool {
-        (self != Status::SUCCESS) && (self.0 & Self::ERROR_BIT == 0)
+        (self != Self::SUCCESS) && (self.0 & Self::ERROR_BIT == 0)
     }
 
     /// Returns true if the status code indicates an error.

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -367,8 +367,8 @@ impl MemoryDescriptor {
 }
 
 impl Default for MemoryDescriptor {
-    fn default() -> MemoryDescriptor {
-        MemoryDescriptor {
+    fn default() -> Self {
+        Self {
             ty: MemoryType::RESERVED,
             phys_start: 0,
             virt_start: 0,
@@ -439,9 +439,9 @@ impl MemoryType {
     /// Construct a custom `MemoryType`. Values in the range `0x8000_0000..=0xffff_ffff` are free for use if you are
     /// an OS loader.
     #[must_use]
-    pub const fn custom(value: u32) -> MemoryType {
+    pub const fn custom(value: u32) -> Self {
         assert!(value >= 0x80000000);
-        MemoryType(value)
+        Self(value)
     }
 }
 

--- a/uefi-raw/src/table/revision.rs
+++ b/uefi-raw/src/table/revision.rs
@@ -61,7 +61,7 @@ impl Revision {
         let major = major as u32;
         let minor = minor as u32;
         let value = (major << 16) | minor;
-        Revision(value)
+        Self(value)
     }
 
     /// Returns the major revision.

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -111,7 +111,7 @@ impl Display for Time {
 
 /// The padding fields of `Time` are ignored for comparison.
 impl PartialEq for Time {
-    fn eq(&self, other: &Time) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.year == other.year
             && self.month == other.month
             && self.day == other.day

--- a/uefi/src/data_types/chars.rs
+++ b/uefi/src/data_types/chars.rs
@@ -35,19 +35,19 @@ impl TryFrom<char> for Char8 {
 }
 
 impl From<Char8> for char {
-    fn from(char: Char8) -> char {
-        char::from(char.0)
+    fn from(char: Char8) -> Self {
+        Self::from(char.0)
     }
 }
 
 impl From<u8> for Char8 {
     fn from(value: u8) -> Self {
-        Char8(value)
+        Self(value)
     }
 }
 
 impl From<Char8> for u8 {
-    fn from(char: Char8) -> u8 {
+    fn from(char: Char8) -> Self {
         char.0
     }
 }
@@ -107,7 +107,7 @@ impl TryFrom<char> for Char16 {
 }
 
 impl From<Char16> for char {
-    fn from(char: Char16) -> char {
+    fn from(char: Char16) -> Self {
         u32::from(char.0).try_into().unwrap()
     }
 }
@@ -127,7 +127,7 @@ impl TryFrom<u16> for Char16 {
 }
 
 impl From<Char16> for u16 {
-    fn from(char: Char16) -> u16 {
+    fn from(char: Char16) -> Self {
         char.0
     }
 }

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -39,7 +39,7 @@ impl Handle {
 
     /// Get the underlying raw pointer.
     #[must_use]
-    pub fn as_ptr(&self) -> *mut c_void {
+    pub const fn as_ptr(&self) -> *mut c_void {
         self.0.as_ptr()
     }
 
@@ -78,7 +78,7 @@ impl Event {
 
     /// Get the underlying raw pointer.
     #[must_use]
-    pub fn as_ptr(&self) -> *mut c_void {
+    pub const fn as_ptr(&self) -> *mut c_void {
         self.0.as_ptr()
     }
 }

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -113,7 +113,7 @@ impl CString16 {
 
 impl Default for CString16 {
     fn default() -> Self {
-        CString16::new()
+        Self::new()
     }
 }
 
@@ -141,7 +141,7 @@ impl TryFrom<&str> for CString16 {
         // Add trailing nul.
         output.push(NUL_16);
 
-        Ok(CString16(output))
+        Ok(Self(output))
     }
 }
 
@@ -175,7 +175,7 @@ impl<'a> TryFrom<&UnalignedSlice<'a, u16>> for CString16 {
 
     fn try_from(input: &UnalignedSlice<u16>) -> Result<Self, Self::Error> {
         let v = input.to_vec();
-        CString16::try_from(v)
+        Self::try_from(v)
     }
 }
 
@@ -189,7 +189,7 @@ impl From<&CStr16> for CString16 {
 impl From<&CString16> for String {
     fn from(value: &CString16) -> Self {
         let slice: &CStr16 = value.as_ref();
-        String::from(slice)
+        Self::from(slice)
     }
 }
 

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -457,7 +457,7 @@ impl CStr16 {
     pub fn from_unaligned_slice<'buf>(
         src: &UnalignedSlice<'_, u16>,
         buf: &'buf mut [MaybeUninit<u16>],
-    ) -> Result<&'buf CStr16, UnalignedCStr16Error> {
+    ) -> Result<&'buf Self, UnalignedCStr16Error> {
         // The input `buf` might be longer than needed, so get a
         // subslice of the required length.
         let buf = buf
@@ -469,7 +469,7 @@ impl CStr16 {
             // Safety: `copy_buf` fully initializes the slice.
             maybe_uninit_slice_assume_init_ref(buf)
         };
-        CStr16::from_u16_with_nul(buf).map_err(|e| match e {
+        Self::from_u16_with_nul(buf).map_err(|e| match e {
             FromSliceWithNulError::InvalidChar(v) => UnalignedCStr16Error::InvalidChar(v),
             FromSliceWithNulError::InteriorNul(v) => UnalignedCStr16Error::InteriorNul(v),
             FromSliceWithNulError::NotNulTerminated => UnalignedCStr16Error::NotNulTerminated,
@@ -593,7 +593,7 @@ impl From<&CStr16> for alloc::string::String {
             .map(u16::from)
             .map(u32::from)
             .map(|int| char::from_u32(int).expect("Should be encodable as UTF-8"))
-            .collect::<alloc::string::String>()
+            .collect::<Self>()
     }
 }
 
@@ -615,8 +615,8 @@ impl<StrType: AsRef<str> + ?Sized> EqStrUntilNul<StrType> for CStr16 {
     }
 }
 
-impl AsRef<CStr16> for CStr16 {
-    fn as_ref(&self) -> &CStr16 {
+impl AsRef<Self> for CStr16 {
+    fn as_ref(&self) -> &Self {
         self
     }
 }

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -524,7 +524,7 @@ impl CStr16 {
 
     /// Returns if the string is empty. This ignores the null character.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.num_chars() == 0
     }
 
@@ -566,7 +566,7 @@ impl CStr16 {
     /// Returns the underlying bytes as slice including the terminating null
     /// character.
     #[must_use]
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.0.as_ptr().cast(), self.num_bytes()) }
     }
 }

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -28,7 +28,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     /// The `data` pointer must point to a packed array of at least
     /// `len` elements of type `T`. The pointer must remain valid for as
     /// long as the `'a` lifetime.
-    pub unsafe fn new(data: *const T, len: usize) -> Self {
+    pub const unsafe fn new(data: *const T, len: usize) -> Self {
         Self {
             data,
             len,

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -18,7 +18,7 @@ pub struct UefiDirectoryIter(UefiDirectoryHandle);
 impl UefiDirectoryIter {
     /// Constructor.
     #[must_use]
-    pub fn new(handle: UefiDirectoryHandle) -> Self {
+    pub const fn new(handle: UefiDirectoryHandle) -> Self {
         Self(handle)
     }
 }

--- a/uefi/src/fs/file_system/fs.rs
+++ b/uefi/src/fs/file_system/fs.rs
@@ -26,7 +26,7 @@ pub struct FileSystem<'a>(ScopedProtocol<'a, SimpleFileSystemProtocol>);
 impl<'a> FileSystem<'a> {
     /// Constructor.
     #[must_use]
-    pub fn new(proto: ScopedProtocol<'a, SimpleFileSystemProtocol>) -> Self {
+    pub const fn new(proto: ScopedProtocol<'a, SimpleFileSystemProtocol>) -> Self {
         Self(proto)
     }
 

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -21,7 +21,7 @@ impl Path {
 
     /// Returns the underlying string.
     #[must_use]
-    pub fn to_cstr16(&self) -> &CStr16 {
+    pub const fn to_cstr16(&self) -> &CStr16 {
         &self.0
     }
 
@@ -79,7 +79,7 @@ impl Path {
 
     /// Returns of the path is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.to_cstr16().is_empty()
     }
 }

--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -58,7 +58,7 @@ impl core::fmt::Write for DebugconWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for &byte in s.as_bytes() {
             unsafe {
-                core::arch::asm!("outb %al, %dx", in("al") byte, in("dx") DebugconWriter::IO_PORT, options(att_syntax))
+                core::arch::asm!("outb %al, %dx", in("al") byte, in("dx") Self::IO_PORT, options(att_syntax))
             };
         }
         Ok(())
@@ -83,7 +83,7 @@ impl Logger {
     /// [`set_output`]: Self::set_output
     #[must_use]
     pub const fn new() -> Self {
-        Logger {
+        Self {
             writer: AtomicPtr::new(ptr::null_mut()),
         }
     }

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -54,6 +54,7 @@ pub fn system_table() -> SystemTable<Boot> {
 /// **PLEASE NOTE** that these helpers are meant for the pre exit boot service
 /// epoch. Limited functionality might work after exiting them, such as logging
 /// to the debugcon device.
+#[allow(clippy::missing_const_for_fn)]
 pub fn init() -> Result<()> {
     // Setup logging and memory allocation
 
@@ -72,6 +73,7 @@ pub fn init() -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::missing_const_for_fn)]
 pub(crate) fn exit() {
     #[cfg(feature = "logger")]
     logger::disable();

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -89,8 +89,11 @@
 #![no_std]
 // Enable some additional warnings and lints.
 #![warn(clippy::ptr_as_ptr, missing_docs, unused)]
-#![deny(clippy::all)]
-#![deny(clippy::must_use_candidate)]
+#![deny(
+    clippy::all,
+    clippy::must_use_candidate,
+    clippy::use_self
+)]
 #![deny(missing_debug_implementations)]
 
 #[cfg(feature = "alloc")]

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -92,7 +92,8 @@
 #![deny(
     clippy::all,
     clippy::must_use_candidate,
-    clippy::use_self
+    clippy::use_self,
+    clippy::missing_const_for_fn
 )]
 #![deny(missing_debug_implementations)]
 

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -315,7 +315,7 @@ impl MemoryMapBackingMemory {
     /// takes into account that, as you go, more (small) allocations might
     /// happen.
     #[must_use]
-    fn safe_allocation_size_hint(mmm: MemoryMapMeta) -> usize {
+    const fn safe_allocation_size_hint(mmm: MemoryMapMeta) -> usize {
         // Allocate space for extra entries beyond the current size of the
         // memory map. The value of 8 matches the value in the Linux kernel:
         // https://github.com/torvalds/linux/blob/e544a07438/drivers/firmware/efi/libstub/efistub.h#L173

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -373,7 +373,7 @@ impl MemoryMapOwned {
     pub(crate) fn from_initialized_mem(buf: MemoryMapBackingMemory, meta: MemoryMapMeta) -> Self {
         assert!(meta.desc_size >= mem::size_of::<MemoryDescriptor>());
         let len = meta.entry_count();
-        MemoryMapOwned { buf, meta, len }
+        Self { buf, meta, len }
     }
 }
 

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -102,7 +102,7 @@ impl GraphicsOutput {
 
     /// Returns a [`ModeIter`].
     #[must_use]
-    pub fn modes<'a>(&'a self, bs: &'a BootServices) -> ModeIter {
+    pub const fn modes<'a>(&'a self, bs: &'a BootServices) -> ModeIter {
         ModeIter {
             gop: self,
             bs,

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -98,11 +98,11 @@ pub enum Key {
 }
 
 impl From<InputKey> for Key {
-    fn from(k: InputKey) -> Key {
+    fn from(k: InputKey) -> Self {
         if k.scan_code == ScanCode::NULL.0 {
-            Key::Printable(Char16::try_from(k.unicode_char).unwrap())
+            Self::Printable(Char16::try_from(k.unicode_char).unwrap())
         } else {
-            Key::Special(ScanCode(k.scan_code))
+            Self::Special(ScanCode(k.scan_code))
         }
     }
 }

--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -5,27 +5,27 @@ pub struct ExceptionType(isize);
 
 impl ExceptionType {
     /// Undefined Exception
-    pub const EXCEPT_EBC_UNDEFINED: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_EBC_UNDEFINED: Self = Self(0);
     /// Divide-by-zero Error
-    pub const EXCEPT_EBC_DIVIDE_ERROR: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_EBC_DIVIDE_ERROR: Self = Self(1);
     /// Debug Exception
-    pub const EXCEPT_EBC_DEBUG: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_EBC_DEBUG: Self = Self(2);
     /// Breakpoint
-    pub const EXCEPT_EBC_BREAKPOINT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_EBC_BREAKPOINT: Self = Self(3);
     /// Overflow
-    pub const EXCEPT_EBC_OVERFLOW: ExceptionType = ExceptionType(4);
+    pub const EXCEPT_EBC_OVERFLOW: Self = Self(4);
     /// Invalid Opcode
-    pub const EXCEPT_EBC_INVALID_OPCODE: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_EBC_INVALID_OPCODE: Self = Self(5);
     /// Stack-Segment Fault
-    pub const EXCEPT_EBC_STACK_FAULT: ExceptionType = ExceptionType(6);
+    pub const EXCEPT_EBC_STACK_FAULT: Self = Self(6);
     /// Alignment Check
-    pub const EXCEPT_EBC_ALIGNMENT_CHECK: ExceptionType = ExceptionType(7);
+    pub const EXCEPT_EBC_ALIGNMENT_CHECK: Self = Self(7);
     /// Instruction Encoding Exception
-    pub const EXCEPT_EBC_INSTRUCTION_ENCODING: ExceptionType = ExceptionType(8);
+    pub const EXCEPT_EBC_INSTRUCTION_ENCODING: Self = Self(8);
     /// Bad Breakpoint Exception
-    pub const EXCEPT_EBC_BAD_BREAK: ExceptionType = ExceptionType(9);
+    pub const EXCEPT_EBC_BAD_BREAK: Self = Self(9);
     /// Single Step Exception
-    pub const EXCEPT_EBC_SINGLE_STEP: ExceptionType = ExceptionType(10);
+    pub const EXCEPT_EBC_SINGLE_STEP: Self = Self(10);
 }
 
 #[cfg(target_arch = "x86")]
@@ -69,39 +69,39 @@ impl ExceptionType {
 #[cfg(target_arch = "x86_64")]
 impl ExceptionType {
     /// Divide-by-zero Error
-    pub const EXCEPT_X64_DIVIDE_ERROR: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_X64_DIVIDE_ERROR: Self = Self(0);
     /// Debug Exception
-    pub const EXCEPT_X64_DEBUG: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_X64_DEBUG: Self = Self(1);
     /// Non-maskable Interrupt
-    pub const EXCEPT_X64_NMI: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_X64_NMI: Self = Self(2);
     /// Breakpoint
-    pub const EXCEPT_X64_BREAKPOINT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_X64_BREAKPOINT: Self = Self(3);
     /// Overflow
-    pub const EXCEPT_X64_OVERFLOW: ExceptionType = ExceptionType(4);
+    pub const EXCEPT_X64_OVERFLOW: Self = Self(4);
     /// Bound Range Exceeded
-    pub const EXCEPT_X64_BOUND: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_X64_BOUND: Self = Self(5);
     /// Invalid Opcode
-    pub const EXCEPT_X64_INVALID_OPCODE: ExceptionType = ExceptionType(6);
+    pub const EXCEPT_X64_INVALID_OPCODE: Self = Self(6);
     /// Double Fault
-    pub const EXCEPT_X64_DOUBLE_FAULT: ExceptionType = ExceptionType(8);
+    pub const EXCEPT_X64_DOUBLE_FAULT: Self = Self(8);
     /// Invalid TSS
-    pub const EXCEPT_X64_INVALID_TSS: ExceptionType = ExceptionType(10);
+    pub const EXCEPT_X64_INVALID_TSS: Self = Self(10);
     /// Segment Not Present
-    pub const EXCEPT_X64_SEG_NOT_PRESENT: ExceptionType = ExceptionType(11);
+    pub const EXCEPT_X64_SEG_NOT_PRESENT: Self = Self(11);
     /// Stack-Segment Fault
-    pub const EXCEPT_X64_STACK_FAULT: ExceptionType = ExceptionType(12);
+    pub const EXCEPT_X64_STACK_FAULT: Self = Self(12);
     /// General Protection Fault
-    pub const EXCEPT_X64_GP_FAULT: ExceptionType = ExceptionType(13);
+    pub const EXCEPT_X64_GP_FAULT: Self = Self(13);
     /// Page Fault
-    pub const EXCEPT_X64_PAGE_FAULT: ExceptionType = ExceptionType(14);
+    pub const EXCEPT_X64_PAGE_FAULT: Self = Self(14);
     /// x87 Floating-Point Exception
-    pub const EXCEPT_X64_FP_ERROR: ExceptionType = ExceptionType(16);
+    pub const EXCEPT_X64_FP_ERROR: Self = Self(16);
     /// Alignment Check
-    pub const EXCEPT_X64_ALIGNMENT_CHECK: ExceptionType = ExceptionType(17);
+    pub const EXCEPT_X64_ALIGNMENT_CHECK: Self = Self(17);
     /// Machine Check
-    pub const EXCEPT_X64_MACHINE_CHECK: ExceptionType = ExceptionType(18);
+    pub const EXCEPT_X64_MACHINE_CHECK: Self = Self(18);
     /// SIMD Floating-Point Exception
-    pub const EXCEPT_X64_SIMD: ExceptionType = ExceptionType(19);
+    pub const EXCEPT_X64_SIMD: Self = Self(19);
 }
 
 #[cfg(target_arch = "arm")]

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -4,6 +4,7 @@
 // `cargo xtask gen-code`
 //
 // See `/xtask/src/device_path/README.md` for more details.
+#![allow(clippy::missing_const_for_fn)]
 
 use crate::data_types::UnalignedSlice;
 use crate::mem::memory_map::MemoryType;

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -217,7 +217,7 @@ impl DevicePathNode {
 
     /// Returns the payload data of this node.
     #[must_use]
-    pub fn data(&self) -> &[u8] {
+    pub const fn data(&self) -> &[u8] {
         &self.data
     }
 

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -171,7 +171,7 @@ impl DevicePathNode {
     /// remain valid for the lifetime `'a`, and cannot be mutated during
     /// that lifetime.
     #[must_use]
-    pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a DevicePathNode {
+    pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a Self {
         let header = *ptr.cast::<DevicePathHeader>();
 
         let data_len = usize::from(header.length) - mem::size_of::<DevicePathHeader>();
@@ -339,7 +339,7 @@ impl PartialEq for DevicePathInstance {
 
 #[cfg(feature = "alloc")]
 impl ToOwned for DevicePathInstance {
-    type Owned = Box<DevicePathInstance>;
+    type Owned = Box<Self>;
 
     fn to_owned(&self) -> Self::Owned {
         self.to_boxed()
@@ -433,7 +433,7 @@ impl DevicePath {
     /// remain valid for the lifetime `'a`, and cannot be mutated during
     /// that lifetime.
     #[must_use]
-    pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a DevicePath {
+    pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a Self {
         &*Self::ptr_from_ffi(ptr.cast::<c_void>())
     }
 
@@ -527,7 +527,7 @@ impl<'a> TryFrom<&[u8]> for &'a DevicePath {
 
 #[cfg(feature = "alloc")]
 impl ToOwned for DevicePath {
-    type Owned = Box<DevicePath>;
+    type Owned = Box<Self>;
 
     fn to_owned(&self) -> Self::Owned {
         self.to_boxed()
@@ -678,118 +678,118 @@ pub struct DeviceSubType(pub u8);
 
 impl DeviceSubType {
     /// PCI Device Path.
-    pub const HARDWARE_PCI: DeviceSubType = DeviceSubType(1);
+    pub const HARDWARE_PCI: Self = Self(1);
     /// PCCARD Device Path.
-    pub const HARDWARE_PCCARD: DeviceSubType = DeviceSubType(2);
+    pub const HARDWARE_PCCARD: Self = Self(2);
     /// Memory-mapped Device Path.
-    pub const HARDWARE_MEMORY_MAPPED: DeviceSubType = DeviceSubType(3);
+    pub const HARDWARE_MEMORY_MAPPED: Self = Self(3);
     /// Vendor-Defined Device Path.
-    pub const HARDWARE_VENDOR: DeviceSubType = DeviceSubType(4);
+    pub const HARDWARE_VENDOR: Self = Self(4);
     /// Controller Device Path.
-    pub const HARDWARE_CONTROLLER: DeviceSubType = DeviceSubType(5);
+    pub const HARDWARE_CONTROLLER: Self = Self(5);
     /// BMC Device Path.
-    pub const HARDWARE_BMC: DeviceSubType = DeviceSubType(6);
+    pub const HARDWARE_BMC: Self = Self(6);
 
     /// ACPI Device Path.
-    pub const ACPI: DeviceSubType = DeviceSubType(1);
+    pub const ACPI: Self = Self(1);
     /// Expanded ACPI Device Path.
-    pub const ACPI_EXPANDED: DeviceSubType = DeviceSubType(2);
+    pub const ACPI_EXPANDED: Self = Self(2);
     /// ACPI _ADR Device Path.
-    pub const ACPI_ADR: DeviceSubType = DeviceSubType(3);
+    pub const ACPI_ADR: Self = Self(3);
     /// NVDIMM Device Path.
-    pub const ACPI_NVDIMM: DeviceSubType = DeviceSubType(4);
+    pub const ACPI_NVDIMM: Self = Self(4);
 
     /// ATAPI Device Path.
-    pub const MESSAGING_ATAPI: DeviceSubType = DeviceSubType(1);
+    pub const MESSAGING_ATAPI: Self = Self(1);
     /// SCSI Device Path.
-    pub const MESSAGING_SCSI: DeviceSubType = DeviceSubType(2);
+    pub const MESSAGING_SCSI: Self = Self(2);
     /// Fibre Channel Device Path.
-    pub const MESSAGING_FIBRE_CHANNEL: DeviceSubType = DeviceSubType(3);
+    pub const MESSAGING_FIBRE_CHANNEL: Self = Self(3);
     /// 1394 Device Path.
-    pub const MESSAGING_1394: DeviceSubType = DeviceSubType(4);
+    pub const MESSAGING_1394: Self = Self(4);
     /// USB Device Path.
-    pub const MESSAGING_USB: DeviceSubType = DeviceSubType(5);
+    pub const MESSAGING_USB: Self = Self(5);
     /// I2O Device Path.
-    pub const MESSAGING_I2O: DeviceSubType = DeviceSubType(6);
+    pub const MESSAGING_I2O: Self = Self(6);
     /// Infiniband Device Path.
-    pub const MESSAGING_INFINIBAND: DeviceSubType = DeviceSubType(9);
+    pub const MESSAGING_INFINIBAND: Self = Self(9);
     /// Vendor-Defined Device Path.
-    pub const MESSAGING_VENDOR: DeviceSubType = DeviceSubType(10);
+    pub const MESSAGING_VENDOR: Self = Self(10);
     /// MAC Address Device Path.
-    pub const MESSAGING_MAC_ADDRESS: DeviceSubType = DeviceSubType(11);
+    pub const MESSAGING_MAC_ADDRESS: Self = Self(11);
     /// IPV4 Device Path.
-    pub const MESSAGING_IPV4: DeviceSubType = DeviceSubType(12);
+    pub const MESSAGING_IPV4: Self = Self(12);
     /// IPV6 Device Path.
-    pub const MESSAGING_IPV6: DeviceSubType = DeviceSubType(13);
+    pub const MESSAGING_IPV6: Self = Self(13);
     /// UART Device Path.
-    pub const MESSAGING_UART: DeviceSubType = DeviceSubType(14);
+    pub const MESSAGING_UART: Self = Self(14);
     /// USB Class Device Path.
-    pub const MESSAGING_USB_CLASS: DeviceSubType = DeviceSubType(15);
+    pub const MESSAGING_USB_CLASS: Self = Self(15);
     /// USB WWID Device Path.
-    pub const MESSAGING_USB_WWID: DeviceSubType = DeviceSubType(16);
+    pub const MESSAGING_USB_WWID: Self = Self(16);
     /// Device Logical Unit.
-    pub const MESSAGING_DEVICE_LOGICAL_UNIT: DeviceSubType = DeviceSubType(17);
+    pub const MESSAGING_DEVICE_LOGICAL_UNIT: Self = Self(17);
     /// SATA Device Path.
-    pub const MESSAGING_SATA: DeviceSubType = DeviceSubType(18);
+    pub const MESSAGING_SATA: Self = Self(18);
     /// iSCSI Device Path node (base information).
-    pub const MESSAGING_ISCSI: DeviceSubType = DeviceSubType(19);
+    pub const MESSAGING_ISCSI: Self = Self(19);
     /// VLAN Device Path node.
-    pub const MESSAGING_VLAN: DeviceSubType = DeviceSubType(20);
+    pub const MESSAGING_VLAN: Self = Self(20);
     /// Fibre Channel Ex Device Path.
-    pub const MESSAGING_FIBRE_CHANNEL_EX: DeviceSubType = DeviceSubType(21);
+    pub const MESSAGING_FIBRE_CHANNEL_EX: Self = Self(21);
     /// Serial Attached SCSI (SAS) Ex Device Path.
-    pub const MESSAGING_SCSI_SAS_EX: DeviceSubType = DeviceSubType(22);
+    pub const MESSAGING_SCSI_SAS_EX: Self = Self(22);
     /// NVM Express Namespace Device Path.
-    pub const MESSAGING_NVME_NAMESPACE: DeviceSubType = DeviceSubType(23);
+    pub const MESSAGING_NVME_NAMESPACE: Self = Self(23);
     /// Uniform Resource Identifiers (URI) Device Path.
-    pub const MESSAGING_URI: DeviceSubType = DeviceSubType(24);
+    pub const MESSAGING_URI: Self = Self(24);
     /// UFS Device Path.
-    pub const MESSAGING_UFS: DeviceSubType = DeviceSubType(25);
+    pub const MESSAGING_UFS: Self = Self(25);
     /// SD (Secure Digital) Device Path.
-    pub const MESSAGING_SD: DeviceSubType = DeviceSubType(26);
+    pub const MESSAGING_SD: Self = Self(26);
     /// Bluetooth Device Path.
-    pub const MESSAGING_BLUETOOTH: DeviceSubType = DeviceSubType(27);
+    pub const MESSAGING_BLUETOOTH: Self = Self(27);
     /// Wi-Fi Device Path.
-    pub const MESSAGING_WIFI: DeviceSubType = DeviceSubType(28);
+    pub const MESSAGING_WIFI: Self = Self(28);
     /// eMMC (Embedded Multi-Media Card) Device Path.
-    pub const MESSAGING_EMMC: DeviceSubType = DeviceSubType(29);
+    pub const MESSAGING_EMMC: Self = Self(29);
     /// BluetoothLE Device Path.
-    pub const MESSAGING_BLUETOOTH_LE: DeviceSubType = DeviceSubType(30);
+    pub const MESSAGING_BLUETOOTH_LE: Self = Self(30);
     /// DNS Device Path.
-    pub const MESSAGING_DNS: DeviceSubType = DeviceSubType(31);
+    pub const MESSAGING_DNS: Self = Self(31);
     /// NVDIMM Namespace Device Path.
-    pub const MESSAGING_NVDIMM_NAMESPACE: DeviceSubType = DeviceSubType(32);
+    pub const MESSAGING_NVDIMM_NAMESPACE: Self = Self(32);
     /// REST Service Device Path.
-    pub const MESSAGING_REST_SERVICE: DeviceSubType = DeviceSubType(33);
+    pub const MESSAGING_REST_SERVICE: Self = Self(33);
     /// NVME over Fabric (NVMe-oF) Namespace Device Path.
-    pub const MESSAGING_NVME_OF_NAMESPACE: DeviceSubType = DeviceSubType(34);
+    pub const MESSAGING_NVME_OF_NAMESPACE: Self = Self(34);
 
     /// Hard Drive Media Device Path.
-    pub const MEDIA_HARD_DRIVE: DeviceSubType = DeviceSubType(1);
+    pub const MEDIA_HARD_DRIVE: Self = Self(1);
     /// CD-ROM Media Device Path.
-    pub const MEDIA_CD_ROM: DeviceSubType = DeviceSubType(2);
+    pub const MEDIA_CD_ROM: Self = Self(2);
     /// Vendor-Defined Media Device Path.
-    pub const MEDIA_VENDOR: DeviceSubType = DeviceSubType(3);
+    pub const MEDIA_VENDOR: Self = Self(3);
     /// File Path Media Device Path.
-    pub const MEDIA_FILE_PATH: DeviceSubType = DeviceSubType(4);
+    pub const MEDIA_FILE_PATH: Self = Self(4);
     /// Media Protocol Device Path.
-    pub const MEDIA_PROTOCOL: DeviceSubType = DeviceSubType(5);
+    pub const MEDIA_PROTOCOL: Self = Self(5);
     /// PIWG Firmware File.
-    pub const MEDIA_PIWG_FIRMWARE_FILE: DeviceSubType = DeviceSubType(6);
+    pub const MEDIA_PIWG_FIRMWARE_FILE: Self = Self(6);
     /// PIWG Firmware Volume.
-    pub const MEDIA_PIWG_FIRMWARE_VOLUME: DeviceSubType = DeviceSubType(7);
+    pub const MEDIA_PIWG_FIRMWARE_VOLUME: Self = Self(7);
     /// Relative Offset Range.
-    pub const MEDIA_RELATIVE_OFFSET_RANGE: DeviceSubType = DeviceSubType(8);
+    pub const MEDIA_RELATIVE_OFFSET_RANGE: Self = Self(8);
     /// RAM Disk Device Path.
-    pub const MEDIA_RAM_DISK: DeviceSubType = DeviceSubType(9);
+    pub const MEDIA_RAM_DISK: Self = Self(9);
 
     /// BIOS Boot Specification Device Path.
-    pub const BIOS_BOOT_SPECIFICATION: DeviceSubType = DeviceSubType(1);
+    pub const BIOS_BOOT_SPECIFICATION: Self = Self(1);
 
     /// End this instance of a Device Path and start a new one.
-    pub const END_INSTANCE: DeviceSubType = DeviceSubType(0x01);
+    pub const END_INSTANCE: Self = Self(0x01);
     /// End entire Device Path.
-    pub const END_ENTIRE: DeviceSubType = DeviceSubType(0xff);
+    pub const END_ENTIRE: Self = Self(0xff);
 }
 
 /// Error returned when attempting to convert from a `&[u8]` to a

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -185,7 +185,7 @@ impl LoadedImage {
     ///  - `MemoryType::BOOT_SERVICES_CODE` for UEFI boot drivers
     ///  - `MemoryType::RUNTIME_SERVICES_CODE` for UEFI runtime drivers
     #[must_use]
-    pub fn code_type(&self) -> MemoryType {
+    pub const fn code_type(&self) -> MemoryType {
         self.0.image_code_type
     }
 
@@ -196,7 +196,7 @@ impl LoadedImage {
     ///  - `MemoryType::BOOT_SERVICES_DATA` for UEFI boot drivers
     ///  - `MemoryType::RUNTIME_SERVICES_DATA` for UEFI runtime drivers
     #[must_use]
-    pub fn data_type(&self) -> MemoryType {
+    pub const fn data_type(&self) -> MemoryType {
         self.0.image_data_type
     }
 }

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -22,7 +22,7 @@ impl Directory {
     /// This function should only be called on files which ARE directories,
     /// doing otherwise is unsafe.
     #[must_use]
-    pub unsafe fn new(handle: FileHandle) -> Self {
+    pub const unsafe fn new(handle: FileHandle) -> Self {
         Self(RegularFile::new(handle))
     }
 

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -248,13 +248,13 @@ impl FileInfo {
 
     /// Returns if the file is a directory.
     #[must_use]
-    pub fn is_directory(&self) -> bool {
+    pub const fn is_directory(&self) -> bool {
         self.attribute.contains(FileAttribute::DIRECTORY)
     }
 
     /// Returns if the file is a regular file.
     #[must_use]
-    pub fn is_regular_file(&self) -> bool {
+    pub const fn is_regular_file(&self) -> bool {
         !self.is_directory()
     }
 }

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -19,7 +19,7 @@ impl RegularFile {
     /// This function should only be called on handles which ARE NOT directories,
     /// doing otherwise is unsafe.
     #[must_use]
-    pub unsafe fn new(handle: FileHandle) -> Self {
+    pub const unsafe fn new(handle: FileHandle) -> Self {
         Self(handle)
     }
 

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -261,13 +261,13 @@ impl SimpleNetwork {
     /// On QEMU, this event seems to never fire; it is suggested to verify that your implementation
     /// of UEFI properly implements this event before using it.
     #[must_use]
-    pub fn wait_for_packet(&self) -> &Event {
+    pub const fn wait_for_packet(&self) -> &Event {
         &self.wait_for_packet
     }
 
     /// Returns a reference to the Simple Network mode.
     #[must_use]
-    pub fn mode(&self) -> &NetworkMode {
+    pub const fn mode(&self) -> &NetworkMode {
         unsafe { &*self.mode }
     }
 }
@@ -347,14 +347,14 @@ pub struct NetworkStats {
 
 impl NetworkStats {
     /// Any statistic value of -1 is not available
-    fn available(&self, stat: u64) -> bool {
+    const fn available(&self, stat: u64) -> bool {
         stat as i64 != -1
     }
 
     /// Takes a statistic and converts it to an option
     ///
     /// When the statistic is not available, `None` is returned
-    fn to_option(&self, stat: u64) -> Option<u64> {
+    const fn to_option(&self, stat: u64) -> Option<u64> {
         match self.available(stat) {
             true => Some(stat),
             false => None,
@@ -364,175 +364,175 @@ impl NetworkStats {
     /// The total number of frames received, including error frames
     /// and dropped frames
     #[must_use]
-    pub fn rx_total_frames(&self) -> Option<u64> {
+    pub const fn rx_total_frames(&self) -> Option<u64> {
         self.to_option(self.rx_total_frames)
     }
 
     /// The total number of good frames received and copied
     /// into receive buffers
     #[must_use]
-    pub fn rx_good_frames(&self) -> Option<u64> {
+    pub const fn rx_good_frames(&self) -> Option<u64> {
         self.to_option(self.rx_good_frames)
     }
 
     /// The number of frames below the minimum length for the
     /// communications device
     #[must_use]
-    pub fn rx_undersize_frames(&self) -> Option<u64> {
+    pub const fn rx_undersize_frames(&self) -> Option<u64> {
         self.to_option(self.rx_undersize_frames)
     }
 
     /// The number of frames longer than the maximum length for
     /// the communications length device
     #[must_use]
-    pub fn rx_oversize_frames(&self) -> Option<u64> {
+    pub const fn rx_oversize_frames(&self) -> Option<u64> {
         self.to_option(self.rx_oversize_frames)
     }
 
     /// The number of valid frames that were dropped because
     /// the receive buffers were full
     #[must_use]
-    pub fn rx_dropped_frames(&self) -> Option<u64> {
+    pub const fn rx_dropped_frames(&self) -> Option<u64> {
         self.to_option(self.rx_dropped_frames)
     }
 
     /// The number of valid unicast frames received and not dropped
     #[must_use]
-    pub fn rx_unicast_frames(&self) -> Option<u64> {
+    pub const fn rx_unicast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_unicast_frames)
     }
 
     /// The number of valid broadcast frames received and not dropped
     #[must_use]
-    pub fn rx_broadcast_frames(&self) -> Option<u64> {
+    pub const fn rx_broadcast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_broadcast_frames)
     }
 
     /// The number of valid multicast frames received and not dropped
     #[must_use]
-    pub fn rx_multicast_frames(&self) -> Option<u64> {
+    pub const fn rx_multicast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_multicast_frames)
     }
 
     /// Number of frames with CRC or alignment errors
     #[must_use]
-    pub fn rx_crc_error_frames(&self) -> Option<u64> {
+    pub const fn rx_crc_error_frames(&self) -> Option<u64> {
         self.to_option(self.rx_crc_error_frames)
     }
 
     /// The total number of bytes received including frames with errors
     /// and dropped frames
     #[must_use]
-    pub fn rx_total_bytes(&self) -> Option<u64> {
+    pub const fn rx_total_bytes(&self) -> Option<u64> {
         self.to_option(self.rx_total_bytes)
     }
 
     /// The total number of frames transmitted including frames
     /// with errors and dropped frames
     #[must_use]
-    pub fn tx_total_frames(&self) -> Option<u64> {
+    pub const fn tx_total_frames(&self) -> Option<u64> {
         self.to_option(self.tx_total_frames)
     }
 
     /// The total number of valid frames transmitted and copied
     /// into receive buffers
     #[must_use]
-    pub fn tx_good_frames(&self) -> Option<u64> {
+    pub const fn tx_good_frames(&self) -> Option<u64> {
         self.to_option(self.tx_good_frames)
     }
 
     /// The number of frames below the minimum length for
     /// the media. This would be less than 64 for Ethernet
     #[must_use]
-    pub fn tx_undersize_frames(&self) -> Option<u64> {
+    pub const fn tx_undersize_frames(&self) -> Option<u64> {
         self.to_option(self.tx_undersize_frames)
     }
 
     /// The number of frames longer than the maximum length for
     /// the media. This would be 1500 for Ethernet
     #[must_use]
-    pub fn tx_oversize_frames(&self) -> Option<u64> {
+    pub const fn tx_oversize_frames(&self) -> Option<u64> {
         self.to_option(self.tx_oversize_frames)
     }
 
     /// The number of valid frames that were dropped because
     /// received buffers were full
     #[must_use]
-    pub fn tx_dropped_frames(&self) -> Option<u64> {
+    pub const fn tx_dropped_frames(&self) -> Option<u64> {
         self.to_option(self.tx_dropped_frames)
     }
 
     /// The number of valid unicast frames transmitted and not
     /// dropped
     #[must_use]
-    pub fn tx_unicast_frames(&self) -> Option<u64> {
+    pub const fn tx_unicast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_unicast_frames)
     }
 
     /// The number of valid broadcast frames transmitted and
     /// not dropped
     #[must_use]
-    pub fn tx_broadcast_frames(&self) -> Option<u64> {
+    pub const fn tx_broadcast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_broadcast_frames)
     }
 
     /// The number of valid multicast frames transmitted
     /// and not dropped
     #[must_use]
-    pub fn tx_multicast_frames(&self) -> Option<u64> {
+    pub const fn tx_multicast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_multicast_frames)
     }
 
     /// The number of transmitted frames with CRC or
     /// alignment errors
     #[must_use]
-    pub fn tx_crc_error_frames(&self) -> Option<u64> {
+    pub const fn tx_crc_error_frames(&self) -> Option<u64> {
         self.to_option(self.tx_crc_error_frames)
     }
 
     /// The total number of bytes transmitted including
     /// error frames and dropped frames
     #[must_use]
-    pub fn tx_total_bytes(&self) -> Option<u64> {
+    pub const fn tx_total_bytes(&self) -> Option<u64> {
         self.to_option(self.tx_total_bytes)
     }
 
     /// The number of collisions detected on this subnet
     #[must_use]
-    pub fn collisions(&self) -> Option<u64> {
+    pub const fn collisions(&self) -> Option<u64> {
         self.to_option(self.collisions)
     }
 
     /// The number of frames destined for unsupported protocol
     #[must_use]
-    pub fn unsupported_protocol(&self) -> Option<u64> {
+    pub const fn unsupported_protocol(&self) -> Option<u64> {
         self.to_option(self.unsupported_protocol)
     }
 
     /// The number of valid frames received that were duplicated
     #[must_use]
-    pub fn rx_duplicated_frames(&self) -> Option<u64> {
+    pub const fn rx_duplicated_frames(&self) -> Option<u64> {
         self.to_option(self.rx_duplicated_frames)
     }
 
     /// The number of encrypted frames received that failed
     /// to decrypt
     #[must_use]
-    pub fn rx_decrypt_error_frames(&self) -> Option<u64> {
+    pub const fn rx_decrypt_error_frames(&self) -> Option<u64> {
         self.to_option(self.rx_decrypt_error_frames)
     }
 
     /// The number of frames that failed to transmit after
     /// exceeding the retry limit
     #[must_use]
-    pub fn tx_error_frames(&self) -> Option<u64> {
+    pub const fn tx_error_frames(&self) -> Option<u64> {
         self.to_option(self.tx_error_frames)
     }
 
     /// The number of frames that transmitted successfully
     /// after more than one attempt
     #[must_use]
-    pub fn tx_retry_frames(&self) -> Option<u64> {
+    pub const fn tx_retry_frames(&self) -> Option<u64> {
         self.to_option(self.tx_retry_frames)
     }
 }

--- a/uefi/src/proto/shell_params.rs
+++ b/uefi/src/proto/shell_params.rs
@@ -16,7 +16,7 @@ pub struct ShellParameters(ShellParametersProtocol);
 impl ShellParameters {
     /// Get the number of shell parameter arguments
     #[must_use]
-    pub fn args_len(&self) -> usize {
+    pub const fn args_len(&self) -> usize {
         self.0.argc
     }
 
@@ -29,7 +29,7 @@ impl ShellParameters {
 
     /// Get a slice of the args, as Char16 pointers
     #[must_use]
-    fn args_slice(&self) -> &[*const Char16] {
+    const fn args_slice(&self) -> &[*const Char16] {
         unsafe {
             from_raw_parts(
                 self.0.argv.cast::<*const data_types::chars::Char16>(),

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -165,7 +165,7 @@ impl PcrEvent {
             ptr_write_unaligned_and_add(&mut ptr, event_data_size);
             ptr::copy(event_data.as_ptr(), ptr, event_data.len());
 
-            let ptr: *mut PcrEvent =
+            let ptr: *mut Self =
                 ptr_meta::from_raw_parts_mut(buffer.as_mut_ptr().cast(), event_data.len());
             Ok(&mut *ptr)
         }

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -49,13 +49,13 @@ pub struct BootServiceCapability {
 impl BootServiceCapability {
     /// Version of the `BootServiceCapability` structure.
     #[must_use]
-    pub fn structure_version(&self) -> Version {
+    pub const fn structure_version(&self) -> Version {
         self.structure_version
     }
 
     /// Version of the `Tcg` protocol.
     #[must_use]
-    pub fn protocol_spec_version(&self) -> Version {
+    pub const fn protocol_spec_version(&self) -> Version {
         self.protocol_spec_version
     }
 
@@ -69,13 +69,13 @@ impl BootServiceCapability {
 
     /// Whether the TPM device is present.
     #[must_use]
-    pub fn tpm_present(&self) -> bool {
+    pub const fn tpm_present(&self) -> bool {
         self.tpm_present_flag != 0
     }
 
     /// Whether the TPM device is deactivated.
     #[must_use]
-    pub fn tpm_deactivated(&self) -> bool {
+    pub const fn tpm_deactivated(&self) -> bool {
         self.tpm_deactivated_flag != 0
     }
 }
@@ -199,7 +199,7 @@ impl PcrEvent {
 
     /// PCR index for the event.
     #[must_use]
-    pub fn pcr_index(&self) -> PcrIndex {
+    pub const fn pcr_index(&self) -> PcrIndex {
         self.pcr_index
     }
 
@@ -207,7 +207,7 @@ impl PcrEvent {
     ///
     /// [`event_data`]: Self::event_data
     #[must_use]
-    pub fn event_type(&self) -> EventType {
+    pub const fn event_type(&self) -> EventType {
         self.event_type
     }
 
@@ -219,13 +219,13 @@ impl PcrEvent {
     /// [`digest`]: Self::digest
     /// [`event_type`]: Self::event_type
     #[must_use]
-    pub fn event_data(&self) -> &[u8] {
+    pub const fn event_data(&self) -> &[u8] {
         &self.event_data
     }
 
     /// SHA-1 digest of the data hashed for this event.
     #[must_use]
-    pub fn digest(&self) -> Sha1Digest {
+    pub const fn digest(&self) -> Sha1Digest {
         self.digest
     }
 }
@@ -288,7 +288,7 @@ pub struct EventLog<'a> {
 }
 
 impl<'a> EventLog<'a> {
-    pub(super) unsafe fn new(
+    pub(super) const unsafe fn new(
         location: *const u8,
         last_entry: *const u8,
         is_truncated: bool,
@@ -303,7 +303,7 @@ impl<'a> EventLog<'a> {
 
     /// Iterator of events in the log.
     #[must_use]
-    pub fn iter(&self) -> EventLogIter {
+    pub const fn iter(&self) -> EventLogIter {
         EventLogIter {
             log: self,
             location: self.location,
@@ -319,7 +319,7 @@ impl<'a> EventLog<'a> {
     ///
     /// [`v1::Tcg`]: Tcg
     #[must_use]
-    pub fn is_truncated(&self) -> bool {
+    pub const fn is_truncated(&self) -> bool {
         self.is_truncated
     }
 }

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -123,7 +123,7 @@ impl Default for BootServiceCapability {
 impl BootServiceCapability {
     /// Whether the TPM device is present.
     #[must_use]
-    pub fn tpm_present(&self) -> bool {
+    pub const fn tpm_present(&self) -> bool {
         self.present_flag != 0
     }
 }
@@ -419,7 +419,7 @@ impl<'a> EventLog<'a> {
     /// Whether the event log is truncated due to not enough space in the log to
     /// contain some events.
     #[must_use]
-    pub fn is_truncated(&self) -> bool {
+    pub const fn is_truncated(&self) -> bool {
         self.is_truncated
     }
 }
@@ -533,7 +533,7 @@ impl<'a> PcrEvent<'a> {
 
     /// PCR index for the event.
     #[must_use]
-    pub fn pcr_index(&self) -> PcrIndex {
+    pub const fn pcr_index(&self) -> PcrIndex {
         self.pcr_index
     }
 
@@ -541,7 +541,7 @@ impl<'a> PcrEvent<'a> {
     ///
     /// [`event_data`]: Self::event_data
     #[must_use]
-    pub fn event_type(&self) -> EventType {
+    pub const fn event_type(&self) -> EventType {
         self.event_type
     }
 
@@ -553,7 +553,7 @@ impl<'a> PcrEvent<'a> {
     /// [`digests`]: Self::digests
     /// [`event_type`]: Self::event_type
     #[must_use]
-    pub fn event_data(&self) -> &[u8] {
+    pub const fn event_data(&self) -> &[u8] {
         self.event_data
     }
 

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -102,7 +102,7 @@ pub struct BootServiceCapability {
 impl Default for BootServiceCapability {
     fn default() -> Self {
         // OK to unwrap, the size is less than u8.
-        let struct_size = u8::try_from(mem::size_of::<BootServiceCapability>()).unwrap();
+        let struct_size = u8::try_from(mem::size_of::<Self>()).unwrap();
 
         Self {
             size: struct_size,
@@ -211,7 +211,7 @@ impl PcrEventInputs {
             );
             ptr::copy(event_data.as_ptr(), ptr, event_data.len());
 
-            let ptr: *mut PcrEventInputs =
+            let ptr: *mut Self =
                 ptr_meta::from_raw_parts_mut(buffer.as_mut_ptr().cast(), event_data.len());
             Ok(&mut *ptr)
         }
@@ -261,7 +261,7 @@ impl Debug for PcrEventInputs {
 
 // Manual `PartialEq` implementation since it can't be derived for a packed DST.
 impl PartialEq for PcrEventInputs {
-    fn eq(&self, other: &PcrEventInputs) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.size == other.size
             && self.event_header == other.event_header
             && self.event == other.event

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -60,7 +60,7 @@ impl<Data: Debug> Error<Data> {
     /// - to retain the erroneous status code,
     /// - do not care about the payload, and
     /// - refrain from generic type complexity in a higher API level.
-    pub fn to_err_without_payload(&self) -> Error<()> {
+    pub const fn to_err_without_payload(&self) -> Error<()> {
         Error {
             status: self.status,
             data: (),

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -44,7 +44,7 @@ impl<Data: Debug> Error<Data> {
 
 impl From<Status> for Error<()> {
     fn from(status: Status) -> Self {
-        Error::new(status, ())
+        Self::new(status, ())
     }
 }
 

--- a/uefi/src/result/mod.rs
+++ b/uefi/src/result/mod.rs
@@ -80,9 +80,9 @@ impl<Output, ErrData: Debug> ResultExt<Output, ErrData> for Result<Output, ErrDa
         }
     }
 
-    fn handle_warning<O>(self, op: O) -> Result<Output, ErrData>
+    fn handle_warning<O>(self, op: O) -> Self
     where
-        O: FnOnce(Error<ErrData>) -> Result<Output, ErrData>,
+        O: FnOnce(Error<ErrData>) -> Self,
     {
         match self {
             Ok(output) => Ok(output),

--- a/uefi/src/result/status.rs
+++ b/uefi/src/result/status.rs
@@ -59,7 +59,7 @@ impl StatusExt for Status {
     #[inline]
     fn to_result_with_err<ErrData: Debug>(
         self,
-        err: impl FnOnce(Status) -> ErrData,
+        err: impl FnOnce(Self) -> ErrData,
     ) -> Result<(), ErrData> {
         if self.is_success() {
             Ok(())
@@ -72,7 +72,7 @@ impl StatusExt for Status {
     fn to_result_with<T, ErrData: Debug>(
         self,
         val: impl FnOnce() -> T,
-        err: impl FnOnce(Status) -> ErrData,
+        err: impl FnOnce(Self) -> ErrData,
     ) -> Result<T, ErrData> {
         if self.is_success() {
             Ok(val())

--- a/uefi/src/table/runtime.rs
+++ b/uefi/src/table/runtime.rs
@@ -605,7 +605,7 @@ impl TryFrom<&[u8]> for Time {
     type Error = TimeByteConversionError;
 
     fn try_from(bytes: &[u8]) -> core::result::Result<Self, Self::Error> {
-        if size_of::<Time>() <= bytes.len() {
+        if size_of::<Self>() <= bytes.len() {
             let year = u16::from_le_bytes(bytes[0..2].try_into().unwrap());
             let month = bytes[2];
             let day = bytes[3];
@@ -636,7 +636,7 @@ impl TryFrom<&[u8]> for Time {
                 daylight,
             };
 
-            Time::new(time_params).map_err(TimeByteConversionError::InvalidFields)
+            Self::new(time_params).map_err(TimeByteConversionError::InvalidFields)
         } else {
             Err(TimeByteConversionError::InvalidSize)
         }

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -117,7 +117,7 @@ impl<View: SystemTableView> SystemTable<View> {
 
     /// Get the underlying raw pointer.
     #[must_use]
-    pub fn as_ptr(&self) -> *const c_void {
+    pub const fn as_ptr(&self) -> *const c_void {
         self.table.cast()
     }
 }

--- a/uefi/src/table/system.rs
+++ b/uefi/src/table/system.rs
@@ -278,7 +278,7 @@ impl SystemTable<Boot> {
     /// handling require taking this risk.
     #[must_use]
     pub const unsafe fn unsafe_clone(&self) -> Self {
-        SystemTable {
+        Self {
             table: self.table,
             _marker: PhantomData,
         }

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -66,6 +66,7 @@ fn gen_code_as_string(groups: &[NodeGroup]) -> Result<String> {
 // `cargo xtask gen-code`
 //
 // See `/xtask/src/device_path/README.md` for more details.
+#![allow(clippy::missing_const_for_fn)]
 
 {code}"
     );


### PR DESCRIPTION
Follow-up of #546, which adds `const` to more functions, adds it as mandatory lint, and also uses `Self` where possible.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
