### PR TITLE
uefi: Clean up imports of uefi::table::runtime

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -19,7 +19,9 @@
 //!
 //! [`proto`]: crate::proto
 
-pub use uefi_raw::table::boot::{EventType, MemoryAttribute, MemoryDescriptor, MemoryType, Tpl, PAGE_SIZE};
+pub use uefi_raw::table::boot::{
+    EventType, MemoryAttribute, MemoryDescriptor, MemoryType, Tpl, PAGE_SIZE,
+};
 
 use crate::data_types::PhysicalAddress;
 use crate::mem::memory_map::{MemoryMapBackingMemory, MemoryMapKey, MemoryMapMeta, MemoryMapOwned};

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -1,6 +1,6 @@
 use super::FileAttribute;
 use crate::data_types::Align;
-use crate::table::runtime::Time;
+use crate::runtime::Time;
 use crate::{CStr16, Char16, Guid, Identify};
 use core::ffi::c_void;
 use core::fmt::{self, Display, Formatter};
@@ -426,7 +426,7 @@ impl FileProtocolInfo for FileSystemVolumeLabel {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::table::runtime::{Daylight, Time, TimeParams};
+    use crate::runtime::{Daylight, Time, TimeParams};
     use crate::CString16;
     use alloc::vec;
 

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -348,7 +348,7 @@ pub enum FileMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::table::runtime::Time;
+    use crate::runtime::Time;
     use crate::{CString16, Guid, Identify};
     use ::alloc::vec;
     use uefi_raw::protocol::file_system::FileProtocolRevision;


### PR DESCRIPTION
Use `uefi::runtime` instead.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
