### PR TITLE
uefi: Fix compilation of minimal example

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -12,7 +12,7 @@
 //! Minimal example for an UEFI application using functionality of the
 //! `uefi` crate:
 //!
-//! ```ignore
+//! ```no_run
 //! #![no_main]
 //! #![no_std]
 //!
@@ -24,6 +24,7 @@
 //!
 //!     Status::SUCCESS
 //! }
+//! # extern crate std;
 //! ```
 //!
 //! Please find more info in our [Rust UEFI Book].


### PR DESCRIPTION
This turns out to be easier than I expected: just add `extern crate std;` so that the panic handler and global allocator are set. The line is hidden so that it doesn't appear in the rendered docs.

This allows the code block to `no_run` instead of `ignore`, so it will be compiled (but not run, so there's no `main` linker error), and that also has the nice side effect of removing the orange `!` warning bubble in the rendered docs.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
