### PR TITLE
uefi: Deny clippy::ref_as_ptr

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -790,7 +790,7 @@ pub fn locate_handle<'buf>(
         SearchType::ByRegisterNotify(registration) => {
             (1, ptr::null(), registration.0.as_ptr().cast_const())
         }
-        SearchType::ByProtocol(guid) => (2, guid as *const Guid, ptr::null()),
+        SearchType::ByProtocol(guid) => (2, ptr::from_ref(guid), ptr::null()),
     };
 
     let mut buffer_size = buffer.len() * mem::size_of::<Handle>();
@@ -829,7 +829,7 @@ pub fn locate_handle_buffer(search_ty: SearchType) -> Result<HandleBuffer> {
         SearchType::ByRegisterNotify(registration) => {
             (1, ptr::null(), registration.0.as_ptr().cast_const())
         }
-        SearchType::ByProtocol(guid) => (2, guid as *const _, ptr::null()),
+        SearchType::ByProtocol(guid) => (2, ptr::from_ref(guid), ptr::null()),
     };
 
     let mut num_handles: usize = 0;

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -8,7 +8,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
-use core::ops;
+use core::{ops, ptr};
 
 /// Error returned by [`CString16::try_from::<&str>`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -204,7 +204,7 @@ impl ops::Deref for CString16 {
     type Target = CStr16;
 
     fn deref(&self) -> &CStr16 {
-        unsafe { &*(self.0.as_slice() as *const [Char16] as *const CStr16) }
+        unsafe { &*(ptr::from_ref(self.0.as_slice()) as *const CStr16) }
     }
 }
 

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -5,7 +5,7 @@ use core::borrow::Borrow;
 use core::ffi::CStr;
 use core::fmt::{self, Display, Formatter};
 use core::mem::MaybeUninit;
-use core::slice;
+use core::{ptr, slice};
 
 #[cfg(feature = "alloc")]
 use super::CString16;
@@ -173,7 +173,7 @@ impl CStr8 {
     /// null-terminated string, with no interior null bytes.
     #[must_use]
     pub const unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
-        &*(chars as *const [u8] as *const Self)
+        &*(ptr::from_ref(chars) as *const Self)
     }
 
     /// Returns the inner pointer to this CStr8.
@@ -186,7 +186,7 @@ impl CStr8 {
     /// character.
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8] {
-        unsafe { &*(&self.0 as *const [Char8] as *const [u8]) }
+        unsafe { &*(ptr::from_ref(&self.0) as *const [u8]) }
     }
 }
 
@@ -407,7 +407,7 @@ impl CStr16 {
     /// null-terminated string, with no interior null characters.
     #[must_use]
     pub const unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
-        &*(codes as *const [u16] as *const Self)
+        &*(ptr::from_ref(codes) as *const Self)
     }
 
     /// Creates a `&CStr16` from a [`Char16`] slice, stopping at the first nul character.
