### PR TITLE
Remove unstable gate for `core::error::Error` impls

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 - MSRV increased to 1.81.
+- `core::error::Error` impls are no longer gated by the `unstable` feature.
 
 
 # uefi - 0.33.0 (2024-10-23)

--- a/uefi/src/data_types/chars.rs
+++ b/uefi/src/data_types/chars.rs
@@ -15,7 +15,6 @@ impl Display for CharConversionError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for CharConversionError {}
 
 /// A Latin-1 character

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -32,7 +32,6 @@ impl Display for FromStrError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for FromStrError {}
 
 /// An owned UCS-2 null-terminated string.

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -30,7 +30,6 @@ impl Display for FromSliceUntilNulError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for FromSliceUntilNulError {}
 
 /// Error converting from a slice (which cannot contain interior nuls) to a
@@ -57,7 +56,6 @@ impl Display for FromSliceWithNulError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for FromSliceWithNulError {}
 
 /// Error returned by [`CStr16::from_unaligned_slice`].
@@ -88,7 +86,6 @@ impl Display for UnalignedCStr16Error {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for UnalignedCStr16Error {}
 
 /// Error returned by [`CStr16::from_str_with_buf`].
@@ -115,7 +112,6 @@ impl Display for FromStrWithBufError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for FromStrWithBufError {}
 
 /// A null-terminated Latin-1 string.

--- a/uefi/src/fs/file_system/error.rs
+++ b/uefi/src/fs/file_system/error.rs
@@ -94,18 +94,16 @@ impl From<PathError> for Error {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for Error {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Error::Io(err) => Some(err),
-            Error::Path(err) => Some(err),
-            Error::Utf8Encoding(err) => Some(err),
+            Self::Io(err) => Some(err),
+            Self::Path(err) => Some(err),
+            Self::Utf8Encoding(err) => Some(err),
         }
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for IoError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         Some(&self.uefi_error)

--- a/uefi/src/fs/path/validation.rs
+++ b/uefi/src/fs/path/validation.rs
@@ -38,7 +38,6 @@ impl Display for PathError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for PathError {}
 
 /// Validates a path for the needs of the [`fs`] module.

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -25,7 +25,6 @@ impl Display for MemoryMapError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for MemoryMapError {}
 
 /// Implementation of [`MemoryMap`] for the given buffer.

--- a/uefi/src/proto/boot_policy.rs
+++ b/uefi/src/proto/boot_policy.rs
@@ -20,7 +20,6 @@ impl Display for BootPolicyError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for BootPolicyError {}
 
 /// The UEFI boot policy is a property that influences the behaviour of

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -189,7 +189,6 @@ impl Display for BuildError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for BuildError {}
 
 /// Trait for types that can be used to build a node via

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -704,12 +704,11 @@ impl Display for DevicePathToTextError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for DevicePathToTextError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            DevicePathToTextError::CantLocateHandleBuffer(e) => Some(e),
-            DevicePathToTextError::CantOpenProtocol(e) => Some(e),
+            Self::CantLocateHandleBuffer(e) => Some(e),
+            Self::CantOpenProtocol(e) => Some(e),
             _ => None,
         }
     }

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -248,7 +248,6 @@ impl Display for LanguageError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for LanguageError {}
 
 #[derive(Debug, PartialEq)]

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -137,7 +137,6 @@ impl Display for FileInfoCreationError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for FileInfoCreationError {}
 
 /// Generic file information

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1247,7 +1247,6 @@ impl Display for IcmpError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for IcmpError {}
 
 /// Corresponds to the anonymous union inside
@@ -1294,7 +1293,6 @@ impl Display for TftpError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for TftpError {}
 
 /// Returned by [`BaseCode::tftp_read_dir`].
@@ -1337,5 +1335,4 @@ impl Display for ReadDirParseError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for ReadDirParseError {}

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -171,5 +171,4 @@ impl Display for StrConversionError {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for StrConversionError {}

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -68,5 +68,4 @@ impl<Data: Debug> Error<Data> {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl<Data: Debug> core::error::Error for Error<Data> {}

--- a/uefi/src/runtime.rs
+++ b/uefi/src/runtime.rs
@@ -605,7 +605,6 @@ pub struct TimeError {
     pub daylight: bool,
 }
 
-#[cfg(feature = "unstable")]
 impl core::error::Error for TimeError {}
 
 impl Display for TimeError {


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/uefi-rs/issues/1200

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
