### PR TITLE
Revert "uefi: Drop BootServices arg from device path <-> text conversions"

### DIFF
--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -49,6 +49,7 @@ fn print_image_path(boot_services: &BootServices) -> Result {
         loaded_image.file_path().expect("File path is not set");
     let image_device_path_text = device_path_to_text
         .convert_device_path_to_text(
+            boot_services,
             image_device_path,
             DisplayOnly(true),
             AllowShortcuts(false),

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -43,7 +43,7 @@ pub fn test(bt: &BootServices) {
             );
 
             let text = device_path_to_text
-                .convert_device_node_to_text(path, DisplayOnly(true), AllowShortcuts(false))
+                .convert_device_node_to_text(bt, path, DisplayOnly(true), AllowShortcuts(false))
                 .expect("Failed to convert device path to text");
             let text = &*text;
             info!("path name: {text}");
@@ -81,7 +81,7 @@ pub fn test(bt: &BootServices) {
 
         let path_components = device_path
             .node_iter()
-            .map(|node| node.to_string(DisplayOnly(false), AllowShortcuts(false)))
+            .map(|node| node.to_string(bt, DisplayOnly(false), AllowShortcuts(false)))
             .map(|str| str.unwrap().to_string())
             .collect::<Vec<_>>();
 
@@ -107,7 +107,7 @@ pub fn test(bt: &BootServices) {
 
         // Test that to_string works for device_paths
         let path = device_path
-            .to_string(DisplayOnly(false), AllowShortcuts(false))
+            .to_string(bt, DisplayOnly(false), AllowShortcuts(false))
             .unwrap()
             .to_string();
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -23,8 +23,6 @@ details of a significant change to the API in this release.
 
 ## Changed
 - **Breaking:** `uefi::helpers::init` no longer takes an argument.
-- **Breaking:** The conversion functions between device paths and text no longer
-  take a `BootServices` argument. The global system table is used instead.
 - The lifetime of the `SearchType` returned from
   `BootServices::register_protocol_notify` is now tied to the protocol GUID.
   The old `MemoryMap` was renamed to `MemoryMapOwned`.

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -90,8 +90,10 @@ use ptr_meta::Pointee;
 
 #[cfg(feature = "alloc")]
 use {
-    crate::boot::{self, OpenProtocolAttributes, OpenProtocolParams, ScopedProtocol, SearchType},
     crate::proto::device_path::text::{AllowShortcuts, DevicePathToText, DisplayOnly},
+    crate::table::boot::{
+        BootServices, OpenProtocolAttributes, OpenProtocolParams, ScopedProtocol, SearchType,
+    },
     crate::{CString16, Identify},
     alloc::borrow::ToOwned,
     alloc::boxed::Box,
@@ -230,13 +232,14 @@ impl DevicePathNode {
     #[cfg(feature = "alloc")]
     pub fn to_string(
         &self,
+        bs: &BootServices,
         display_only: DisplayOnly,
         allow_shortcuts: AllowShortcuts,
     ) -> Result<CString16, DevicePathToTextError> {
-        let to_text_protocol = open_text_protocol()?;
+        let to_text_protocol = open_text_protocol(bs)?;
 
         to_text_protocol
-            .convert_device_node_to_text(self, display_only, allow_shortcuts)
+            .convert_device_node_to_text(bs, self, display_only, allow_shortcuts)
             .map(|pool_string| {
                 let cstr16 = &*pool_string;
                 // Another allocation; pool string is dropped. This overhead
@@ -481,13 +484,14 @@ impl DevicePath {
     #[cfg(feature = "alloc")]
     pub fn to_string(
         &self,
+        bs: &BootServices,
         display_only: DisplayOnly,
         allow_shortcuts: AllowShortcuts,
     ) -> Result<CString16, DevicePathToTextError> {
-        let to_text_protocol = open_text_protocol()?;
+        let to_text_protocol = open_text_protocol(bs)?;
 
         to_text_protocol
-            .convert_device_path_to_text(self, display_only, allow_shortcuts)
+            .convert_device_path_to_text(bs, self, display_only, allow_shortcuts)
             .map(|pool_string| {
                 let cstr16 = &*pool_string;
                 // Another allocation; pool string is dropped. This overhead
@@ -874,17 +878,20 @@ impl core::error::Error for DevicePathToTextError {
 /// Helper function to open the [`DevicePathToText`] protocol using the boot
 /// services.
 #[cfg(feature = "alloc")]
-fn open_text_protocol() -> Result<ScopedProtocol<DevicePathToText>, DevicePathToTextError> {
-    let &handle = boot::locate_handle_buffer(SearchType::ByProtocol(&DevicePathToText::GUID))
+fn open_text_protocol(
+    bs: &BootServices,
+) -> Result<ScopedProtocol<DevicePathToText>, DevicePathToTextError> {
+    let &handle = bs
+        .locate_handle_buffer(SearchType::ByProtocol(&DevicePathToText::GUID))
         .map_err(DevicePathToTextError::CantLocateHandleBuffer)?
         .first()
         .ok_or(DevicePathToTextError::NoHandle)?;
 
     unsafe {
-        boot::open_protocol::<DevicePathToText>(
+        bs.open_protocol::<DevicePathToText>(
             OpenProtocolParams {
                 handle,
-                agent: boot::image_handle(),
+                agent: bs.image_handle(),
                 controller: None,
             },
             OpenProtocolAttributes::GetProtocol,


### PR DESCRIPTION
Reverts rust-osdev/uefi-rs#1327 (per https://github.com/rust-osdev/uefi-rs/issues/893#issuecomment-2286637186)