### PR TITLE
uefi-raw: Add explicit padding field for MemoryDescriptor

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi-raw - [Unreleased]
 
+## Changed
+- `MemoryDescriptor` now has an explicit padding field, allowing trivial
+  memory-safe serialization and deserialization
 
 # uefi-raw - 0.8.0 (2024-09-09)
 

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -20,6 +20,11 @@
     unused
 )]
 
+// Useful for convenience in tests, such as `dbg!`
+#[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate std;
+
 #[macro_use]
 mod enums;
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //!     Status::SUCCESS
 //! }
-//! # extern crate std;
+//! # extern crate std; // For panic handler
 //! ```
 //!
 //! Please find more info in our [Rust UEFI Book].
@@ -234,6 +234,11 @@ extern crate alloc;
 extern crate self as uefi;
 #[macro_use]
 extern crate uefi_raw;
+
+// Useful for convenience in tests, such as `dbg!`
+#[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate std;
 
 #[macro_use]
 pub mod data_types;

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -432,6 +432,7 @@ mod tests {
     const BASE_MMAP_UNSORTED: [MemoryDescriptor; 3] = [
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            padding0: 0,
             phys_start: 0x3000,
             virt_start: 0x3000,
             page_count: 1,
@@ -439,6 +440,7 @@ mod tests {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            padding0: 0,
             phys_start: 0x2000,
             virt_start: 0x2000,
             page_count: 1,
@@ -446,6 +448,7 @@ mod tests {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            padding0: 0,
             phys_start: 0x1000,
             virt_start: 0x1000,
             page_count: 1,

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -131,6 +131,7 @@ mod tests_mmap_artificial {
 
         const BASE: MemoryDescriptor = MemoryDescriptor {
             ty: TY,
+            padding0: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,
@@ -169,6 +170,7 @@ mod tests_mmap_artificial {
 
         const BASE: MemoryDescriptor = MemoryDescriptor {
             ty: TY,
+            padding0: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,
@@ -278,6 +280,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
@@ -288,6 +291,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::BOOT_SERVICES_DATA,
@@ -298,6 +302,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
@@ -308,6 +313,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
@@ -318,6 +324,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
@@ -328,6 +335,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
@@ -338,6 +346,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
@@ -348,6 +357,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
@@ -358,6 +368,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
@@ -368,6 +379,7 @@ mod tests_mmap_real {
                     | MemoryAttribute::WRITE_COMBINE
                     | MemoryAttribute::WRITE_THROUGH
                     | MemoryAttribute::WRITE_BACK,
+                ..Default::default()
             },
         ];
         assert_eq!(entries.as_slice(), &expected);

--- a/uefi/tests/memory_map.rs
+++ b/uefi/tests/memory_map.rs
@@ -12,6 +12,7 @@ fn parse_boot_information_efi_mmap() {
             virt_start: 0x3000,
             page_count: 1,
             att: MemoryAttribute::WRITE_BACK,
+            ..Default::default()
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
@@ -19,6 +20,7 @@ fn parse_boot_information_efi_mmap() {
             virt_start: 0x2000,
             page_count: 1,
             att: MemoryAttribute::WRITE_BACK,
+            ..Default::default()
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
@@ -26,6 +28,7 @@ fn parse_boot_information_efi_mmap() {
             virt_start: 0x1000,
             page_count: 1,
             att: MemoryAttribute::WRITE_BACK,
+            ..Default::default()
         },
     ];
     let map_size = mmap_source.len() * desc_size;

--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -354,7 +354,13 @@ fn check_item(item: &Item, src: &Path) -> Result<(), Error> {
             // Allow.
         }
         item => {
-            return Err(Error::new(ErrorKind::ForbiddenItemKind, src, item));
+            let allowed_exception = match item {
+                Item::ExternCrate(x) => x.ident == "std",
+                _ => false,
+            };
+            if !allowed_exception {
+                return Err(Error::new(ErrorKind::ForbiddenItemKind, src, item));
+            }
         }
     }
 


### PR DESCRIPTION
~~IMHO, having implicit padding bytes in Low-Level types (used for Casting etc) is a bad idea. When you cast a `&[MemoryDescriptor]` to `&[u8]`, Miri complains about uninitialized bytes.~~

~~Exporting one (or multiple) public `_pad0` fields however is also not nice. So, we should identify all structs where this is relevant and come up with a solution. Perhaps, lets move to constructor-based types with private fields? This is breaking, how-ever.~~

By convention, structs having a C representation should be explicit with their
in-between padding fields. This allows users **memory-safe trivial serialization
and deserialization** by accessing the underlying memory as byte slice. Without
this fields being explicit, Miri complains about uninitialized memory accesses,
which is UB.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
