### PR TITLE
Fix clippy::needless_lifetimes in Rust 1.83 and ShimLock ABI on ia32

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1613,7 +1613,7 @@ pub enum LoadImageSource<'a> {
     },
 }
 
-impl<'a> LoadImageSource<'a> {
+impl LoadImageSource<'_> {
     /// Returns the raw FFI parameters for `load_image`.
     #[must_use]
     pub(crate) fn to_ffi_params(
@@ -1677,7 +1677,7 @@ pub enum SearchType<'guid> {
     ByRegisterNotify(ProtocolSearchKey),
 }
 
-impl<'guid> SearchType<'guid> {
+impl SearchType<'_> {
     /// Constructs a new search type for a specified protocol.
     #[must_use]
     pub const fn from_proto<P: ProtocolPointer + ?Sized>() -> Self {

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -170,7 +170,7 @@ impl TryFrom<Vec<u16>> for CString16 {
     }
 }
 
-impl<'a> TryFrom<&UnalignedSlice<'a, u16>> for CString16 {
+impl TryFrom<&UnalignedSlice<'_, u16>> for CString16 {
     type Error = FromSliceWithNulError;
 
     fn try_from(input: &UnalignedSlice<u16>) -> Result<Self, Self::Error> {
@@ -193,7 +193,7 @@ impl From<&CString16> for String {
     }
 }
 
-impl<'a> UnalignedSlice<'a, u16> {
+impl UnalignedSlice<'_, u16> {
     /// Copies `self` to a new [`CString16`].
     pub fn to_cstring16(&self) -> Result<CString16, FromSliceWithNulError> {
         CString16::try_from(self)

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -720,7 +720,7 @@ impl PartialEq<CString16> for &CStr16 {
     }
 }
 
-impl<'a> UnalignedSlice<'a, u16> {
+impl UnalignedSlice<'_, u16> {
     /// Create a [`CStr16`] from an [`UnalignedSlice`] using an aligned
     /// buffer for storage. The lifetime of the output is tied to `buf`,
     /// not `self`.

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -134,7 +134,7 @@ impl<'a, T: Copy> UnalignedSlice<'a, T> {
     }
 }
 
-impl<'a, T: Copy + Debug> Debug for UnalignedSlice<'a, T> {
+impl<T: Copy + Debug> Debug for UnalignedSlice<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -175,7 +175,7 @@ pub struct UnalignedSliceIntoIter<'a, T: Copy> {
     index: usize,
 }
 
-impl<'a, T: Copy> Iterator for UnalignedSliceIntoIter<'a, T> {
+impl<T: Copy> Iterator for UnalignedSliceIntoIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
@@ -192,7 +192,7 @@ pub struct UnalignedSliceIter<'a, T: Copy> {
     index: usize,
 }
 
-impl<'a, T: Copy> Iterator for UnalignedSliceIter<'a, T> {
+impl<T: Copy> Iterator for UnalignedSliceIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -110,7 +110,7 @@ pub struct Components<'a> {
     i: usize,
 }
 
-impl<'a> Iterator for Components<'a> {
+impl Iterator for Components<'_> {
     // Attention. We can't iterate over &'Ctr16, as we would break any guarantee
     // made for the terminating null character.
     type Item = CString16;

--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -217,7 +217,7 @@ impl<'writer, 'a, W: fmt::Write> DecoratedLog<'writer, 'a, W> {
     }
 }
 
-impl<'writer, 'a, W: fmt::Write> fmt::Write for DecoratedLog<'writer, 'a, W> {
+impl<W: fmt::Write> fmt::Write for DecoratedLog<'_, '_, W> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         // Split the input string into lines
         let mut lines = s.lines();

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -57,7 +57,7 @@ impl<'a> MemoryMapRef<'a> {
     }
 }
 
-impl<'a> MemoryMap for MemoryMapRef<'a> {
+impl MemoryMap for MemoryMapRef<'_> {
     fn meta(&self) -> MemoryMapMeta {
         self.meta
     }
@@ -119,7 +119,7 @@ impl<'a> MemoryMapRefMut<'a> {
     }
 }
 
-impl<'a> MemoryMap for MemoryMapRefMut<'a> {
+impl MemoryMap for MemoryMapRefMut<'_> {
     fn meta(&self) -> MemoryMapMeta {
         self.meta
     }
@@ -144,7 +144,7 @@ impl<'a> MemoryMap for MemoryMapRefMut<'a> {
     }
 }
 
-impl<'a> MemoryMapMut for MemoryMapRefMut<'a> {
+impl MemoryMapMut for MemoryMapRefMut<'_> {
     fn sort(&mut self) {
         self.qsort(0, self.len - 1);
     }
@@ -154,7 +154,7 @@ impl<'a> MemoryMapMut for MemoryMapRefMut<'a> {
     }
 }
 
-impl<'a> MemoryMapRefMut<'a> {
+impl MemoryMapRefMut<'_> {
     /// Hoare partition scheme for quicksort.
     /// Must be called with `low` and `high` being indices within bounds.
     fn qsort(&mut self, low: usize, high: usize) {

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -414,7 +414,7 @@ pub struct ModeIter<'gop> {
     max: u32,
 }
 
-impl<'gop> Iterator for ModeIter<'gop> {
+impl Iterator for ModeIter<'_> {
     type Item = Mode;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -435,7 +435,7 @@ impl<'gop> Iterator for ModeIter<'gop> {
     }
 }
 
-impl<'gop> Debug for ModeIter<'gop> {
+impl Debug for ModeIter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ModeIter")
             .field("current", &self.current)
@@ -557,7 +557,7 @@ pub struct FrameBuffer<'gop> {
     _lifetime: PhantomData<&'gop mut u8>,
 }
 
-impl<'gop> FrameBuffer<'gop> {
+impl FrameBuffer<'_> {
     /// Access the raw framebuffer pointer
     ///
     /// To use this pointer safely and correctly, you must...

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -255,7 +255,7 @@ pub struct OutputModeIter<'out> {
     max: usize,
 }
 
-impl<'out> Iterator for OutputModeIter<'out> {
+impl Iterator for OutputModeIter<'_> {
     type Item = OutputMode;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -3165,7 +3165,7 @@ pub enum DevicePathNodeEnum<'a> {
     BiosBootSpecBootSpecification(&'a bios_boot_spec::BootSpecification),
 }
 
-impl<'a> TryFrom<&DevicePathNode> for DevicePathNodeEnum<'a> {
+impl TryFrom<&DevicePathNode> for DevicePathNodeEnum<'_> {
     type Error = NodeConversionError;
     fn try_from(node: &DevicePathNode) -> Result<Self, Self::Error> {
         Ok(match node.full_type() {
@@ -3516,7 +3516,7 @@ pub mod build {
             pub vendor_defined_data: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Vendor<'a> {
+        unsafe impl BuildNode for Vendor<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 20usize + size_of_val(self.vendor_defined_data);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -3692,7 +3692,7 @@ pub mod build {
             pub cid_str: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Expanded<'a> {
+        unsafe impl BuildNode for Expanded<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 16usize
                     + size_of_val(self.hid_str)
@@ -3744,7 +3744,7 @@ pub mod build {
             pub adr: &'a AdrSlice,
         }
 
-        unsafe impl<'a> BuildNode for Adr<'a> {
+        unsafe impl BuildNode for Adr<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 4usize + size_of_val(self.adr);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -4129,7 +4129,7 @@ pub mod build {
             pub serial_number: &'a [u16],
         }
 
-        unsafe impl<'a> BuildNode for UsbWwid<'a> {
+        unsafe impl BuildNode for UsbWwid<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 10usize + size_of_val(self.serial_number);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -4638,7 +4638,7 @@ pub mod build {
             pub vendor_defined_data: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Vendor<'a> {
+        unsafe impl BuildNode for Vendor<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 20usize + size_of_val(self.vendor_defined_data);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -4742,7 +4742,7 @@ pub mod build {
             pub iscsi_target_name: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Iscsi<'a> {
+        unsafe impl BuildNode for Iscsi<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 18usize + size_of_val(self.iscsi_target_name);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -4835,7 +4835,7 @@ pub mod build {
             pub value: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Uri<'a> {
+        unsafe impl BuildNode for Uri<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 4usize + size_of_val(self.value);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5080,7 +5080,7 @@ pub mod build {
             pub addresses: &'a [IpAddress],
         }
 
-        unsafe impl<'a> BuildNode for Dns<'a> {
+        unsafe impl BuildNode for Dns<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 5usize + size_of_val(self.addresses);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5156,7 +5156,7 @@ pub mod build {
             pub vendor_guid_and_data: Option<RestServiceVendorData<'a>>,
         }
 
-        unsafe impl<'a> BuildNode for RestService<'a> {
+        unsafe impl BuildNode for RestService<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 6usize + self.build_size_vendor_guid_and_data();
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5199,7 +5199,7 @@ pub mod build {
             pub subsystem_nqn: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for NvmeOfNamespace<'a> {
+        unsafe impl BuildNode for NvmeOfNamespace<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 21usize + size_of_val(self.subsystem_nqn);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5244,7 +5244,7 @@ pub mod build {
             pub vendor_defined_data: &'a [u8],
         }
 
-        impl<'a> RestService<'a> {
+        impl RestService<'_> {
             fn build_size_vendor_guid_and_data(&self) -> usize {
                 if let Some(src) = &self.vendor_guid_and_data {
                     assert!(self.service_type == device_path::messaging::RestServiceType::VENDOR);
@@ -5393,7 +5393,7 @@ pub mod build {
             pub vendor_defined_data: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for Vendor<'a> {
+        unsafe impl BuildNode for Vendor<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 20usize + size_of_val(self.vendor_defined_data);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5433,7 +5433,7 @@ pub mod build {
             pub path_name: &'a CStr16,
         }
 
-        unsafe impl<'a> BuildNode for FilePath<'a> {
+        unsafe impl BuildNode for FilePath<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 4usize + size_of_val(self.path_name);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5499,7 +5499,7 @@ pub mod build {
             pub data: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for PiwgFirmwareFile<'a> {
+        unsafe impl BuildNode for PiwgFirmwareFile<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 4usize + size_of_val(self.data);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5532,7 +5532,7 @@ pub mod build {
             pub data: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for PiwgFirmwareVolume<'a> {
+        unsafe impl BuildNode for PiwgFirmwareVolume<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 4usize + size_of_val(self.data);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)
@@ -5692,7 +5692,7 @@ pub mod build {
             pub description_string: &'a [u8],
         }
 
-        unsafe impl<'a> BuildNode for BootSpecification<'a> {
+        unsafe impl BuildNode for BootSpecification<'_> {
             fn size_in_bytes(&self) -> Result<u16, BuildError> {
                 let size = 8usize + size_of_val(self.description_string);
                 u16::try_from(size).map_err(|_| BuildError::NodeTooBig)

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -265,7 +265,7 @@ pub struct LanguageIter<'a> {
     kind: LanguageIterKind,
 }
 
-impl<'a> LanguageIter<'a> {
+impl LanguageIter<'_> {
     const fn new(
         languages: *const u8,
         kind: LanguageIterKind,

--- a/uefi/src/proto/shim/mod.rs
+++ b/uefi/src/proto/shim/mod.rs
@@ -45,7 +45,12 @@ pub struct Hashes {
 
 // These macros set the correct calling convention for the Shim protocol methods.
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86")]
+macro_rules! shim_function {
+    (fn $args:tt -> $return_type:ty) => (extern "cdecl" fn $args -> $return_type)
+}
+
+#[cfg(target_arch = "x86_64")]
 macro_rules! shim_function {
     (fn $args:tt -> $return_type:ty) => (extern "sysv64" fn $args -> $return_type)
 }

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -258,7 +258,7 @@ pub struct EventLog<'a> {
     is_truncated: bool,
 }
 
-impl<'a> EventLog<'a> {
+impl EventLog<'_> {
     pub(super) const unsafe fn new(
         location: *const u8,
         last_entry: *const u8,

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -231,7 +231,7 @@ struct AlgorithmDigestSize {
 #[derive(Clone, Debug)]
 struct AlgorithmDigestSizes<'a>(UnalignedSlice<'a, AlgorithmDigestSize>);
 
-impl<'a> AlgorithmDigestSizes<'a> {
+impl AlgorithmDigestSizes<'_> {
     fn get_size(&self, alg: AlgorithmId) -> Option<u16> {
         self.0.iter().find_map(|elem| {
             if { elem.algorithm_id } == alg {
@@ -332,7 +332,7 @@ pub struct EventLog<'a> {
     is_truncated: bool,
 }
 
-impl<'a> EventLog<'a> {
+impl EventLog<'_> {
     /// Iterator of events in the log.
     #[must_use]
     pub fn iter(&self) -> EventLogIter {
@@ -384,7 +384,7 @@ pub struct PcrEventDigests<'a> {
     algorithm_digest_sizes: AlgorithmDigestSizes<'a>,
 }
 
-impl<'a> Debug for PcrEventDigests<'a> {
+impl Debug for PcrEventDigests<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }

--- a/xtask/src/device_path/group.rs
+++ b/xtask/src/device_path/group.rs
@@ -182,7 +182,7 @@ impl NodeGroup {
                 #(#variants),*
             }
 
-            impl<'a> TryFrom<&DevicePathNode> for DevicePathNodeEnum<'a> {
+            impl TryFrom<&DevicePathNode> for DevicePathNodeEnum<'_> {
                 type Error = NodeConversionError;
 
                 fn try_from(node: &DevicePathNode) -> Result<Self, Self::Error> {

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -477,13 +477,17 @@ impl Node {
 
     fn gen_builder_impl(&self) -> TokenStream {
         let struct_ident = &self.struct_ident;
-        let lifetime = self.builder_lifetime();
+        let lifetime = if self.is_dst() {
+            Some(quote!(<'_>))
+        } else {
+            None
+        };
 
         let size_in_bytes_method = self.gen_builder_size_in_bytes_method();
         let write_data_method = self.gen_builder_write_data_method();
 
         quote!(
-            unsafe impl #lifetime BuildNode for #struct_ident #lifetime {
+            unsafe impl BuildNode for #struct_ident #lifetime {
                 #size_in_bytes_method
 
                 #write_data_method

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -968,7 +968,7 @@ mod messaging {
     }
 
     #[build]
-    impl<'a> RestService<'a> {
+    impl RestService<'_> {
         fn build_size_vendor_guid_and_data(&self) -> usize {
             if let Some(src) = &self.vendor_guid_and_data {
                 assert!(self.service_type == device_path::messaging::RestServiceType::VENDOR);


### PR DESCRIPTION
<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
