### PR TITLE
boot: Add freestanding locate_handle and find_handles

### DIFF
--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -15,12 +15,12 @@ pub fn test(st: &SystemTable<Boot>) {
     info!("Testing boot services");
     memory::test(bt);
     misc::test(st);
-    test_locate_handle_buffer(bt);
+    test_locate_handles(bt);
     test_load_image(bt);
 }
 
-fn test_locate_handle_buffer(bt: &BootServices) {
-    info!("Testing the `locate_handle_buffer` function");
+fn test_locate_handles(bt: &BootServices) {
+    info!("Testing the `locate_handle_buffer`/`find_handles` functions");
 
     {
         // search all handles
@@ -51,6 +51,11 @@ fn test_locate_handle_buffer(bt: &BootServices) {
             *handles,
             *boot::locate_handle_buffer(SearchType::ByProtocol(&Output::GUID)).unwrap()
         );
+
+        // Compare with `boot::find_handles`. This implicitly tests
+        // `boot::locate_handle` as well.
+        let handles_vec = boot::find_handles::<Output>().unwrap();
+        assert_eq!(*handles, handles_vec);
     }
 }
 


### PR DESCRIPTION
These are relatively old parts of the API. The BootServices::locate_handle method in particular doesn't quite match our current conventions. For the freestanding version, changed the input buffer to not be an `Option`, and changed the buffer-too-small case to be an error rather than returning `Ok(usize)`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
