### PR TITLE
Use ovmf-prebuilt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "fs-err",
  "heck",
  "itertools",
+ "log",
  "lzma-rs",
  "mbrman",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,13 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "os_info"
-version = "3.8.2"
+name = "ovmf-prebuilt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+checksum = "e0839ec8849e7a5443268f3369458c2dadc409ef807ab10b7f77d4bb9bf1708d"
 dependencies = [
  "log",
- "windows-sys 0.52.0",
+ "lzma-rs",
+ "sha2",
+ "tar",
+ "ureq",
 ]
 
 [[package]]
@@ -1156,19 +1159,15 @@ dependencies = [
  "heck",
  "itertools",
  "log",
- "lzma-rs",
  "mbrman",
  "nix",
- "os_info",
+ "ovmf-prebuilt",
  "proc-macro2",
  "quote",
  "regex",
  "serde_json",
- "sha2",
  "syn 2.0.87",
- "tar",
  "tempfile",
- "ureq",
  "walkdir",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,17 +13,13 @@ fs-err = "3.0.0"
 heck = "0.5.0"
 itertools = "0.13.0"
 log.workspace = true
-lzma-rs = "0.3.0"
 mbrman = "0.5.1"
 nix = { version = "0.29.0", default-features = false, features = ["fs"] }
-os_info = { version = "3.6.0", default-features = false }
+ovmf-prebuilt = "0.2.0"
 proc-macro2 = { version = "1.0.46", features = ["span-locations"] }
 quote = "1.0.21"
 regex = "1.10.2"
 serde_json = "1.0.73"
-sha2 = "0.10.6"
 syn = { version = "2.0.0", features = ["full"] }
-tar = "0.4.38"
 tempfile = "3.6.0"
-ureq = "2.8.0"
 walkdir = "2.4.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ fatfs = { version = "0.3.6", default-features = false, features = ["alloc", "std
 fs-err = "3.0.0"
 heck = "0.5.0"
 itertools = "0.13.0"
+log.workspace = true
 lzma-rs = "0.3.0"
 mbrman = "0.5.1"
 nix = { version = "0.29.0", default-features = false, features = ["fs"] }
@@ -24,5 +25,5 @@ sha2 = "0.10.6"
 syn = { version = "2.0.0", features = ["full"] }
 tar = "0.4.38"
 tempfile = "3.6.0"
-walkdir = "2.4.0"
 ureq = "2.8.0"
+walkdir = "2.4.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use arch::UefiArch;
 use cargo::{Cargo, CargoAction, Feature, Package, TargetTypes};
 use clap::Parser;
 use itertools::Itertools;
+use log::{LevelFilter, Metadata, Record};
 use opt::{Action, BuildOpt, ClippyOpt, CovOpt, DocOpt, Opt, QemuOpt, TpmVersion};
 use std::process::Command;
 use util::run_cmd;
@@ -322,8 +323,32 @@ fn has_cmd(target_cmd: &str) -> bool {
     run_cmd(cmd).is_ok()
 }
 
+fn install_logger() {
+    struct Logger;
+
+    impl log::Log for Logger {
+        fn enabled(&self, _: &Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &Record) {
+            println!("[{}] {}", record.level(), record.args());
+        }
+
+        fn flush(&self) {}
+    }
+
+    static LOGGER: Logger = Logger;
+
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(LevelFilter::Info))
+        .unwrap();
+}
+
 fn main() -> Result<()> {
     let opt = Opt::parse();
+
+    install_logger();
 
     match &opt.action {
         Action::Build(build_opt) => build(build_opt),


### PR DESCRIPTION
This simplifies xtask/qemu.rs a bit.

Also install a simple logger in `main`, so that download messages from ovmf-prebuilt get printed.

For now I've kept the same edk2 tag, because the latest version is crashing QEMU in our CI. I'll follow up on that later to figure out why.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
