### PR TITLE
uefi: Fix lifetimes in device_path TryFrom<&[u8]> impls

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -39,6 +39,14 @@
   > use uefi::table::boot::BootServices;
   ```
 
+
+# uefi - 0.30.0 (unreleased)
+## Changed
+- **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
+  `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to
+  memory unsafety. See <https://github.com/rust-osdev/uefi-rs/issues/1281>.
+
+
 # uefi - 0.29.0 (2024-07-02)
 
 ## Added

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -119,7 +119,7 @@ pub struct DevicePathHeader {
     pub length: u16,
 }
 
-impl<'a> TryFrom<&[u8]> for &'a DevicePathHeader {
+impl<'a> TryFrom<&'a [u8]> for &'a DevicePathHeader {
     type Error = ByteConversionError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -265,7 +265,7 @@ impl PartialEq for DevicePathNode {
     }
 }
 
-impl<'a> TryFrom<&[u8]> for &'a DevicePathNode {
+impl<'a> TryFrom<&'a [u8]> for &'a DevicePathNode {
     type Error = ByteConversionError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -516,7 +516,7 @@ impl PartialEq for DevicePath {
     }
 }
 
-impl<'a> TryFrom<&[u8]> for &'a DevicePath {
+impl<'a> TryFrom<&'a [u8]> for &'a DevicePath {
     type Error = ByteConversionError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {


### PR DESCRIPTION
The missing lifetime means that the &[u8] buffer could be freed while the &DevicePath still exists, which is UB.

Bug: https://github.com/rust-osdev/uefi-rs/issues/1281

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
