### PR TITLE
Fix handling of a null interface pointer in `boot::open_protocol`

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -10,6 +10,7 @@ details of the deprecated items that were removed in this release.
 - **Breaking:** `FileSystem` no longer has a lifetime parameter, and the
   deprecated conversion from `uefi::table::boot::ScopedProtocol` has been
   removed.
+- Fixed `boot::open_protocol` to properly handle a null interface pointer.
 
 
 # uefi - 0.32.0 (2024-09-09)

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -969,9 +969,16 @@ pub unsafe fn open_protocol<P: ProtocolPointer + ?Sized>(
         Handle::opt_to_ptr(params.controller),
         attributes as u32,
     )
-    .to_result_with_val(|| ScopedProtocol {
-        interface: NonNull::new(P::mut_ptr_from_ffi(interface)),
-        open_params: params,
+    .to_result_with_val(|| {
+        let interface = if interface.is_null() {
+            None
+        } else {
+            NonNull::new(P::mut_ptr_from_ffi(interface))
+        };
+        ScopedProtocol {
+            interface,
+            open_params: params,
+        }
     })
 }
 


### PR DESCRIPTION
Also update `test_load_image` to use the freestanding functions, so that this case is tested (`LoadedImageDevicePath` is loaded with a null interface pointer).

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
