### PR TITLE
Revert "ci: check if crate can be packaged"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,16 +127,6 @@ jobs:
         # library packages. Note that xtask isn't used or built here; since it's
         # just a dev tool we don't care about the MSRV for that package.
         run: cargo build --target x86_64-unknown-uefi -p uefi-test-runner
-  # Tests that the published crates keep being package-able (thus, releasable).
-  package:
-    name: Package Crates
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: cargo package -p uefi -p uefi-raw -p uefi-macros
   # This job requires the nightly channel, but keep it as a separate job from
   # `nightly_channel` because it takes a while to run.
   build_feature_permutations:


### PR DESCRIPTION
This reverts commit fc5c0a98c7f19acb9ccada14cd6a63d4c85e9b62.

When `cargo package` builds `uefi`, it does so with dependencies from crates.io. That causes a problem if `uefi` depends on some not-yet-released API changes in `uefi-raw` or `uefi-macros`. For example, see: https://github.com/rust-osdev/uefi-rs/pull/1383#issuecomment-2315661178

I couldn't find a way to force it to use local deps, so revert the job for now.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
