### PR TITLE
uefi: Inline the template example into lib.rs doc

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -13,7 +13,17 @@
 //! `uefi` crate:
 //!
 //! ```ignore
-#![doc = include_str!("../../template/src/main.rs")]
+//! #![no_main]
+//! #![no_std]
+//!
+//! use uefi::prelude::*;
+//!
+//! #[entry]
+//! fn main(_handle: Handle, system_table: SystemTable<Boot>) -> Status {
+//!     uefi::helpers::init().unwrap();
+//!
+//!     Status::SUCCESS
+//! }
 //! ```
 //!
 //! Please find more info in our [Rust UEFI Book].


### PR DESCRIPTION
This include is blocking the release job:
https://github.com/rust-osdev/uefi-rs/pull/1330#issuecomment-2299476889

For now, just inline the example so that we can release. Filed https://github.com/rust-osdev/uefi-rs/issues/1337 to track a better fix.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
