### PR TITLE
boot: Add freestanding stall

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -521,6 +521,18 @@ pub unsafe fn exit(
     )
 }
 
+/// Stalls execution for the given number of microseconds.
+pub fn stall(microseconds: usize) {
+    let bt = boot_services_raw_panicking();
+    let bt = unsafe { bt.as_ref() };
+
+    unsafe {
+        // No error conditions are defined in the spec for this function, so
+        // ignore the status.
+        let _ = (bt.stall)(microseconds);
+    }
+}
+
 /// A buffer returned by [`locate_handle_buffer`] that contains an array of
 /// [`Handle`]s that support the requested protocol.
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
One minor implementation change from the BootServices version: the Status value is ignored rather than asserting it is `SUCCESS`. There shouldn't be any practical difference, as stalling should always succeed. In the unlikely event that some implementation returns an error, a panic is unlikely to be desirable to the caller.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
