### PR TITLE
Fix `cargo xtask fmt --check`

### DIFF
--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -1,7 +1,6 @@
 use crate::reconnect_serial_to_console;
-use uefi::boot;
 use uefi::proto::console::serial::{ControlBits, Serial};
-use uefi::{Result, ResultExt, Status};
+use uefi::{boot, Result, ResultExt, Status};
 
 // For the duration of this function, the serial device is opened in
 // exclusive mode. That means logs will not work, which means we should

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -231,6 +231,8 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
 
 /// Formats the project: nix, rust, and yml.
 fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
+    let mut any_errors = false;
+
     // fmt rust
     {
         eprintln!("Formatting: rust");
@@ -255,6 +257,7 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
                 } else {
                     eprintln!("❌ rust formatter failed: {e:#?}");
                 }
+                any_errors = true;
             }
         }
     }
@@ -279,6 +282,7 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
                 } else {
                     eprintln!("❌ yml formatter failed: {e:#?}");
                 }
+                any_errors = true;
             }
         }
     } else {
@@ -305,10 +309,15 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
                 } else {
                     eprintln!("❌ nix formatter failed: {e:#?}");
                 }
+                any_errors = true;
             }
         }
     } else {
         eprintln!("Formatting: nix - SKIPPED");
+    }
+
+    if any_errors {
+        bail!("one or more formatting errors");
     }
 
     Ok(())

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -102,10 +102,13 @@ impl OvmfPaths {
                 );
             }
         } else {
-            let prebuilt = Prebuilt::fetch(Source {
-                tag: OVMF_PREBUILT_TAG,
-                sha256: OVMF_PREBUILT_HASH,
-            }, OVMF_PREBUILT_DIR)?;
+            let prebuilt = Prebuilt::fetch(
+                Source {
+                    tag: OVMF_PREBUILT_TAG,
+                    sha256: OVMF_PREBUILT_HASH,
+                },
+                OVMF_PREBUILT_DIR,
+            )?;
 
             Ok(prebuilt.get_file(arch.into(), file_type))
         }


### PR DESCRIPTION
Format checking was printing errors but not exiting non-zero, so the CI didn't actually catch formatting errors since da55df613496b68899996d44e2dc2fb0ffb45bf9.

Fix that, and fix up a few format errors that snuck in.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
