### PR TITLE
boot: Add freestanding version of raise_tpl

### DIFF
--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -13,6 +13,7 @@ use uefi::{boot, guid, Event, Guid, Identify};
 
 pub fn test(st: &SystemTable<Boot>) {
     let bt = st.boot_services();
+    test_tpl();
     info!("Testing timer...");
     test_timer(bt);
     info!("Testing events...");
@@ -26,6 +27,12 @@ pub fn test(st: &SystemTable<Boot>) {
     test_reinstall_protocol_interface(bt);
     test_uninstall_protocol_interface(bt);
     test_install_configuration_table(st);
+}
+
+fn test_tpl() {
+    info!("Testing watchdog...");
+    // There's no way to query the TPL, so we can't assert that this does anything.
+    let _guard = unsafe { boot::raise_tpl(Tpl::NOTIFY) };
 }
 
 fn test_timer(bt: &BootServices) {


### PR DESCRIPTION
This comes with its own version of the `TplGuard` struct. This one has no `BootServices` reference and no lifetime param.

Also add a test. The test can't actually verify the results since there's no way to query the TPL, but it at least calls `raise_tpl`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
