### PR TITLE
Increase MSRV to 1.79

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70"
+channel = "1.79"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 keywords = ["uefi", "efi"]
 license = "MPL-2.0"
 repository = "https://github.com/rust-osdev/uefi-rs"
-rust-version = "1.70"
+rust-version = "1.79"
 
 [workspace.dependencies]
 bitflags = "2.0.0"

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+## Changed
+- MSRV increased to 1.79.
+
 
 # uefi - 0.33.0 (2024-10-23)
 

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -57,7 +57,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     /// Returns the element at `index`, or `None` if the `index` is out
     /// of bounds.
     #[must_use]
-    pub fn get(&self, index: usize) -> Option<T> {
+    pub const fn get(&self, index: usize) -> Option<T> {
         if index < self.len {
             Some(unsafe { self.data.add(index).read_unaligned() })
         } else {

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -65,9 +65,8 @@
 //! can't test all possible hardware/firmware/platform combinations in CI.
 //!
 //! ## MSRV
-//! <!-- Keep in Sync with README! -->
 //!
-//! The minimum supported Rust version is currently 1.70.
+//! The minimum supported Rust version is currently 1.79.
 //! Our policy is to support at least the past two stable releases.
 //!
 //! # API/User Documentation, Documentation Structure, and other Resources

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -324,7 +324,7 @@ impl MemoryMapBackingMemory {
 
     /// Returns a slice to the underlying memory.
     #[must_use]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         unsafe { self.0.as_ref() }
     }
 

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -41,7 +41,7 @@ impl ComponentName1 {
     /// English is encoded as "eng".
     ///
     /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
-    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    pub const fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V1)
     }
 
@@ -108,7 +108,7 @@ impl ComponentName2 {
     /// as "en".
     ///
     /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
-    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    pub const fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V2)
     }
 
@@ -266,7 +266,7 @@ pub struct LanguageIter<'a> {
 }
 
 impl<'a> LanguageIter<'a> {
-    fn new(
+    const fn new(
         languages: *const u8,
         kind: LanguageIterKind,
     ) -> core::result::Result<Self, LanguageError> {


### PR DESCRIPTION
Mark a few new functions `const` to satisfy clippy lints. Also drop the "Keep in Sync with README!" comment for the MSRV doc; it's not in the readme anymore.

This upgrade will allow using various `core` improvements that have been stabilized since 1.70, including a number of `ptr` conveniences like `byte_add`, `is_aligned`, and `from_ref`/`from_mut` that make unsafe code easier to write.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
