### PR TITLE
release: uefi-0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -24,7 +24,7 @@ to your `Cargo.toml`. The resulting `Cargo.toml` should look like that:
 ```toml
 [dependencies]
 log = "0.4.21"
-uefi = { version = "0.29.0", features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.30.0", features = [ "panic_handler", "logger" ] }
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.29.0", features = ["panic_handler"] }
+uefi = { version = "0.30.0", features = ["panic_handler"] }

--- a/uefi-raw/src/capsule.rs
+++ b/uefi-raw/src/capsule.rs
@@ -18,7 +18,7 @@ pub struct CapsuleBlockDescriptor {
     /// Either a data block pointer or a continuation pointer.
     ///
     /// * If `length` is non-zero, this is the physical address of the data
-    /// block.
+    ///   block.
     /// * If `length` is zero:
     ///   * If `addr` is non-zero, this is the physical address of another block
     ///     of `CapsuleBlockDescriptor`.

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,8 +1,7 @@
 # uefi - [Unreleased]
 
 
-
-# uefi - 0.30.0 (unreleased)
+# uefi - 0.30.0 (2024-08-02)
 ## Changed
 - **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
   `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.29.0"
+version = "0.30.0"
 readme = "README.md"
 description = "Safe and easy-to-use wrapper for building UEFI apps."
 


### PR DESCRIPTION
This release contains a cherry-pick of https://github.com/rust-osdev/uefi-rs/pull/1282.

(The change in uefi-raw/src/capsule.rs was needed to fix a clippy lint.)

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
