### PR TITLE
Use size_of/size_of_val/align_of/align_of_val from the prelude

### DIFF
--- a/uefi-raw/src/status.rs
+++ b/uefi-raw/src/status.rs
@@ -98,7 +98,7 @@ pub enum Status: usize => {
 
 impl Status {
     /// Bit indicating that an UEFI status code is an error.
-    pub const ERROR_BIT: usize = 1 << (core::mem::size_of::<usize>() * 8 - 1);
+    pub const ERROR_BIT: usize = 1 << (usize::BITS - 1);
 
     /// Returns true if status code indicates success.
     #[inline]

--- a/uefi-raw/src/table/system.rs
+++ b/uefi-raw/src/table/system.rs
@@ -4,7 +4,7 @@ use crate::table::configuration::ConfigurationTable;
 use crate::table::runtime::RuntimeServices;
 use crate::table::Header;
 use crate::{Char16, Handle};
-use core::{mem, ptr};
+use core::ptr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
@@ -44,7 +44,7 @@ impl Default for SystemTable {
         Self {
             header: Header {
                 signature: Self::SIGNATURE,
-                size: u32::try_from(mem::size_of::<Self>()).unwrap(),
+                size: u32::try_from(size_of::<Self>()).unwrap(),
                 ..Header::default()
             },
 

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::mem;
 use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, BltRegion, GraphicsOutput};
 use uefi::proto::rng::Rng;
@@ -77,7 +76,7 @@ impl Buffer {
 
 /// Get a random `usize` value.
 fn get_random_usize(rng: &mut Rng) -> usize {
-    let mut buf = [0; mem::size_of::<usize>()];
+    let mut buf = [0; size_of::<usize>()];
     rng.get_rng(None, &mut buf).expect("get_rng failed");
     usize::from_le_bytes(buf)
 }

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,5 +1,4 @@
 use core::ffi::c_void;
-use core::mem;
 use core::ptr::{self, NonNull};
 
 use uefi::boot::{
@@ -121,13 +120,11 @@ fn test_register_protocol_notify() {
 fn test_install_protocol_interface() {
     info!("Installing TestProtocol");
 
-    let alloc: *mut TestProtocol = boot::allocate_pool(
-        MemoryType::BOOT_SERVICES_DATA,
-        mem::size_of::<TestProtocol>(),
-    )
-    .unwrap()
-    .cast()
-    .as_ptr();
+    let alloc: *mut TestProtocol =
+        boot::allocate_pool(MemoryType::BOOT_SERVICES_DATA, size_of::<TestProtocol>())
+            .unwrap()
+            .cast()
+            .as_ptr();
     unsafe { alloc.write(TestProtocol { data: 123 }) };
 
     let _ = unsafe {

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -277,7 +277,7 @@ pub(crate) fn get_memory_map(buf: &mut [u8]) -> Result<MemoryMapMeta> {
     let mut desc_version = 0;
 
     assert_eq!(
-        (map_buffer as usize) % mem::align_of::<MemoryDescriptor>(),
+        (map_buffer as usize) % align_of::<MemoryDescriptor>(),
         0,
         "Memory map buffers must be aligned like a MemoryDescriptor"
     );
@@ -793,11 +793,11 @@ pub fn locate_handle<'buf>(
         SearchType::ByProtocol(guid) => (2, ptr::from_ref(guid), ptr::null()),
     };
 
-    let mut buffer_size = buffer.len() * mem::size_of::<Handle>();
+    let mut buffer_size = buffer.len() * size_of::<Handle>();
     let status =
         unsafe { (bt.locate_handle)(ty, guid, key, &mut buffer_size, buffer.as_mut_ptr().cast()) };
 
-    let num_handles = buffer_size / mem::size_of::<Handle>();
+    let num_handles = buffer_size / size_of::<Handle>();
 
     match status {
         Status::SUCCESS => {

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -99,8 +99,8 @@ impl Event {
 /// Trait for querying the alignment of a struct.
 ///
 /// For a statically-sized type the alignment can be retrieved with
-/// [`core::mem::align_of`]. For a dynamically-sized type (DST),
-/// [`core::mem::align_of_val`] provides the alignment given a reference. But in
+/// [`align_of`]. For a dynamically-sized type (DST),
+/// [`align_of_val`] provides the alignment given a reference. But in
 /// some cases it's helpful to know the alignment of a DST prior to having a
 /// value, meaning there's no reference to pass to `align_of_val`. For example,
 /// when using an API that creates a value using a `[u8]` buffer, the alignment

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -5,8 +5,8 @@ use super::*;
 use crate::boot;
 use core::fmt::{Debug, Display, Formatter};
 use core::ops::{Index, IndexMut};
+use core::ptr;
 use core::ptr::NonNull;
-use core::{mem, ptr};
 use uefi_raw::PhysicalAddress;
 
 /// Errors that may happen when constructing a [`MemoryMapRef`] or
@@ -284,7 +284,7 @@ impl MemoryMapBackingMemory {
 
         // Should be fine as UEFI always has  allocations with a guaranteed
         // alignment of 8 bytes.
-        assert_eq!(ptr.align_offset(mem::align_of::<MemoryDescriptor>()), 0);
+        assert_eq!(ptr.align_offset(align_of::<MemoryDescriptor>()), 0);
 
         // If this panics, the UEFI implementation is broken.
         assert_eq!(memory_map_meta.map_size % memory_map_meta.desc_size, 0);
@@ -293,7 +293,7 @@ impl MemoryMapBackingMemory {
     }
 
     unsafe fn from_raw(ptr: *mut u8, len: usize) -> Self {
-        assert_eq!(ptr.align_offset(mem::align_of::<MemoryDescriptor>()), 0);
+        assert_eq!(ptr.align_offset(align_of::<MemoryDescriptor>()), 0);
 
         let ptr = NonNull::new(ptr).expect("UEFI should never return a null ptr. An error should have been reflected via an Err earlier.");
         let slice = NonNull::slice_from_raw_parts(ptr, len);
@@ -367,7 +367,7 @@ impl MemoryMapOwned {
     /// (stored inside the provided buffer) and the corresponding
     /// [`MemoryMapMeta`].
     pub(crate) fn from_initialized_mem(buf: MemoryMapBackingMemory, meta: MemoryMapMeta) -> Self {
-        assert!(meta.desc_size >= mem::size_of::<MemoryDescriptor>());
+        assert!(meta.desc_size >= size_of::<MemoryDescriptor>());
         let len = meta.entry_count();
         Self { buf, meta, len }
     }
@@ -431,7 +431,7 @@ impl IndexMut<usize> for MemoryMapOwned {
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    use core::mem::size_of;
+    use size_of;
 
     const BASE_MMAP_UNSORTED: [MemoryDescriptor; 3] = [
         MemoryDescriptor {

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -41,11 +41,10 @@ pub use iter::*;
 pub use uefi_raw::table::boot::{MemoryAttribute, MemoryDescriptor, MemoryType};
 
 use crate::data_types::Align;
-use core::mem;
 
 impl Align for MemoryDescriptor {
     fn alignment() -> usize {
-        mem::align_of::<Self>()
+        align_of::<Self>()
     }
 }
 
@@ -90,7 +89,7 @@ impl MemoryMapMeta {
         // extended by a future UEFI revision by a significant amount, we
         // update the struct, but an old UEFI implementation reports a small
         // size.
-        assert!(self.desc_size >= mem::size_of::<MemoryDescriptor>());
+        assert!(self.desc_size >= size_of::<MemoryDescriptor>());
         assert!(self.map_size > 0);
 
         // Ensure the mmap size is (somehow) sane.
@@ -238,8 +237,8 @@ mod tests_mmap_artificial {
 mod tests_mmap_real {
     use super::*;
     use alloc::vec::Vec;
-    use core::mem::size_of;
     use core::slice;
+    use size_of;
 
     const MMAP_META: MemoryMapMeta = MemoryMapMeta {
         map_size: MMAP_RAW.len() * size_of::<u64>(),

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -55,7 +55,6 @@ use crate::util::usize_from_u32;
 use crate::{boot, Result, StatusExt};
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
-use core::mem;
 use core::ptr::{self, NonNull};
 use uefi_raw::protocol::console::{
     GraphicsOutputBltOperation, GraphicsOutputModeInformation, GraphicsOutputProtocol,
@@ -181,7 +180,7 @@ impl GraphicsOutput {
                             dest_y,
                             width,
                             height,
-                            px_stride * core::mem::size_of::<BltPixel>(),
+                            px_stride * size_of::<BltPixel>(),
                         )
                         .to_result(),
                     }
@@ -221,7 +220,7 @@ impl GraphicsOutput {
                             dest_y,
                             width,
                             height,
-                            px_stride * core::mem::size_of::<BltPixel>(),
+                            px_stride * size_of::<BltPixel>(),
                         )
                         .to_result(),
                     }
@@ -620,7 +619,7 @@ impl FrameBuffer<'_> {
     #[inline]
     pub unsafe fn write_value<T>(&mut self, index: usize, value: T) {
         debug_assert!(
-            index.saturating_add(mem::size_of::<T>()) <= self.size,
+            index.saturating_add(size_of::<T>()) <= self.size,
             "Frame buffer accessed out of bounds"
         );
         let ptr = self.base.add(index).cast::<T>();
@@ -643,7 +642,7 @@ impl FrameBuffer<'_> {
     #[must_use]
     pub unsafe fn read_value<T>(&self, index: usize) -> T {
         debug_assert!(
-            index.saturating_add(mem::size_of::<T>()) <= self.size,
+            index.saturating_add(size_of::<T>()) <= self.size,
             "Frame buffer accessed out of bounds"
         );
         (self.base.add(index) as *const T).read_volatile()

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -245,10 +245,10 @@ mod tests {
     use crate::proto::device_path::messaging::{
         Ipv4AddressOrigin, IscsiLoginOptions, IscsiProtocol, RestServiceAccessMode, RestServiceType,
     };
-    use core::{mem, slice};
+    use core::slice;
 
     fn path_to_bytes(path: &DevicePath) -> &[u8] {
-        unsafe { slice::from_raw_parts(path.as_ffi_ptr().cast::<u8>(), mem::size_of_val(path)) }
+        unsafe { slice::from_raw_parts(path.as_ffi_ptr().cast::<u8>(), size_of_val(path)) }
     }
 
     /// Test building an ACPI ADR node.

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -67,15 +67,15 @@ impl LoadedImage {
 
         if self.0.load_options.is_null() {
             Err(LoadOptionsError::NotSet)
-        } else if (load_options_size % mem::size_of::<u16>() != 0)
-            || (((self.0.load_options as usize) % mem::align_of::<u16>()) != 0)
+        } else if (load_options_size % size_of::<u16>() != 0)
+            || (((self.0.load_options as usize) % align_of::<u16>()) != 0)
         {
             Err(LoadOptionsError::NotAligned)
         } else {
             let s = unsafe {
                 slice::from_raw_parts(
                     self.0.load_options.cast::<u16>(),
-                    load_options_size / mem::size_of::<u16>(),
+                    load_options_size / size_of::<u16>(),
                 )
             };
             CStr16::from_u16_with_nul(s).map_err(LoadOptionsError::InvalidString)

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -4,7 +4,7 @@ use crate::runtime::Time;
 use crate::{CStr16, Char16, Guid, Identify};
 use core::ffi::c_void;
 use core::fmt::{self, Display, Formatter};
-use core::{mem, ptr};
+use core::ptr;
 use ptr_meta::Pointee;
 
 /// Common trait for data structures that can be used with
@@ -69,7 +69,7 @@ trait InfoInternal: Align + ptr_meta::Pointee<Metadata = usize> {
     {
         // Calculate the final size of the struct.
         let name_length_ucs2 = name.as_slice_with_nul().len();
-        let name_size = mem::size_of_val(name.as_slice_with_nul());
+        let name_size = size_of_val(name.as_slice_with_nul());
         let info_size = Self::name_offset() + name_size;
         let info_size = Self::round_up_to_alignment(info_size);
 
@@ -432,7 +432,7 @@ mod tests {
 
     fn validate_layout<T: InfoInternal + ?Sized>(info: &T, name: &[Char16]) {
         // Check the hardcoded struct alignment.
-        assert_eq!(mem::align_of_val(info), T::alignment());
+        assert_eq!(align_of_val(info), T::alignment());
         // Check the hardcoded name slice offset.
         assert_eq!(
             unsafe { (name.as_ptr() as *const u8).offset_from(info as *const _ as *const u8) },
@@ -481,7 +481,7 @@ mod tests {
         // = 100
         // Round size up to match FileInfo alignment of 8: 104
         assert_eq!(info.size, 104);
-        assert_eq!(info.size, mem::size_of_val(info) as u64);
+        assert_eq!(info.size, size_of_val(info) as u64);
 
         assert_eq!(info.file_size(), file_size);
         assert_eq!(info.physical_size(), physical_size);
@@ -518,7 +518,7 @@ mod tests {
         // = 58
         // Round size up to match FileSystemInfo alignment of 8: 64
         assert_eq!(info.size, 64);
-        assert_eq!(info.size, mem::size_of_val(info) as u64);
+        assert_eq!(info.size, size_of_val(info) as u64);
 
         assert_eq!(info.read_only, read_only);
         assert_eq!(info.volume_size, volume_size);

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -170,7 +170,7 @@ pub trait File: Sized {
     /// * [`uefi::Status::BAD_BUFFER_SIZE`]
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
         let info_ptr = ptr::from_ref(info).cast::<c_void>();
-        let info_size = mem::size_of_val(info);
+        let info_size = size_of_val(info);
         unsafe { (self.imp().set_info)(self.imp(), &Info::GUID, info_size, info_ptr).to_result() }
     }
 
@@ -404,7 +404,7 @@ mod tests {
             &CString16::try_from("test_file").unwrap(),
         )
         .unwrap();
-        let required_size = mem::size_of_val(info);
+        let required_size = size_of_val(info);
         if *buffer_size < required_size {
             *buffer_size = required_size;
             Status::BUFFER_TOO_SMALL

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -678,10 +678,10 @@ impl DiscoverInfo {
         let server_count = srv_list.len();
         assert!(server_count <= u16::MAX as usize, "too many servers");
 
-        let required_size = core::mem::size_of::<bool>() * 4
-            + core::mem::size_of::<IpAddress>()
-            + core::mem::size_of::<u16>()
-            + core::mem::size_of_val(srv_list);
+        let required_size = size_of::<bool>() * 4
+            + size_of::<IpAddress>()
+            + size_of::<u16>()
+            + size_of_val(srv_list);
 
         if buffer.len() < required_size {
             return Err(Status::BUFFER_TOO_SMALL.into());

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -158,7 +158,7 @@ impl SimpleNetwork {
     /// Collect statistics on a network interface.
     pub fn collect_statistics(&self) -> Result<NetworkStats> {
         let mut stats_table: NetworkStats = Default::default();
-        let mut stats_size = core::mem::size_of::<NetworkStats>();
+        let mut stats_size = size_of::<NetworkStats>();
         let status = (self.statistics)(self, false, Some(&mut stats_size), Some(&mut stats_table));
         status.to_result_with_val(|| stats_table)
     }

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -2,7 +2,7 @@
 
 use crate::proto::unsafe_protocol;
 use crate::{Result, Status, StatusExt};
-use core::{mem, ptr};
+use core::ptr;
 
 pub use uefi_raw::protocol::rng::RngAlgorithmType;
 
@@ -18,7 +18,7 @@ impl Rng {
         &mut self,
         algorithm_list: &'buf mut [RngAlgorithmType],
     ) -> Result<&'buf [RngAlgorithmType], Option<usize>> {
-        let mut algorithm_list_size = mem::size_of_val(algorithm_list);
+        let mut algorithm_list_size = size_of_val(algorithm_list);
 
         unsafe {
             (self.0.get_info)(
@@ -28,7 +28,7 @@ impl Rng {
             )
             .to_result_with(
                 || {
-                    let len = algorithm_list_size / mem::size_of::<RngAlgorithmType>();
+                    let len = algorithm_list_size / size_of::<RngAlgorithmType>();
                     &algorithm_list[..len]
                 },
                 |status| {

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -15,7 +15,7 @@ use crate::util::{ptr_write_unaligned_and_add, usize_from_u32};
 use crate::{Error, Result, Status, StatusExt};
 use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
-use core::{mem, ptr};
+use core::ptr;
 use ptr_meta::Pointee;
 use uefi_raw::protocol::tcg::v1::{TcgBootServiceCapability, TcgProtocol};
 
@@ -117,10 +117,10 @@ impl PcrEvent {
         let event_data_size = u32::try_from(event_data.len())
             .map_err(|_| Error::new(Status::INVALID_PARAMETER, None))?;
 
-        let required_size = mem::size_of::<PcrIndex>()
-            + mem::size_of::<EventType>()
-            + mem::size_of::<Sha1Digest>()
-            + mem::size_of::<u32>()
+        let required_size = size_of::<PcrIndex>()
+            + size_of::<EventType>()
+            + size_of::<Sha1Digest>()
+            + size_of::<u32>()
             + event_data.len();
 
         if buffer.len() < required_size {
@@ -322,7 +322,7 @@ impl<'a> Iterator for EventLogIter<'a> {
         if self.location == self.log.last_entry {
             self.location = ptr::null();
         } else {
-            self.location = unsafe { self.location.add(mem::size_of_val(event)) };
+            self.location = unsafe { self.location.add(size_of_val(event)) };
         }
 
         Some(event)
@@ -512,8 +512,7 @@ mod tests {
         assert_eq!(event.event_data(), data);
 
         let event_ptr: *const PcrEvent = event;
-        let bytes =
-            unsafe { slice::from_raw_parts(event_ptr.cast::<u8>(), mem::size_of_val(event)) };
+        let bytes = unsafe { slice::from_raw_parts(event_ptr.cast::<u8>(), size_of_val(event)) };
         #[rustfmt::skip]
         assert_eq!(bytes, [
             // PCR index

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -1,11 +1,10 @@
-use core::mem;
 use core::ptr::{self, NonNull};
 
 /// Copy the bytes of `val` to `ptr`, then advance pointer to just after the
 /// newly-copied bytes.
 pub unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
     ptr.cast::<T>().write_unaligned(val);
-    *ptr = ptr.add(mem::size_of::<T>());
+    *ptr = ptr.add(size_of::<T>());
 }
 
 /// Convert from a `u32` to a `usize`. Panic if the input does fit. On typical
@@ -18,7 +17,7 @@ pub unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
 pub const fn usize_from_u32(val: u32) -> usize {
     // This is essentially the same as `usize::try_from(val).unwrap()`, but
     // works in a `const` context on stable.
-    if mem::size_of::<usize>() < mem::size_of::<u32>() && val < (usize::MAX as u32) {
+    if size_of::<usize>() < size_of::<u32>() && val < (usize::MAX as u32) {
         panic!("value does not fit in a usize");
     } else {
         val as usize


### PR DESCRIPTION
As of Rust 1.80, these functions are in the prelude so we don't need to import `mem` or fully specify the path.

Also replace one use of `size_of` with `usize::BITS` as suggested by clippy.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
