### PR TITLE
Add warning to custom memory types

### DIFF
--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -439,6 +439,7 @@ impl MemoryType {
 
     /// Construct a custom `MemoryType`. Values in the range `0x8000_0000..=0xffff_ffff` are free for use if you are
     /// an OS loader.
+    /// **Warning:** Some EFI firmware versions (e.g., OVMF r11337) may crash or behave incorrectly when using a custom `MemoryType`.
     #[must_use]
     pub const fn custom(value: u32) -> Self {
         assert!(value >= 0x80000000);

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -439,7 +439,8 @@ impl MemoryType {
 
     /// Construct a custom `MemoryType`. Values in the range `0x8000_0000..=0xffff_ffff` are free for use if you are
     /// an OS loader.
-    /// Warning* Some EFI firmware versions (e.g., OVMF r11337) may crash or [behave incorrectly](<https://wiki.osdev.org/UEFI#My_bootloader_hangs_if_I_use_user_defined_EFI_MEMORY_TYPE_values>) when using a custom `MemoryType`.
+    ///
+    /// **Warning**: Some EFI firmware versions (e.g., OVMF r11337) may crash or [behave incorrectly](https://wiki.osdev.org/UEFI#My_bootloader_hangs_if_I_use_user_defined_EFI_MEMORY_TYPE_values) when using a custom `MemoryType`.
     #[must_use]
     pub const fn custom(value: u32) -> Self {
         assert!(value >= 0x80000000);

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -439,7 +439,7 @@ impl MemoryType {
 
     /// Construct a custom `MemoryType`. Values in the range `0x8000_0000..=0xffff_ffff` are free for use if you are
     /// an OS loader.
-    /// **Warning:** Some EFI firmware versions (e.g., OVMF r11337) may crash or behave incorrectly when using a custom `MemoryType`.
+    /// Warning* Some EFI firmware versions (e.g., OVMF r11337) may crash or [behave incorrectly](<https://wiki.osdev.org/UEFI#My_bootloader_hangs_if_I_use_user_defined_EFI_MEMORY_TYPE_values>) when using a custom `MemoryType`.
     #[must_use]
     pub const fn custom(value: u32) -> Self {
         assert!(value >= 0x80000000);


### PR DESCRIPTION
<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

When using custom memory types in an uefi application there is a bug that causes the system to freeze on some machines. I had the same issue and struggled for quite sometime. #1375

Thus, I think it would be helpful to add a warning to the documentation regarding this issue:

>For the memory management functions in EFI, an OS is meant to be able to use "memory type" values above 0x80000000 >for its own purposes. In the OVMF EFI firmware release "r11337" (for Qemu, etc) there is a bug where the firmware >assumes the memory type is within the range of values defined for EFI's own use, and uses the memory type as an array >index. The end result is an "array index out of bounds" bug; where the higher memory type values (e.g. perfectly legal >values above 0x80000000) cause the 64-bit version of the firmware to crash (page fault), and cause incorrect "attribute" >values to be reported by the 32-bit version of the firmware. This same bug is also present in whatever version of the EFI >firmware VirtualBox uses (which looks like an older version of OVMF); and I suspect (but don't know) that the bug may be >present in a wide variety of firmware that was derived from the tianocore project (not just OVMF). 
[Source](https://wiki.osdev.org/UEFI#My_bootloader_hangs_if_I_use_user_defined_EFI_MEMORY_TYPE_values)

It is a small change, but can still save new devs a lot of time & frustration.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
