### PR TITLE
uefi: Add uefi::runtime::variable_exists

### DIFF
--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -73,8 +73,12 @@ fn test_variables(rt: &RuntimeServices) {
 
 /// Test the variable functions in `uefi::runtime`.
 fn test_variables_freestanding() {
+    assert!(!runtime::variable_exists(NAME, VENDOR).unwrap());
+
     // Create the test variable.
     runtime::set_variable(NAME, VENDOR, ATTRS, VALUE).expect("failed to set variable");
+
+    assert!(runtime::variable_exists(NAME, VENDOR).unwrap());
 
     // Test `get_variable` with too small of a buffer.
     let mut buf = [0u8; 0];
@@ -106,6 +110,7 @@ fn test_variables_freestanding() {
 
     // Delete the variable and verify it can no longer be read.
     runtime::delete_variable(NAME, VENDOR).expect("failed to delete variable");
+    assert!(!runtime::variable_exists(NAME, VENDOR).unwrap());
     assert_eq!(
         runtime::get_variable(NAME, VENDOR, &mut buf)
             .unwrap_err()

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -11,6 +11,7 @@ how to integrate the `uefi` crate into them.
 - Added `Handle::new`.
 - Added the `uefi::boot`, `uefi::runtime`, and `uefi::system` modules to the
   prelude.
+- Added `runtime::variable_exists`.
 
 ## Changed
 - The `BootServices`, `RuntimeServices`, and `SystemTable` structs have been


### PR DESCRIPTION
This is a slightly more convenient alternative to `get_variable` when you only want to know if a variable exists. Useful if you want to set a variable only if it is not already set.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
