### PR TITLE
Fix unused warnings if log-debugcon is not enabled

### DIFF
--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -46,16 +46,25 @@ pub fn disable() {
 /// cloud-hypervisor.
 ///
 /// More info: <https://phip1611.de/blog/how-to-use-qemus-debugcon-feature/>
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "log-debugcon"
+))]
 #[derive(Copy, Clone, Debug)]
 struct DebugconWriter;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "log-debugcon"
+))]
 impl DebugconWriter {
     const IO_PORT: u16 = 0xe9;
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "log-debugcon"
+))]
 impl core::fmt::Write for DebugconWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for &byte in s.as_bytes() {


### PR DESCRIPTION
Also update xtask so that the `--feature-permutations` test catches this.
## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
