### PR TITLE
uefi-raw: Add DriverBindingProtocol

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `protocol::string::UnicodeCollationProtocol`.
 - Added `protocol::tcg` module, containing the TCG v1 and v2 protocols.
+- Added `DriverBindingProtocol`.
 
 
 # uefi-raw - 0.9.0 (2024-10-23)

--- a/uefi-raw/src/protocol/driver.rs
+++ b/uefi-raw/src/protocol/driver.rs
@@ -1,4 +1,33 @@
+use crate::protocol::device_path::DevicePathProtocol;
 use crate::{guid, Guid, Handle, Status};
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DriverBindingProtocol {
+    pub supported: unsafe extern "efiapi" fn(
+        this: *const Self,
+        controller_handle: Handle,
+        remaining_device_path: *const DevicePathProtocol,
+    ) -> Status,
+    pub start: unsafe extern "efiapi" fn(
+        this: *const Self,
+        controller_handle: Handle,
+        remaining_device_path: *const DevicePathProtocol,
+    ) -> Status,
+    pub stop: unsafe extern "efiapi" fn(
+        this: *const Self,
+        controller_handle: Handle,
+        number_of_children: usize,
+        child_handle_buffer: *const Handle,
+    ) -> Status,
+    pub version: u32,
+    pub image_handle: Handle,
+    pub driver_binding_handle: Handle,
+}
+
+impl DriverBindingProtocol {
+    pub const GUID: Guid = guid!("18a031ab-b443-4d1a-a5c0-0c09261e9f71");
+}
 
 #[derive(Debug)]
 #[repr(C)]


### PR DESCRIPTION
Add the interface for `EFI_DRIVER_BINDING_PROTOCOL`.

Ref: [UEFI 2.10: 11.1 EFI Driver Binding Protocol](https://uefi.org/specs/UEFI/2.10/11_Protocols_UEFI_Driver_Model.html)

<details>
<summary>Example usage</summary>

```rust
#![no_main]
#![no_std]

use uefi::prelude::*;
use uefi_raw::protocol::device_path::DevicePathProtocol;
use uefi_raw::protocol::driver::DriverBindingProtocol;

// EFI_DRIVER_BINDING_SUPPORTED
unsafe extern "efiapi" fn supported(
    _this: *const DriverBindingProtocol,
    _controller: uefi_raw::Handle,
    _remaining: *const DevicePathProtocol,
) -> Status {
    log::info!("DriverBindingSupported called");
    Status::SUCCESS
}

// EFI_DRIVER_BINDING_START
unsafe extern "efiapi" fn start(
    _this: *const DriverBindingProtocol,
    _controller: uefi_raw::Handle,
    _remaining: *const DevicePathProtocol,
) -> Status {
    log::info!("DriverBindingStart called");
    Status::SUCCESS
}

// EFI_DRIVER_BINDING_STOP
unsafe extern "efiapi" fn stop(
    _this: *const DriverBindingProtocol,
    _controller: uefi_raw::Handle,
    _number_of_children: usize,
    _child_handle_buffer: *const uefi_raw::Handle,
) -> Status {
    log::info!("DriverBindingStop called");
    Status::SUCCESS
}

// EFI_DRIVER_BINDING_PROTOCOL
static mut DRIVER_BINDING: DriverBindingProtocol = DriverBindingProtocol {
    supported,
    start,
    stop,
    version: 1,
    image_handle: core::ptr::null_mut(),
    driver_binding_handle: core::ptr::null_mut(),
};

#[entry]
fn main() -> Status {
    uefi::helpers::init().unwrap();
    let image = boot::image_handle();

    log::info!("driver run");

    unsafe {
        DRIVER_BINDING.image_handle = image.as_ptr();
        DRIVER_BINDING.driver_binding_handle = image.as_ptr();
    }

    unsafe {
        boot::install_protocol_interface(
            Some(image),
            &DriverBindingProtocol::GUID,
            core::ptr::addr_of!(DRIVER_BINDING).cast(),
        )
        .unwrap();
    }

    log::info!("DriverBindingProtocol installed");
    Status::SUCCESS
}
```

</details>

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)