### PR TITLE
Fix clippy::use_self

### DIFF
--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -31,39 +31,39 @@ impl ExceptionType {
 #[cfg(target_arch = "x86")]
 impl ExceptionType {
     /// Divide-by-zero Error
-    pub const EXCEPT_IA32_DIVIDE_ERROR: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_IA32_DIVIDE_ERROR: Self = Self(0);
     /// Debug Exception
-    pub const EXCEPT_IA32_DEBUG: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_IA32_DEBUG: Self = Self(1);
     /// Non-maskable Interrupt
-    pub const EXCEPT_IA32_NMI: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_IA32_NMI: Self = Self(2);
     /// Breakpoint
-    pub const EXCEPT_IA32_BREAKPOINT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_IA32_BREAKPOINT: Self = Self(3);
     /// Overflow
-    pub const EXCEPT_IA32_OVERFLOW: ExceptionType = ExceptionType(4);
+    pub const EXCEPT_IA32_OVERFLOW: Self = Self(4);
     /// Bound Range Exceeded
-    pub const EXCEPT_IA32_BOUND: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_IA32_BOUND: Self = Self(5);
     /// Invalid Opcode
-    pub const EXCEPT_IA32_INVALID_OPCODE: ExceptionType = ExceptionType(6);
+    pub const EXCEPT_IA32_INVALID_OPCODE: Self = Self(6);
     /// Double Fault
-    pub const EXCEPT_IA32_DOUBLE_FAULT: ExceptionType = ExceptionType(8);
+    pub const EXCEPT_IA32_DOUBLE_FAULT: Self = Self(8);
     /// Invalid TSS
-    pub const EXCEPT_IA32_INVALID_TSS: ExceptionType = ExceptionType(10);
+    pub const EXCEPT_IA32_INVALID_TSS: Self = Self(10);
     /// Segment Not Present
-    pub const EXCEPT_IA32_SEG_NOT_PRESENT: ExceptionType = ExceptionType(11);
+    pub const EXCEPT_IA32_SEG_NOT_PRESENT: Self = Self(11);
     /// Stack-Segment Fault
-    pub const EXCEPT_IA32_STACK_FAULT: ExceptionType = ExceptionType(12);
+    pub const EXCEPT_IA32_STACK_FAULT: Self = Self(12);
     /// General Protection Fault
-    pub const EXCEPT_IA32_GP_FAULT: ExceptionType = ExceptionType(13);
+    pub const EXCEPT_IA32_GP_FAULT: Self = Self(13);
     /// Page Fault
-    pub const EXCEPT_IA32_PAGE_FAULT: ExceptionType = ExceptionType(14);
+    pub const EXCEPT_IA32_PAGE_FAULT: Self = Self(14);
     /// x87 Floating-Point Exception
-    pub const EXCEPT_IA32_FP_ERROR: ExceptionType = ExceptionType(16);
+    pub const EXCEPT_IA32_FP_ERROR: Self = Self(16);
     /// Alignment Check
-    pub const EXCEPT_IA32_ALIGNMENT_CHECK: ExceptionType = ExceptionType(17);
+    pub const EXCEPT_IA32_ALIGNMENT_CHECK: Self = Self(17);
     /// Machine Check
-    pub const EXCEPT_IA32_MACHINE_CHECK: ExceptionType = ExceptionType(18);
+    pub const EXCEPT_IA32_MACHINE_CHECK: Self = Self(18);
     /// SIMD Floating-Point Exception
-    pub const EXCEPT_IA32_SIMD: ExceptionType = ExceptionType(19);
+    pub const EXCEPT_IA32_SIMD: Self = Self(19);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -107,80 +107,80 @@ impl ExceptionType {
 #[cfg(target_arch = "arm")]
 impl ExceptionType {
     /// Processor reset
-    pub const EXCEPT_ARM_RESET: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_ARM_RESET: Self = Self(0);
     /// Undefined instruction
-    pub const EXCEPT_ARM_UNDEFINED_INSTRUCTION: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_ARM_UNDEFINED_INSTRUCTION: Self = Self(1);
     /// Software Interrupt
-    pub const EXCEPT_ARM_SOFTWARE_INTERRUPT: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_ARM_SOFTWARE_INTERRUPT: Self = Self(2);
     /// Prefetch aborted
-    pub const EXCEPT_ARM_PREFETCH_ABORT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_ARM_PREFETCH_ABORT: Self = Self(3);
     /// Data access memory abort
-    pub const EXCEPT_ARM_DATA_ABORT: ExceptionType = ExceptionType(4);
+    pub const EXCEPT_ARM_DATA_ABORT: Self = Self(4);
     /// Reserved
-    pub const EXCEPT_ARM_RESERVED: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_ARM_RESERVED: Self = Self(5);
     /// Normal interrupt
-    pub const EXCEPT_ARM_IRQ: ExceptionType = ExceptionType(6);
+    pub const EXCEPT_ARM_IRQ: Self = Self(6);
     /// Fast interrupt
-    pub const EXCEPT_ARM_FIQ: ExceptionType = ExceptionType(7);
+    pub const EXCEPT_ARM_FIQ: Self = Self(7);
     /// In the UEFI spec for "convenience", unsure if we'll need it. Set to `EXCEPT_ARM_FIQ`
-    pub const MAX_ARM_EXCEPTION: ExceptionType = ExceptionType::EXCEPT_ARM_FIQ;
+    pub const MAX_ARM_EXCEPTION: Self = Self::EXCEPT_ARM_FIQ;
 }
 
 #[cfg(target_arch = "aarch64")]
 impl ExceptionType {
     /// Synchronous exception, such as attempting to execute an invalid instruction
-    pub const EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS: Self = Self(0);
     /// Normal interrupt
-    pub const EXCEPT_AARCH64_IRQ: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_AARCH64_IRQ: Self = Self(1);
     /// Fast interrupt
-    pub const EXCEPT_AARCH64_FIQ: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_AARCH64_FIQ: Self = Self(2);
     /// System Error
-    pub const EXCEPT_AARCH64_SERROR: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_AARCH64_SERROR: Self = Self(3);
     /// In the UEFI spec for "convenience", unsure if we'll need it. Set to `EXCEPT_AARCH64_SERROR`
-    pub const MAX_AARCH64_EXCEPTION: ExceptionType = ExceptionType::EXCEPT_AARCH64_SERROR;
+    pub const MAX_AARCH64_EXCEPTION: Self = Self::EXCEPT_AARCH64_SERROR;
 }
 
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 impl ExceptionType {
     /// Instruction misaligned
-    pub const EXCEPT_RISCV_INST_MISALIGNED: ExceptionType = ExceptionType(0);
+    pub const EXCEPT_RISCV_INST_MISALIGNED: Self = Self(0);
     /// Instruction access fault
-    pub const EXCEPT_RISCV_INST_ACCESS_FAULT: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_RISCV_INST_ACCESS_FAULT: Self = Self(1);
     /// Illegal instruction
-    pub const EXCEPT_RISCV_ILLEGAL_INST: ExceptionType = ExceptionType(2);
+    pub const EXCEPT_RISCV_ILLEGAL_INST: Self = Self(2);
     /// Breakpoint
-    pub const EXCEPT_RISCV_BREAKPOINT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_RISCV_BREAKPOINT: Self = Self(3);
     /// Load address misaligned
-    pub const EXCEPT_RISCV_LOAD_ADDRESS_MISALIGNED: ExceptionType = ExceptionType(4);
+    pub const EXCEPT_RISCV_LOAD_ADDRESS_MISALIGNED: Self = Self(4);
     /// Load accept fault
-    pub const EXCEPT_RISCV_LOAD_ACCESS_FAULT: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_RISCV_LOAD_ACCESS_FAULT: Self = Self(5);
     /// Store AMO address misaligned
-    pub const EXCEPT_RISCV_STORE_AMO_ADDRESS_MISALIGNED: ExceptionType = ExceptionType(6);
+    pub const EXCEPT_RISCV_STORE_AMO_ADDRESS_MISALIGNED: Self = Self(6);
     /// Store AMO access fault
-    pub const EXCEPT_RISCV_STORE_AMO_ACCESS_FAULT: ExceptionType = ExceptionType(7);
+    pub const EXCEPT_RISCV_STORE_AMO_ACCESS_FAULT: Self = Self(7);
     /// ECALL from User mode
-    pub const EXCEPT_RISCV_ENV_CALL_FROM_UMODE: ExceptionType = ExceptionType(8);
+    pub const EXCEPT_RISCV_ENV_CALL_FROM_UMODE: Self = Self(8);
     /// ECALL from Supervisor mode
-    pub const EXCEPT_RISCV_ENV_CALL_FROM_SMODE: ExceptionType = ExceptionType(9);
+    pub const EXCEPT_RISCV_ENV_CALL_FROM_SMODE: Self = Self(9);
     /// ECALL from Machine mode
-    pub const EXCEPT_RISCV_ENV_CALL_FROM_MMODE: ExceptionType = ExceptionType(11);
+    pub const EXCEPT_RISCV_ENV_CALL_FROM_MMODE: Self = Self(11);
     /// Instruction page fault
-    pub const EXCEPT_RISCV_INST_PAGE_FAULT: ExceptionType = ExceptionType(12);
+    pub const EXCEPT_RISCV_INST_PAGE_FAULT: Self = Self(12);
     /// Load page fault
-    pub const EXCEPT_RISCV_LOAD_PAGE_FAULT: ExceptionType = ExceptionType(13);
+    pub const EXCEPT_RISCV_LOAD_PAGE_FAULT: Self = Self(13);
     /// Store AMO page fault
-    pub const EXCEPT_RISCV_STORE_AMO_PAGE_FAULT: ExceptionType = ExceptionType(15);
+    pub const EXCEPT_RISCV_STORE_AMO_PAGE_FAULT: Self = Self(15);
     // RISC-V interrupt types
     /// Supervisor software interrupt
-    pub const EXCEPT_RISCV_SUPERVISOR_SOFTWARE_INT: ExceptionType = ExceptionType(1);
+    pub const EXCEPT_RISCV_SUPERVISOR_SOFTWARE_INT: Self = Self(1);
     /// Machine software interrupt
-    pub const EXCEPT_RISCV_MACHINE_SOFTWARE_INT: ExceptionType = ExceptionType(3);
+    pub const EXCEPT_RISCV_MACHINE_SOFTWARE_INT: Self = Self(3);
     /// Supervisor timer interrupt
-    pub const EXCEPT_RISCV_SUPERVISOR_TIMER_INT: ExceptionType = ExceptionType(5);
+    pub const EXCEPT_RISCV_SUPERVISOR_TIMER_INT: Self = Self(5);
     /// Machine timer interrupt
-    pub const EXCEPT_RISCV_MACHINE_TIMER_INT: ExceptionType = ExceptionType(7);
+    pub const EXCEPT_RISCV_MACHINE_TIMER_INT: Self = Self(7);
     /// Supervisor external interrupt
-    pub const EXCEPT_RISCV_SUPERVISOR_EXTERNAL_INT: ExceptionType = ExceptionType(9);
+    pub const EXCEPT_RISCV_SUPERVISOR_EXTERNAL_INT: Self = Self(9);
     /// Machine external interrupt
-    pub const EXCEPT_RISCV_MACHINE_EXTERNAL_INT: ExceptionType = ExceptionType(11);
+    pub const EXCEPT_RISCV_MACHINE_EXTERNAL_INT: Self = Self(11);
 }


### PR DESCRIPTION
Fixes clippy::use_self lint errors. Due to clippy not being run on all supported architectures, in CI, clippy lint errors that occur in architecture-specific code may not be caught.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
