### PR TITLE
uefi: Add release data to 0.30.0 release

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -40,7 +40,7 @@
   ```
 
 
-# uefi - 0.30.0 (unreleased)
+# uefi - 0.30.0 (2024-08-02)
 ## Changed
 - **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
   `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to


### PR DESCRIPTION
The 0.30 release is being made from the `version-0.30` branch, so we need to update the release data on the `main` branch as well.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
