### PR TITLE
uefi-raw: Drop unused dependency on ptr_meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,6 @@ name = "uefi-raw"
 version = "0.9.0"
 dependencies = [
  "bitflags 2.6.0",
- "ptr_meta",
  "uguid",
 ]
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -20,7 +20,6 @@ rust-version = "1.70"
 
 [dependencies]
 bitflags.workspace = true
-ptr_meta.workspace = true
 uguid.workspace = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
We don't use DST types in uefi-raw; this dependency was never actually used.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
