### PR TITLE
xtask: Update OVMF prebuilts

### DIFF
--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -19,10 +19,10 @@ use tempfile::TempDir;
 use {std::fs::Permissions, std::os::unix::fs::PermissionsExt};
 
 /// Name of the ovmf-prebuilt release tag.
-const OVMF_PREBUILT_TAG: &str = "edk2-stable202311-r2";
+const OVMF_PREBUILT_TAG: &str = "edk2-stable202402-r1";
 
 /// SHA-256 hash of the release tarball.
-const OVMF_PREBUILT_HASH: &str = "4a7d01b7dc6b0fdbf3a0e17dacd364b772fb5b712aaf64ecf328273584185ca0";
+const OVMF_PREBUILT_HASH: &str = "91f3148ef146794241c77810a49cfa3e925c83eb55c5cc90f34718cc1b10e9eb";
 
 /// Directory into which the prebuilts will be download (relative to the repo root).
 const OVMF_PREBUILT_DIR: &str = "target/ovmf";


### PR DESCRIPTION
edk2-stable202402 is the latest release that passes CI. Starting in edk2-stable202405, the aarch64 job fails early in boot with a "Synchronous Exception" error.

This seems likely to be an issue with the version of QEMU installed on the Github runner, as newer versions of OVMF work fine in my local testing.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
