### PR TITLE
book: Set driver link-arg in `build.rs`

### DIFF
--- a/book/src/how_to/building_drivers.md
+++ b/book/src/how_to/building_drivers.md
@@ -11,10 +11,15 @@ value to `efi_boot_service_driver` or `efi_runtime_driver`.
 
 Example:
 
-```toml
-# In .cargo/config.toml:
-[build]
-rustflags = ["-C", "link-args=/subsystem:efi_runtime_driver"]
+```rust
+// In build.rs
+
+fn main() {
+    let target = std::env::var("TARGET").unwrap();
+    if target.ends_with("-unknown-uefi") {
+        println!("cargo::rustc-link-arg=/subsystem:efi_runtime_driver");
+    }
+}
 ```
 
 [spec-images]: https://uefi.org/specs/UEFI/2.10/02_Overview.html#uefi-images


### PR DESCRIPTION
`config.toml` is a project-level configuration. Cargo will only read the configuration from the current directory and up, and not in:

- package directories in a workspace
- package directories when `--manifest-path` is used

Use `build.rs` instead, which will be executed before the package is built and only apply the flags for the specific package. This allows mixing drivers and applications in a workspace while still invoking Cargo from the workspace root.

Ref: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
Ref: https://doc.rust-lang.org/cargo/reference/build-scripts.html

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
