### PR TITLE
uefi: Add CStr16 conversions from slices with interior nuls

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -5,6 +5,7 @@ details of the deprecated items that were removed in this release.
 
 ## Added
 - Impl `PartialEq` and `Eq` for `GptPartitionEntry`.
+- Added `CStr16::from_u16_until_nul` and `CStr16::from_char16_until_nul`.
 
 ## Changed
 - **Breaking:** Deleted the deprecated `BootServices`, `RuntimeServices`, and


### PR DESCRIPTION
This is modeled after `CStr::from_bytes_until_nul`, which was added in Rust 1.69. It's often the case that you have a slice of data containing a string, but the buffer size is larger than the string; these new methods make that case easy to handle.

[1]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_until_nul

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
