### PR TITLE
Remove dead_code workarounds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,11 +123,6 @@ jobs:
   build_feature_permutations:
     name: Build (feature permutations)
     runs-on: ubuntu-latest
-    env:
-      # TODO: temporarily allow warnings to not be errors on nightly due to
-      # incorrect dead_code lint.
-      # https://github.com/rust-osdev/uefi-rs/issues/1205
-      RUSTFLAGS: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -140,11 +135,6 @@ jobs:
   nightly_channel:
     name: Nightly (build, test, doc)
     runs-on: ubuntu-latest
-    env:
-      # TODO: temporarily allow warnings to not be errors on nightly due to
-      # incorrect dead_code lint.
-      # https://github.com/rust-osdev/uefi-rs/issues/1205
-      RUSTFLAGS: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -167,11 +157,6 @@ jobs:
   miri:
     name: Unit + Doc Tests (Miri)
     runs-on: ubuntu-latest
-    env:
-      # TODO: temporarily allow warnings to not be errors on nightly due to
-      # incorrect dead_code lint.
-      # https://github.com/rust-osdev/uefi-rs/issues/1205
-      RUSTFLAGS: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -9,8 +9,6 @@
 //!
 //! [`BootServices`]: crate::table::boot::BootServices#accessing-protocols
 
-#![warn(dead_code)] // https://github.com/rust-osdev/uefi-rs/issues/1205
-
 use crate::Identify;
 use core::ffi::c_void;
 


### PR DESCRIPTION
The changes to dead_code analysis that lead to unwanted warnings have been reverted for now in rustc.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
