### PR TITLE
Update the uefi::allocator module to use the global system table

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -12,6 +12,9 @@ how to integrate the `uefi` crate into them.
   take a `BootServices` argument. The global system table is used instead.
 - **Breaking:** `GraphicsOutput::modes` no longer takes a `BootServices`
   argument. The global system table is used instead.
+- `allocator::init` and `allocator::exit_boot_services` have been
+  deprecated. These functions are now no-ops. The allocator now internally uses
+  the global system table.
 
 
 # uefi - 0.31.0 (2024-08-21)

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -3,13 +3,9 @@
 //! If the `global_allocator` feature is enabled, the [`Allocator`] will be used
 //! as the global Rust allocator.
 //!
-//! # Usage
-//!
-//! Call the `init` function with a reference to the boot services table.
-//! Failure to do so before calling a memory allocating function will panic.
-//!
-//! Call the `exit_boot_services` function before exiting UEFI boot services.
-//! Failure to do so will turn subsequent allocation into undefined behaviour.
+//! This allocator can only be used while boot services are active. If boot
+//! services are not active, `alloc` will return a null pointer, and `dealloc`
+//! will panic.
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr::{self, NonNull};
@@ -20,18 +16,13 @@ use crate::mem::memory_map::MemoryType;
 use crate::proto::loaded_image::LoadedImage;
 use crate::table::{Boot, SystemTable};
 
-/// Initializes the allocator.
-///
-/// # Safety
-///
-/// This function is unsafe because you _must_ make sure that exit_boot_services
-/// will be called when UEFI boot services will be exited.
-#[allow(unused_unsafe)]
+/// Deprecated; this function is now a no-op.
+#[deprecated = "this function is now a no-op"]
+#[allow(unused_unsafe, clippy::missing_safety_doc)]
 pub unsafe fn init(_: &mut SystemTable<Boot>) {}
 
-/// Notify the allocator library that boot services are not safe to call anymore
-///
-/// You must arrange for this function to be called on exit from UEFI boot services
+/// Deprecated; this function is now a no-op.
+#[deprecated = "this function is now a no-op"]
 #[allow(clippy::missing_const_for_fn)]
 pub fn exit_boot_services() {}
 

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -66,6 +66,10 @@ unsafe impl GlobalAlloc for Allocator {
     /// of type [`MemoryType::LOADER_DATA`] for UEFI applications, [`MemoryType::BOOT_SERVICES_DATA`]
     /// for UEFI boot drivers and [`MemoryType::RUNTIME_SERVICES_DATA`] for UEFI runtime drivers.
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if !boot::are_boot_services_active() {
+            return ptr::null_mut();
+        }
+
         let size = layout.size();
         let align = layout.align();
         let memory_type = MemoryType(MEMORY_TYPE.load(Ordering::Acquire));

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -60,6 +60,18 @@ pub unsafe fn set_image_handle(image_handle: Handle) {
     IMAGE_HANDLE.store(image_handle.as_ptr(), Ordering::Release);
 }
 
+/// Return true if boot services are active, false otherwise.
+pub(crate) fn are_boot_services_active() -> bool {
+    let Some(st) = table::system_table_raw() else {
+        return false;
+    };
+
+    // SAFETY: valid per requirements of `set_system_table`.
+    let st = unsafe { st.as_ref() };
+
+    !st.boot_services.is_null()
+}
+
 fn boot_services_raw_panicking() -> NonNull<uefi_raw::table::boot::BootServices> {
     let st = table::system_table_raw_panicking();
     // SAFETY: valid per requirements of `set_system_table`.

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -48,26 +48,18 @@ pub fn system_table() -> SystemTable<Boot> {
 /// Initialize all helpers defined in [`uefi::helpers`] whose Cargo features
 /// are activated.
 ///
-/// This must be called as early as possible, before trying to use logging or
-/// memory allocation capabilities.
+/// This must be called as early as possible, before trying to use logging.
 ///
 /// **PLEASE NOTE** that these helpers are meant for the pre exit boot service
 /// epoch. Limited functionality might work after exiting them, such as logging
 /// to the debugcon device.
 #[allow(clippy::missing_const_for_fn)]
 pub fn init() -> Result<()> {
-    // Setup logging and memory allocation
-
+    // Set up logging.
     #[cfg(feature = "logger")]
     unsafe {
         let mut st = table::system_table_boot().expect("boot services are not active");
         logger::init(&mut st);
-    }
-
-    #[cfg(feature = "global_allocator")]
-    unsafe {
-        let mut st = table::system_table_boot().expect("boot services are not active");
-        crate::allocator::init(&mut st);
     }
 
     Ok(())
@@ -77,7 +69,4 @@ pub fn init() -> Result<()> {
 pub(crate) fn exit() {
     #[cfg(feature = "logger")]
     logger::disable();
-
-    #[cfg(feature = "global_allocator")]
-    crate::allocator::exit_boot_services();
 }


### PR DESCRIPTION
Explicitly initializing and shutting down the allocator is no longer needed, since all the internal operations use the global system table now. Mark `allocator::init` and `allocator::exit_boot_services` as deprecated, and update `uefi::helper` to stop calling those functions as well.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
