### PR TITLE
Restore some memory exports to uefi::table::boot

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1,6 +1,8 @@
 //! UEFI services available during boot.
 
-pub use uefi_raw::table::boot::{EventType, InterfaceType, Tpl};
+pub use uefi_raw::table::boot::{
+    EventType, InterfaceType, MemoryAttribute, MemoryDescriptor, MemoryType, Tpl,
+};
 
 use super::Revision;
 use crate::data_types::PhysicalAddress;


### PR DESCRIPTION
The next release already has a fair number of breaking changes going into it, so restore a few public exports to uefi::table::boot to reduce the number of changes users have to make on upgrade. Specifically, `MemoryAttribute`, `MemoryDescriptor`, and `MemoryType`.

This module will be deprecated eventually (replaced by `uefi::boot`), so these re-exports will eventually go away in some future release.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
