### PR TITLE
boot: Add freestanding version of `create_event`

### DIFF
--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -1,6 +1,7 @@
 use alloc::string::ToString;
 use core::cell::RefCell;
 use core::ptr::NonNull;
+use uefi::boot;
 use uefi::data_types::Align;
 use uefi::prelude::*;
 use uefi::proto::media::block::BlockIO;
@@ -305,8 +306,7 @@ fn test_raw_disk_io2(handle: Handle, bt: &BootServices) {
 
         unsafe {
             // Create the completion event
-            let mut event = bt
-                .create_event(EventType::empty(), Tpl::NOTIFY, None, None)
+            let mut event = boot::create_event(EventType::empty(), Tpl::NOTIFY, None, None)
                 .expect("Failed to create disk I/O completion event");
 
             // Initialise the task context

--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1616,8 +1616,8 @@ impl<'guid> SearchType<'guid> {
     }
 }
 
-/// Raw event notification function
-type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>);
+/// Event notification callback type.
+pub type EventNotifyFn = unsafe extern "efiapi" fn(event: Event, context: Option<NonNull<c_void>>);
 
 /// Timer events manipulation.
 #[derive(Debug)]


### PR DESCRIPTION
Also made `EventNotifyFn` public, that was an existing oversight.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