@@ -561,7 +561,7 @@ impl CStr16 {
     /// Converts this C string to a u16 slice containing the trailing null.
     #[must_use]
     pub const fn to_u16_slice_with_nul(&self) -> &[u16] {
-        unsafe { &*(&self.0 as *const [Char16] as *const [u16]) }
+        unsafe { &*(ptr::from_ref(&self.0) as *const [u16]) }
     }
 
     /// Returns an iterator over this C string

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -4,6 +4,7 @@
 use crate::fs::path::{PathBuf, SEPARATOR};
 use crate::{CStr16, CString16};
 use core::fmt::{Display, Formatter};
+use core::ptr;
 
 /// A path similar to the `Path` of the standard library, but based on
 /// [`CStr16`] strings and [`SEPARATOR`] as separator.
@@ -16,7 +17,7 @@ impl Path {
     /// Constructor.
     #[must_use]
     pub fn new<S: AsRef<CStr16> + ?Sized>(s: &S) -> &Self {
-        unsafe { &*(s.as_ref() as *const CStr16 as *const Self) }
+        unsafe { &*(ptr::from_ref(s.as_ref()) as *const Self) }
     }
 
     /// Returns the underlying string.

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -220,6 +220,7 @@
     clippy::missing_const_for_fn,
     clippy::must_use_candidate,
     clippy::ptr_as_ptr,
+    clippy::ref_as_ptr,
     clippy::use_self,
     missing_debug_implementations,
     missing_docs,

--- a/uefi/src/polyfill.rs
+++ b/uefi/src/polyfill.rs
@@ -2,6 +2,7 @@
 //! behind unstable features.
 
 use core::mem::MaybeUninit;
+use core::ptr;
 #[cfg(feature = "alloc")]
 use {alloc::vec::Vec, core::mem::ManuallyDrop};
 
@@ -9,7 +10,7 @@ use {alloc::vec::Vec, core::mem::ManuallyDrop};
 ///
 /// See <https://github.com/rust-lang/rust/issues/63569>.
 pub const unsafe fn maybe_uninit_slice_assume_init_ref<T>(s: &[MaybeUninit<T>]) -> &[T] {
-    unsafe { &*(s as *const [MaybeUninit<T>] as *const [T]) }
+    unsafe { &*(ptr::from_ref(s) as *const [T]) }
 }
 
 /// Polyfill for the unstable `MaybeUninit::slice_as_mut_ptr` function.

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -134,7 +134,7 @@ impl GraphicsOutput {
                     self.check_framebuffer_region((dest_x, dest_y), (width, height));
                     (self.0.blt)(
                         &mut self.0,
-                        &color as *const _ as *mut _,
+                        ptr::from_ref(&color) as *mut _,
                         GraphicsOutputBltOperation::BLT_VIDEO_FILL,
                         0,
                         0,

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -169,7 +169,7 @@ pub trait File: Sized {
     /// * [`uefi::Status::VOLUME_FULL`]
     /// * [`uefi::Status::BAD_BUFFER_SIZE`]
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
-        let info_ptr = (info as *const Info).cast::<c_void>();
+        let info_ptr = ptr::from_ref(info).cast::<c_void>();
         let info_size = mem::size_of_val(info);
         unsafe { (self.imp().set_info)(self.imp(), &Info::GUID, info_size, info_ptr).to_result() }
     }

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -173,7 +173,7 @@ impl BaseCode {
     ) -> Result<u64> {
         let (buffer_ptr, mut buffer_size, dont_use_buffer) = if let Some(buffer) = buffer {
             let buffer_size = u64::try_from(buffer.len()).unwrap();
-            ((&mut buffer[0] as *mut u8).cast(), buffer_size, false)
+            (buffer.as_mut_ptr().cast(), buffer_size, false)
         } else {
             (null_mut(), 0, true)
         };
@@ -203,7 +203,7 @@ impl BaseCode {
         overwrite: bool,
         buffer: &[u8],
     ) -> Result {
-        let buffer_ptr = (&buffer[0] as *const u8 as *mut u8).cast();
+        let buffer_ptr = buffer.as_ptr().cast_mut().cast();
         let mut buffer_size = u64::try_from(buffer.len()).expect("buffer length should fit in u64");
 
         unsafe {
@@ -231,7 +231,7 @@ impl BaseCode {
         buffer: &'a mut [u8],
     ) -> Result<impl Iterator<Item = core::result::Result<TftpFileInfo<'a>, ReadDirParseError>> + 'a>
     {
-        let buffer_ptr = (&buffer[0] as *const u8 as *mut u8).cast();
+        let buffer_ptr = buffer.as_mut_ptr().cast();
         let mut buffer_size = u64::try_from(buffer.len()).expect("buffer length should fit in u64");
 
         let status = unsafe {
@@ -334,7 +334,7 @@ impl BaseCode {
     ) -> Result<u64> {
         let (buffer_ptr, mut buffer_size, dont_use_buffer) = if let Some(buffer) = buffer {
             let buffer_size = u64::try_from(buffer.len()).unwrap();
-            ((&mut buffer[0] as *mut u8).cast(), buffer_size, false)
+            (buffer.as_mut_ptr().cast(), buffer_size, false)
         } else {
             (null_mut(), 0, true)
         };
@@ -364,7 +364,7 @@ impl BaseCode {
         info: &MtftpInfo,
     ) -> Result<impl Iterator<Item = core::result::Result<MtftpFileInfo<'a>, ReadDirParseError>> + 'a>
     {
-        let buffer_ptr = (&buffer[0] as *const u8 as *mut u8).cast();
+        let buffer_ptr = buffer.as_mut_ptr().cast();
         let mut buffer_size = u64::try_from(buffer.len()).expect("buffer length should fit in u64");
 
         let status = unsafe {
@@ -464,7 +464,7 @@ impl BaseCode {
         let header_size_tmp;
         let (header_size, header_ptr) = if let Some(header) = header {
             header_size_tmp = header.len();
-            (Some(&header_size_tmp), (&header[0] as *const u8).cast())
+            (Some(&header_size_tmp), header.as_ptr().cast())
         } else {
             (None, null())
         };
@@ -481,7 +481,7 @@ impl BaseCode {
                 header_size,
                 header_ptr,
                 &buffer.len(),
-                (&buffer[0] as *const u8).cast(),
+                buffer.as_ptr().cast(),
             )
         }
         .to_result()
@@ -502,7 +502,7 @@ impl BaseCode {
         let header_size_tmp;
         let (header_size, header_ptr) = if let Some(header) = header {
             header_size_tmp = header.len();
-            (Some(&header_size_tmp), (&mut header[0] as *mut u8).cast())
+            (Some(&header_size_tmp), header.as_mut_ptr().cast())
         } else {
             (None, null_mut())
         };
@@ -520,7 +520,7 @@ impl BaseCode {
                 header_size,
                 header_ptr,
                 &mut buffer_size,
-                (&mut buffer[0] as *mut u8).cast(),
+                buffer.as_mut_ptr().cast(),
             )
         };
         status.to_result_with_val(|| buffer_size)


### PR DESCRIPTION
This detects casts from a reference to a pointer that can be expressed more safely, e.g. with `ptr::as_ref` or `[slice].as_ptr`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
