### PR TITLE
ci: cancel obsolete runs automatically + streamline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test_aarch64:
     name: Integration Test (AArch64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
         timeout-minutes: 4
   test_ia32:
     name: Integration Test (IA-32)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,9 @@ on:
     - cron: '0 0 * * 0-6'
 env:
   RUSTFLAGS: -D warnings
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   test_aarch64:
     name: Integration Test (AArch64)


### PR DESCRIPTION
- cancel obsolete runs automatically
- streamline CI file

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
