### PR TITLE
uefi-raw: unified boolean type

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,12 +1,14 @@
 # uefi-raw - [Unreleased]
 
+## Added
+- `Boolean` type
 
 # uefi-raw - 0.8.0 (2024-09-09)
 
 ## Added
 
 - Added `PAGE_SIZE` constant.
-
+- Added a new `unstable` feature
 
 # uefi-raw - 0.7.0 (2024-08-20)
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -23,5 +23,9 @@ bitflags.workspace = true
 ptr_meta.workspace = true
 uguid.workspace = true
 
+[features]
+default = []
+unstable = []
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -71,7 +71,8 @@ pub type VirtualAddress = u64;
 /// The provided [`Boolean`] can't be converted to [`bool`] as it is neither
 /// `0` nor `1`.
 #[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq)]
-pub struct InvalidBooleanError(u8);
+#[repr(transparent)]
+pub struct InvalidBooleanError(pub u8);
 
 impl Display for InvalidBooleanError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -89,7 +90,7 @@ impl Error for InvalidBooleanError {}
 /// respectively [`TryFrom`] implementations.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[repr(transparent)]
-pub struct Boolean(u8);
+pub struct Boolean(pub u8);
 
 impl Boolean {
     /// [`Boolean`] representing `true`.

--- a/uefi-raw/src/protocol/block.rs
+++ b/uefi-raw/src/protocol/block.rs
@@ -1,4 +1,4 @@
-use crate::{guid, Guid, Status};
+use crate::{guid, Boolean, Guid, Status};
 use core::ffi::c_void;
 
 /// Logical block address.
@@ -9,11 +9,11 @@ pub type Lba = u64;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct BlockIoMedia {
     pub media_id: u32,
-    pub removable_media: bool,
-    pub media_present: bool,
-    pub logical_partition: bool,
-    pub read_only: bool,
-    pub write_caching: bool,
+    pub removable_media: Boolean,
+    pub media_present: Boolean,
+    pub logical_partition: Boolean,
+    pub read_only: Boolean,
+    pub write_caching: Boolean,
     pub block_size: u32,
     pub io_align: u32,
     pub last_block: Lba,
@@ -31,7 +31,7 @@ pub struct BlockIoMedia {
 pub struct BlockIoProtocol {
     pub revision: u64,
     pub media: *const BlockIoMedia,
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub read_blocks: unsafe extern "efiapi" fn(
         this: *const Self,
         media_id: u32,

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -1,6 +1,6 @@
 pub mod serial;
 
-use crate::{guid, Char16, Event, Guid, PhysicalAddress, Status};
+use crate::{guid, Boolean, Char16, Event, Guid, PhysicalAddress, Status};
 use bitflags::bitflags;
 use core::ptr;
 
@@ -42,7 +42,7 @@ pub struct AbsolutePointerState {
 #[derive(Debug)]
 #[repr(C)]
 pub struct AbsolutePointerProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: u8) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub get_state:
         unsafe extern "efiapi" fn(this: *const Self, state: *mut AbsolutePointerState) -> Status,
     pub wait_for_input: Event,
@@ -63,7 +63,7 @@ pub struct InputKey {
 #[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextInputProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub read_key_stroke: unsafe extern "efiapi" fn(this: *mut Self, key: *mut InputKey) -> Status,
     pub wait_for_key: Event,
 }
@@ -80,13 +80,13 @@ pub struct SimpleTextOutputMode {
     pub attribute: i32,
     pub cursor_column: i32,
     pub cursor_row: i32,
-    pub cursor_visible: bool,
+    pub cursor_visible: Boolean,
 }
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextOutputProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended: Boolean) -> Status,
     pub output_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const Char16) -> Status,
     pub test_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const Char16) -> Status,
     pub query_mode: unsafe extern "efiapi" fn(
@@ -100,7 +100,7 @@ pub struct SimpleTextOutputProtocol {
     pub clear_screen: unsafe extern "efiapi" fn(this: *mut Self) -> Status,
     pub set_cursor_position:
         unsafe extern "efiapi" fn(this: *mut Self, column: usize, row: usize) -> Status,
-    pub enable_cursor: unsafe extern "efiapi" fn(this: *mut Self, visible: bool) -> Status,
+    pub enable_cursor: unsafe extern "efiapi" fn(this: *mut Self, visible: Boolean) -> Status,
     pub mode: *mut SimpleTextOutputMode,
 }
 
@@ -124,8 +124,8 @@ pub struct SimplePointerState {
     pub relative_movement_x: i32,
     pub relative_movement_y: i32,
     pub relative_movement_z: i32,
-    pub left_button: u8,
-    pub right_button: u8,
+    pub left_button: Boolean,
+    pub right_button: Boolean,
 }
 
 #[derive(Debug)]
@@ -133,7 +133,7 @@ pub struct SimplePointerState {
 pub struct SimplePointerProtocol {
     pub reset: unsafe extern "efiapi" fn(
         this: *mut SimplePointerProtocol,
-        extended_verification: bool,
+        extended_verification: Boolean,
     ) -> Status,
     pub get_state: unsafe extern "efiapi" fn(
         this: *mut SimplePointerProtocol,

--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -1,4 +1,4 @@
-use crate::{guid, Char16, Guid};
+use crate::{guid, Boolean, Char16, Guid};
 
 /// Device path protocol.
 ///
@@ -25,13 +25,13 @@ impl DevicePathProtocol {
 pub struct DevicePathToTextProtocol {
     pub convert_device_node_to_text: unsafe extern "efiapi" fn(
         device_node: *const DevicePathProtocol,
-        display_only: bool,
-        allow_shortcuts: bool,
+        display_only: Boolean,
+        allow_shortcuts: Boolean,
     ) -> *const Char16,
     pub convert_device_path_to_text: unsafe extern "efiapi" fn(
         device_path: *const DevicePathProtocol,
-        display_only: bool,
-        allow_shortcuts: bool,
+        display_only: Boolean,
+        allow_shortcuts: Boolean,
     ) -> *const Char16,
 }
 

--- a/uefi-raw/src/protocol/file_system.rs
+++ b/uefi-raw/src/protocol/file_system.rs
@@ -1,5 +1,5 @@
 use crate::time::Time;
-use crate::{guid, Char16, Event, Guid, Status};
+use crate::{guid, Boolean, Char16, Event, Guid, Status};
 use bitflags::bitflags;
 use core::ffi::c_void;
 
@@ -151,7 +151,7 @@ impl FileInfo {
 #[repr(C)]
 pub struct FileSystemInfo {
     pub size: u64,
-    pub read_only: u8,
+    pub read_only: Boolean,
     pub volume_size: u64,
     pub free_space: u64,
     pub block_size: u32,

--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -1,5 +1,5 @@
 use crate::protocol::device_path::DevicePathProtocol;
-use crate::{guid, Guid, Status};
+use crate::{guid, Boolean, Guid, Status};
 use core::ffi::c_void;
 
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub struct LoadFileProtocol {
     pub load_file: unsafe extern "efiapi" fn(
         this: *mut LoadFileProtocol,
         file_path: *const DevicePathProtocol,
-        boot_policy: bool,
+        boot_policy: Boolean,
         buffer_size: *mut usize,
         buffer: *mut c_void,
     ) -> Status,
@@ -24,7 +24,7 @@ pub struct LoadFile2Protocol {
     pub load_file: unsafe extern "efiapi" fn(
         this: *mut LoadFile2Protocol,
         file_path: *const DevicePathProtocol,
-        boot_policy: bool,
+        boot_policy: Boolean,
         buffer_size: *mut usize,
         buffer: *mut c_void,
     ) -> Status,

--- a/uefi-raw/src/protocol/network/dhcp4.rs
+++ b/uefi-raw/src/protocol/network/dhcp4.rs
@@ -1,4 +1,4 @@
-use crate::{guid, Char8, Event, Guid, Ipv4Address, MacAddress, Status};
+use crate::{guid, Boolean, Char8, Event, Guid, Ipv4Address, MacAddress, Status};
 use core::ffi::c_void;
 
 newtype_enum! {
@@ -148,7 +148,7 @@ pub struct Dhcp4Protocol {
     pub start: unsafe extern "efiapi" fn(this: *mut Self, completion_event: Event) -> Status,
     pub renew_rebind: unsafe extern "efiapi" fn(
         this: *mut Self,
-        rebind_request: bool,
+        rebind_request: Boolean,
         completion_event: Event,
     ) -> Status,
     pub release: unsafe extern "efiapi" fn(this: *mut Self) -> Status,

--- a/uefi-raw/src/protocol/network/http.rs
+++ b/uefi-raw/src/protocol/network/http.rs
@@ -1,4 +1,4 @@
-use crate::{guid, Char16, Char8, Event, Guid, Ipv4Address, Ipv6Address, Status};
+use crate::{guid, Boolean, Char16, Char8, Event, Guid, Ipv4Address, Ipv6Address, Status};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};
 
@@ -7,7 +7,7 @@ use core::fmt::{self, Debug, Formatter};
 pub struct HttpConfigData {
     pub http_version: HttpVersion,
     pub time_out_millisec: u32,
-    pub local_addr_is_ipv6: bool,
+    pub local_addr_is_ipv6: Boolean,
     pub access_point: HttpAccessPoint,
 }
 
@@ -22,7 +22,7 @@ newtype_enum! {
 #[derive(Debug)]
 #[repr(C)]
 pub struct HttpV4AccessPoint {
-    pub use_default_addr: bool,
+    pub use_default_addr: Boolean,
     pub local_address: Ipv4Address,
     pub local_subnet: Ipv4Address,
     pub local_port: u16,

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -2,7 +2,7 @@
 
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::table::Header;
-use crate::{Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress};
+use crate::{Boolean, Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::ops::RangeInclusive;
@@ -103,7 +103,7 @@ pub struct BootServices {
 
     // Image services
     pub load_image: unsafe extern "efiapi" fn(
-        boot_policy: u8,
+        boot_policy: Boolean,
         parent_image_handle: Handle,
         device_path: *const DevicePathProtocol,
         source_buffer: *const u8,
@@ -140,7 +140,7 @@ pub struct BootServices {
         controller: Handle,
         driver_image: Handle,
         remaining_device_path: *const DevicePathProtocol,
-        recursive: bool,
+        recursive: Boolean,
     ) -> Status,
     pub disconnect_controller: unsafe extern "efiapi" fn(
         controller: Handle,

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -4,7 +4,7 @@ use crate::capsule::CapsuleHeader;
 use crate::table::boot::MemoryDescriptor;
 use crate::table::Header;
 use crate::time::Time;
-use crate::{guid, Char16, Guid, PhysicalAddress, Status};
+use crate::{guid, Boolean, Char16, Guid, PhysicalAddress, Status};
 use bitflags::bitflags;
 use core::ffi::c_void;
 
@@ -115,7 +115,7 @@ pub struct TimeCapabilities {
 
     /// Whether a time set operation clears the device's time below the
     /// "resolution" reporting level. False for normal PC-AT CMOS RTC devices.
-    pub sets_to_zero: bool,
+    pub sets_to_zero: Boolean,
 }
 
 bitflags! {

--- a/uefi-test-runner/src/proto/load.rs
+++ b/uefi-test-runner/src/proto/load.rs
@@ -11,12 +11,12 @@ use uefi::proto::BootPolicy;
 use uefi::{boot, Guid, Handle};
 use uefi_raw::protocol::device_path::DevicePathProtocol;
 use uefi_raw::protocol::media::{LoadFile2Protocol, LoadFileProtocol};
-use uefi_raw::Status;
+use uefi_raw::{Boolean, Status};
 
 unsafe extern "efiapi" fn raw_load_file(
     this: *mut LoadFile2Protocol,
     _file_path: *const DevicePathProtocol,
-    _boot_policy: bool,
+    _boot_policy: Boolean,
     buffer_size: *mut usize,
     buffer: *mut c_void,
 ) -> Status {

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -15,8 +15,8 @@ details of the deprecated items that were removed in this release.
 - **Breaking:** `FileSystem` no longer has a lifetime parameter, and the
   deprecated conversion from `uefi::table::boot::ScopedProtocol` has been
   removed.
+- **Breaking:** Removed `BootPolicyError` as `BootPolicy`
 - Fixed `boot::open_protocol` to properly handle a null interface pointer.
-
 
 # uefi - 0.32.0 (2024-09-09)
 

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -561,7 +561,7 @@ pub fn connect_controller(
                 .map(|dp| dp.as_ffi_ptr())
                 .unwrap_or(ptr::null())
                 .cast(),
-            recursive,
+            recursive.into(),
         )
     }
     .to_result_with_err(|_| ())

--- a/uefi/src/proto/boot_policy.rs
+++ b/uefi/src/proto/boot_policy.rs
@@ -1,6 +1,6 @@
 //! Module for the [`BootPolicy`] helper type.
 
-use uefi_raw::{Boolean, InvalidBooleanError};
+use uefi_raw::Boolean;
 
 /// The UEFI boot policy is a property that influences the behaviour of
 /// various UEFI functions that load files (typically UEFI images).
@@ -33,16 +33,13 @@ impl From<BootPolicy> for Boolean {
     }
 }
 
-impl TryFrom<Boolean> for BootPolicy {
-    type Error = InvalidBooleanError;
-
-    fn try_from(value: Boolean) -> Result<Self, Self::Error> {
-        let boolean: bool = value.try_into()?;
-        let policy = match boolean {
+impl From<Boolean> for BootPolicy {
+    fn from(value: Boolean) -> Self {
+        let boolean: bool = value.into();
+        match boolean {
             true => Self::BootSelection,
             false => Self::ExactMatch,
-        };
-        Ok(policy)
+        }
     }
 }
 

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -20,7 +20,7 @@ impl Pointer {
     ///
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Retrieves the pointer device's current state, if a state change occurred

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -19,7 +19,7 @@ impl Input {
     ///
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Reads the next keystroke from the input device, if any.

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -118,7 +118,7 @@ impl Output {
     #[must_use]
     pub fn cursor_visible(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.data().cursor_visible.try_into().unwrap()
+        self.data().cursor_visible.into()
     }
 
     /// Make the cursor visible or invisible.

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -28,7 +28,7 @@ pub struct Output(SimpleTextOutputProtocol);
 impl Output {
     /// Resets and clears the text output device hardware.
     pub fn reset(&mut self, extended: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended.into()) }.to_result()
     }
 
     /// Clears the output screen.
@@ -116,8 +116,9 @@ impl Output {
 
     /// Returns whether the cursor is currently shown or not.
     #[must_use]
-    pub const fn cursor_visible(&self) -> bool {
-        self.data().cursor_visible
+    pub fn cursor_visible(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.data().cursor_visible.try_into().unwrap()
     }
 
     /// Make the cursor visible or invisible.
@@ -125,7 +126,7 @@ impl Output {
     /// The output device may not support this operation, in which case an
     /// `Unsupported` error will be returned.
     pub fn enable_cursor(&mut self, visible: bool) -> Result {
-        unsafe { (self.0.enable_cursor)(&mut self.0, visible) }.to_result()
+        unsafe { (self.0.enable_cursor)(&mut self.0, visible.into()) }.to_result()
     }
 
     /// Returns the column and row of the cursor.

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -91,8 +91,8 @@ impl DevicePathToText {
         let text_device_node = unsafe {
             (self.0.convert_device_node_to_text)(
                 device_node.as_ffi_ptr().cast(),
-                display_only.0,
-                allow_shortcuts.0,
+                display_only.0.into(),
+                allow_shortcuts.0.into(),
             )
         };
         PoolString::new(text_device_node.cast())
@@ -113,8 +113,8 @@ impl DevicePathToText {
         let text_device_path = unsafe {
             (self.0.convert_device_path_to_text)(
                 device_path.as_ffi_ptr().cast(),
-                display_only.0,
-                allow_shortcuts.0,
+                display_only.0.into(),
+                allow_shortcuts.0.into(),
             )
         };
         PoolString::new(text_device_path.cast())

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -117,35 +117,35 @@ impl BlockIOMedia {
     #[must_use]
     pub fn is_removable_media(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.0.removable_media.try_into().unwrap()
+        self.0.removable_media.into()
     }
 
     /// True if there is a media currently present in the device.
     #[must_use]
     pub fn is_media_present(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.0.media_present.try_into().unwrap()
+        self.0.media_present.into()
     }
 
     /// True if block IO was produced to abstract partition structure.
     #[must_use]
     pub fn is_logical_partition(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.0.logical_partition.try_into().unwrap()
+        self.0.logical_partition.into()
     }
 
     /// True if the media is marked read-only.
     #[must_use]
     pub fn is_read_only(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.0.read_only.try_into().unwrap()
+        self.0.read_only.into()
     }
 
     /// True if `writeBlocks` function writes data.
     #[must_use]
     pub fn is_write_caching(&self) -> bool {
         // Panic: Misbehaving UEFI impls are so unlikely; just fail
-        self.0.write_caching.try_into().unwrap()
+        self.0.write_caching.into()
     }
 
     /// The intrinsic block size of the device.

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -27,7 +27,7 @@ impl BlockIO {
     /// # Errors
     /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning correctly and could not be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Read the requested number of blocks from the device.
@@ -115,32 +115,37 @@ impl BlockIOMedia {
 
     /// True if the media is removable.
     #[must_use]
-    pub const fn is_removable_media(&self) -> bool {
-        self.0.removable_media
+    pub fn is_removable_media(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.0.removable_media.try_into().unwrap()
     }
 
     /// True if there is a media currently present in the device.
     #[must_use]
-    pub const fn is_media_present(&self) -> bool {
-        self.0.media_present
+    pub fn is_media_present(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.0.media_present.try_into().unwrap()
     }
 
     /// True if block IO was produced to abstract partition structure.
     #[must_use]
-    pub const fn is_logical_partition(&self) -> bool {
-        self.0.logical_partition
+    pub fn is_logical_partition(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.0.logical_partition.try_into().unwrap()
     }
 
     /// True if the media is marked read-only.
     #[must_use]
-    pub const fn is_read_only(&self) -> bool {
-        self.0.read_only
+    pub fn is_read_only(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.0.read_only.try_into().unwrap()
     }
 
     /// True if `writeBlocks` function writes data.
     #[must_use]
-    pub const fn is_write_caching(&self) -> bool {
-        self.0.write_caching
+    pub fn is_write_caching(&self) -> bool {
+        // Panic: Misbehaving UEFI impls are so unlikely; just fail
+        self.0.write_caching.try_into().unwrap()
     }
 
     /// The intrinsic block size of the device.

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -4,12 +4,12 @@ use crate::proto::unsafe_protocol;
 #[cfg(all(feature = "alloc", feature = "unstable"))]
 use alloc::alloc::Global;
 use uefi_raw::protocol::media::{LoadFile2Protocol, LoadFileProtocol};
-use uefi_raw::Boolean;
 #[cfg(feature = "alloc")]
 use {
     crate::{mem::make_boxed, proto::device_path::DevicePath, Result, StatusExt},
     alloc::boxed::Box,
     uefi::proto::BootPolicy,
+    uefi_raw::Boolean,
 };
 
 /// Load File Protocol.

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -4,6 +4,7 @@ use crate::proto::unsafe_protocol;
 #[cfg(all(feature = "alloc", feature = "unstable"))]
 use alloc::alloc::Global;
 use uefi_raw::protocol::media::{LoadFile2Protocol, LoadFileProtocol};
+use uefi_raw::Boolean;
 #[cfg(feature = "alloc")]
 use {
     crate::{mem::make_boxed, proto::device_path::DevicePath, Result, StatusExt},
@@ -141,7 +142,7 @@ impl LoadFile2 {
                 (self.0.load_file)(
                     this,
                     file_path.as_ffi_ptr().cast(),
-                    false, /* always false - see spec */
+                    Boolean::FALSE, /* always false - see spec */
                     &mut size,
                     buf.as_mut_ptr().cast(),
                 )

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -26,7 +26,7 @@ pub mod tcg;
 
 mod boot_policy;
 
-pub use boot_policy::{BootPolicy, BootPolicyError};
+pub use boot_policy::BootPolicy;
 pub use uefi_macros::unsafe_protocol;
 
 use crate::Identify;


### PR DESCRIPTION
This streamlines the existing usages of `u8` and `bool`. Note that `BootPolicy` from #1297 is seamlessly integrated into `u8` and `bool`.

# Steps to Undraft
- [x] close #1297 and rebase onto
- [x] reevaluate the discussion from https://github.com/rust-osdev/uefi-rs/pull/1326#discussion_r1715547228

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
