### PR TITLE
uefi: Add panic doc to uefi::helpers::init

### DIFF
--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -55,6 +55,10 @@ pub fn system_table() -> SystemTable<Boot> {
 /// **PLEASE NOTE** that these helpers are meant for the pre exit boot service
 /// epoch. Limited functionality might work after exiting them, such as logging
 /// to the debugcon device.
+///
+/// # Panics
+///
+/// This function may panic if called more than once.
 #[allow(clippy::missing_const_for_fn)]
 pub fn init() -> Result<()> {
     // Set up logging.


### PR DESCRIPTION
This function may panic if called more than once, because `log::set_logger` panics if called more than once. Document this panic.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
