### PR TITLE
Increase MSRV to 1.81

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79"
+channel = "1.81"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 keywords = ["uefi", "efi"]
 license = "MPL-2.0"
 repository = "https://github.com/rust-osdev/uefi-rs"
-rust-version = "1.79"
+rust-version = "1.81"
 
 [workspace.dependencies]
 bitflags = "2.0.0"

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,7 +1,7 @@
 # uefi - [Unreleased]
 
 ## Changed
-- MSRV increased to 1.79.
+- MSRV increased to 1.81.
 
 
 # uefi - 0.33.0 (2024-10-23)

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -66,7 +66,7 @@
 //!
 //! ## MSRV
 //!
-//! The minimum supported Rust version is currently 1.79.
+//! The minimum supported Rust version is currently 1.81.
 //! Our policy is to support at least the past two stable releases.
 //!
 //! # API/User Documentation, Documentation Structure, and other Resources


### PR DESCRIPTION
1.83 has been released, so we can bump MSRV to 1.81. This will unblock https://github.com/rust-osdev/uefi-rs/issues/1200 and also allow updating the `ptr_meta` dep.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
