### PR TITLE
relicensing: Rewrite set_timer PR

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Added `HiiDatabaseProtocol`.
 - Added `ScsiIoProtocol`.
 - Added `Default` and other common impls for HTTP types.
+- Added `boot::TimerDelay`.
+
+## Changed
+- The definition of `BootServices::set_timer` now uses `TimerDelay` rather than
+  a plain integer.
 
 
 # uefi-raw - 0.9.0 (2024-10-23)

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -47,7 +47,8 @@ pub struct BootServices {
         notify_ctx: *mut c_void,
         out_event: *mut Event,
     ) -> Status,
-    pub set_timer: unsafe extern "efiapi" fn(event: Event, ty: u32, trigger_time: u64) -> Status,
+    pub set_timer:
+        unsafe extern "efiapi" fn(event: Event, ty: TimerDelay, trigger_time: u64) -> Status,
     pub wait_for_event: unsafe extern "efiapi" fn(
         number_of_events: usize,
         events: *mut Event,
@@ -484,3 +485,11 @@ pub enum Tpl: usize => {
 /// Note that this is not necessarily the processor's page size. The UEFI page
 /// size is always 4 KiB.
 pub const PAGE_SIZE: usize = 4096;
+
+newtype_enum! {
+    pub enum TimerDelay: i32 => {
+        CANCEL = 0,
+        PERIODIC = 1,
+        RELATIVE = 2,
+    }
+}


### PR DESCRIPTION
See https://github.com/rust-osdev/uefi-rs/issues/1521. This rewrites code from pavlus that we do not have relicensing approval for.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
