### PR TITLE
uefi-raw: Use `efiapi` After Stabilization

### DIFF
--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -189,28 +189,10 @@ pub struct BootServices {
         out_proto: *mut *mut c_void,
     ) -> Status,
 
-    /// Warning: this function pointer is declared as `extern "C"` rather than
-    /// `extern "efiapi". That means it will work correctly when called from a
-    /// UEFI target (`*-unknown-uefi`), but will not work when called from a
-    /// target with a different calling convention such as
-    /// `x86_64-unknown-linux-gnu`.
-    ///
-    /// Support for C-variadics with `efiapi` requires the unstable
-    /// [`extended_varargs_abi_support`](https://github.com/rust-lang/rust/issues/100189)
-    /// feature.
+    // Multi-protocol handlers
     pub install_multiple_protocol_interfaces:
-        unsafe extern "C" fn(handle: *mut Handle, ...) -> Status,
-
-    /// Warning: this function pointer is declared as `extern "C"` rather than
-    /// `extern "efiapi". That means it will work correctly when called from a
-    /// UEFI target (`*-unknown-uefi`), but will not work when called from a
-    /// target with a different calling convention such as
-    /// `x86_64-unknown-linux-gnu`.
-    ///
-    /// Support for C-variadics with `efiapi` requires the unstable
-    /// [`extended_varargs_abi_support`](https://github.com/rust-lang/rust/issues/100189)
-    /// feature.
-    pub uninstall_multiple_protocol_interfaces: unsafe extern "C" fn(handle: Handle, ...) -> Status,
+        unsafe extern "efiapi" fn(handle: *mut Handle, ...) -> Status,
+    pub uninstall_multiple_protocol_interfaces: unsafe extern "efiapi" fn(handle: Handle, ...) -> Status,
 
     // CRC services
     pub calculate_crc32:


### PR DESCRIPTION
<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

`extended_varargs_abi_support` has been stabilized in PR https://github.com/rust-lang/rust/pull/116161.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)