### PR TITLE
Merge release-v0.30 branch into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -252,14 +252,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -444,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -553,7 +553,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -730,14 +730,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -991,11 +992,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1003,6 +1004,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -24,7 +24,7 @@ to your `Cargo.toml`. The resulting `Cargo.toml` should look like that:
 ```toml
 [dependencies]
 log = "0.4.21"
-uefi = { version = "0.29.0", features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.30.0", features = [ "panic_handler", "logger" ] }
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.29.0", features = ["panic_handler"] }
+uefi = { version = "0.30.0", features = ["panic_handler"] }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -47,6 +47,13 @@
   memory unsafety. See <https://github.com/rust-osdev/uefi-rs/issues/1281>.
 
 
+# uefi - 0.30.0 (2024-08-02)
+## Changed
+- **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
+  `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to
+  memory unsafety. See <https://github.com/rust-osdev/uefi-rs/issues/1281>.
+
+
 # uefi - 0.29.0 (2024-07-02)
 
 ## Added

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -41,13 +41,7 @@
 
 
 # uefi - 0.30.0 (2024-08-02)
-## Changed
-- **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
-  `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to
-  memory unsafety. See <https://github.com/rust-osdev/uefi-rs/issues/1281>.
 
-
-# uefi - 0.30.0 (2024-08-02)
 ## Changed
 - **Breaking:**: Fixed a bug in the impls of `TryFrom<&[u8]>` for
   `&DevicePathHeader`, `&DevicePathNode` and `&DevicePath` that could lead to

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.29.0"
+version = "0.30.0"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,


### PR DESCRIPTION
It is weird that we have a release v0.30 branch and a released version, but `uefi` is still
at `0.29` on the main branch. This merges the branch from #1285 into main with some necessary adaptions.


## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
