### PR TITLE
Add SPDX headers

### DIFF
--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![recursion_limit = "128"]
 
 extern crate proc_macro;

--- a/uefi-macros/tests/compilation.rs
+++ b/uefi-macros/tests/compilation.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/uefi-raw/src/capsule.rs
+++ b/uefi-raw/src/capsule.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI update capsules.
 //!
 //! Capsules are used to pass information to the firmware, for example to

--- a/uefi-raw/src/enums.rs
+++ b/uefi-raw/src/enums.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module provides tooling that facilitates dealing with C-style enums
 //!
 //! C-style enums and Rust-style enums are quite different. There are things

--- a/uefi-raw/src/firmware_storage.rs
+++ b/uefi-raw/src/firmware_storage.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Types related to firmware storage.
 
 use crate::Guid;

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Raw interface for working with UEFI.
 //!
 //! This crate is intended for implementing UEFI services. It is also used for

--- a/uefi-raw/src/protocol/block.rs
+++ b/uefi-raw/src/protocol/block.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Guid, Status};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod serial;
 
 use crate::{guid, Char16, Event, Guid, PhysicalAddress, Status};

--- a/uefi-raw/src/protocol/console/serial.rs
+++ b/uefi-raw/src/protocol/console/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Guid, Status};
 use bitflags::bitflags;
 

--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod device_path_gen;
 
 use crate::{guid, Char16, Guid};

--- a/uefi-raw/src/protocol/device_path/device_path_gen.rs
+++ b/uefi-raw/src/protocol/device_path/device_path_gen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // DO NOT EDIT
 //
 // This file was automatically generated with:

--- a/uefi-raw/src/protocol/disk.rs
+++ b/uefi-raw/src/protocol/disk.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Event, Guid, Status};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/driver.rs
+++ b/uefi-raw/src/protocol/driver.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::{guid, Guid, Handle, Status};
 

--- a/uefi-raw/src/protocol/file_system.rs
+++ b/uefi-raw/src/protocol/file_system.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::time::Time;
 use crate::{guid, Char16, Event, Guid, Status};
 use bitflags::bitflags;

--- a/uefi-raw/src/protocol/firmware_volume.rs
+++ b/uefi-raw/src/protocol/firmware_volume.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::firmware_storage::FirmwareVolumeAttributes;
 use crate::protocol::block::Lba;
 use crate::{guid, Guid, Handle, PhysicalAddress, Status};

--- a/uefi-raw/src/protocol/hii/database.rs
+++ b/uefi-raw/src/protocol/hii/database.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Bindings for HII Database Protocol
 
 use super::{HiiHandle, HiiPackageHeader, HiiPackageListHeader, KeyDescriptor};

--- a/uefi-raw/src/protocol/hii/mod.rs
+++ b/uefi-raw/src/protocol/hii/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! HII Protocols
 
 pub mod database;

--- a/uefi-raw/src/protocol/loaded_image.rs
+++ b/uefi-raw/src/protocol/loaded_image.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::table::boot::MemoryType;
 use crate::table::system::SystemTable;

--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::{guid, Guid, Status};
 use core::ffi::c_void;

--- a/uefi-raw/src/protocol/memory_protection.rs
+++ b/uefi-raw/src/protocol/memory_protection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::table::boot::MemoryAttribute;
 use crate::{guid, Guid, PhysicalAddress, Status};
 

--- a/uefi-raw/src/protocol/misc.rs
+++ b/uefi-raw/src/protocol/misc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::table::runtime;
 use crate::{guid, Guid, Status};
 

--- a/uefi-raw/src/protocol/mod.rs
+++ b/uefi-raw/src/protocol/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Protocol definitions.
 //!
 //! Protocols are sets of related functionality identified by a unique

--- a/uefi-raw/src/protocol/network/dhcp4.rs
+++ b/uefi-raw/src/protocol/network/dhcp4.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Char8, Event, Guid, Ipv4Address, MacAddress, Status};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/network/http.rs
+++ b/uefi-raw/src/protocol/network/http.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Char16, Char8, Event, Guid, Ipv4Address, Ipv6Address, Status};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};

--- a/uefi-raw/src/protocol/network/ip4.rs
+++ b/uefi-raw/src/protocol/network/ip4.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::Ipv4Address;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/uefi-raw/src/protocol/network/ip4_config2.rs
+++ b/uefi-raw/src/protocol/network/ip4_config2.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::protocol::network::ip4::Ip4RouteTable;
 use crate::{guid, Char16, Event, Guid, Ipv4Address, MacAddress, Status};
 use core::ffi::c_void;

--- a/uefi-raw/src/protocol/network/mod.rs
+++ b/uefi-raw/src/protocol/network/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod dhcp4;
 pub mod http;
 pub mod ip4;

--- a/uefi-raw/src/protocol/network/tls.rs
+++ b/uefi-raw/src/protocol/network/tls.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Guid, Status};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/rng.rs
+++ b/uefi-raw/src/protocol/rng.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `Rng` protocol.
 
 use crate::{guid, Guid, Status};

--- a/uefi-raw/src/protocol/scsi.rs
+++ b/uefi-raw/src/protocol/scsi.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Event, Guid, Status};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/shell_params.rs
+++ b/uefi-raw/src/protocol/shell_params.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Char16, Guid};
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/string.rs
+++ b/uefi-raw/src/protocol/string.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{guid, Char16, Char8, Guid};
 
 #[derive(Debug)]

--- a/uefi-raw/src/protocol/tcg.rs
+++ b/uefi-raw/src/protocol/tcg.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocols.
 //!
 //! These protocols provide access to the [TPM][tpm] (Trusted Platform Module).

--- a/uefi-raw/src/protocol/tcg/enums.rs
+++ b/uefi-raw/src/protocol/tcg/enums.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 newtype_enum! {
     /// Algorithm identifiers.
     ///

--- a/uefi-raw/src/protocol/tcg/v1.rs
+++ b/uefi-raw/src/protocol/tcg/v1.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
 //! Module) 1.1 and 1.2.
 //!

--- a/uefi-raw/src/protocol/tcg/v2.rs
+++ b/uefi-raw/src/protocol/tcg/v2.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
 //! Module) 2.0.
 //!

--- a/uefi-raw/src/status.rs
+++ b/uefi-raw/src/status.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::fmt::Debug;
 
 newtype_enum! {

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI services available during boot.
 
 use crate::protocol::device_path::DevicePathProtocol;

--- a/uefi-raw/src/table/configuration.rs
+++ b/uefi-raw/src/table/configuration.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::Guid;
 use core::ffi::c_void;
 

--- a/uefi-raw/src/table/header.rs
+++ b/uefi-raw/src/table/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::Revision;
 
 /// The common header that all UEFI tables begin with.

--- a/uefi-raw/src/table/mod.rs
+++ b/uefi-raw/src/table/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Standard UEFI tables.
 
 mod header;

--- a/uefi-raw/src/table/revision.rs
+++ b/uefi-raw/src/table/revision.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::fmt;
 
 /// A revision of the UEFI specification.

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI services available at runtime, even after the OS boots.
 
 use crate::capsule::CapsuleHeader;

--- a/uefi-raw/src/table/system.rs
+++ b/uefi-raw/src/table/system.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::protocol::console::{SimpleTextInputProtocol, SimpleTextOutputProtocol};
 use crate::table::boot::BootServices;
 use crate::table::configuration::ConfigurationTable;

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Date and time types.
 
 use bitflags::bitflags;

--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // ANCHOR: all
 // ANCHOR: features
 #![no_main]

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // ANCHOR: all
 #![no_main]
 #![no_std]

--- a/uefi-test-runner/examples/shell_params.rs
+++ b/uefi-test-runner/examples/shell_params.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // ANCHOR: all
 // ANCHOR: features
 #![no_main]

--- a/uefi-test-runner/examples/sierpinski.rs
+++ b/uefi-test-runner/examples/sierpinski.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // ANCHOR: all
 #![no_main]
 #![no_std]

--- a/uefi-test-runner/examples/timestamp.rs
+++ b/uefi-test-runner/examples/timestamp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // ANCHOR: all
 // ANCHOR: features
 #![no_main]

--- a/uefi-test-runner/src/bin/shell_launcher.rs
+++ b/uefi-test-runner/src/bin/shell_launcher.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This application launches the UEFI shell app and runs the main
 //! uefi-test-running app inside that shell. This allows testing of protocols
 //! that require the shell.

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::vec::Vec;
 use uefi::boot::{self, AllocateType};
 use uefi::mem::memory_map::{MemoryMap, MemoryMapMut, MemoryType};

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::ffi::c_void;
 use core::ptr::{self, NonNull};
 

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::string::ToString;
 use uefi::boot::{LoadImageSource, SearchType};
 use uefi::fs::FileSystem;

--- a/uefi-test-runner/src/fs/mod.rs
+++ b/uefi-test-runner/src/fs/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Tests functionality from the `uefi::fs` module. See function [`test`].
 
 use alloc::string::{String, ToString};

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![no_std]
 #![no_main]
 

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{send_request_to_host, HostRequest};
 use uefi::boot::{self, OpenProtocolAttributes, OpenProtocolParams};
 use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::prelude::*;
 
 pub fn test() {

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot;
 use uefi::proto::console::pointer::Pointer;
 

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::reconnect_serial_to_console;
 use uefi::proto::console::serial::{ControlBits, Serial};
 use uefi::{boot, Result, ResultExt, Status};

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::prelude::*;
 use uefi::proto::console::text::{Color, Output};
 

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::vec::Vec;
 use core::ffi::c_void;
 use uefi::boot;

--- a/uefi-test-runner/src/proto/device_path.rs
+++ b/uefi-test-runner/src/proto/device_path.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use uefi::proto::device_path::build::{self, DevicePathBuilder};

--- a/uefi-test-runner/src/proto/driver.rs
+++ b/uefi-test-runner/src/proto/driver.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot::{self, ScopedProtocol, SearchType};
 use uefi::prelude::*;
 use uefi::proto::driver::{ComponentName, ComponentName2, LanguageError, LanguageIter};

--- a/uefi-test-runner/src/proto/load.rs
+++ b/uefi-test-runner/src/proto/load.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::prelude::*;
 use uefi::proto::loaded_image::LoadedImage;
 

--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::string::ToString;
 use core::cell::RefCell;
 use core::ptr::NonNull;

--- a/uefi-test-runner/src/proto/misc.rs
+++ b/uefi-test-runner/src/proto/misc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::prelude::*;
 use uefi::proto::misc::ResetNotification;
 use uefi::runtime::ResetType;

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot::{self, OpenProtocolParams};
 use uefi::proto::loaded_image::LoadedImage;
 use uefi::{proto, Identify};

--- a/uefi-test-runner/src/proto/network/mod.rs
+++ b/uefi-test-runner/src/proto/network/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub fn test() {
     info!("Testing Network protocols");
 

--- a/uefi-test-runner/src/proto/network/pxe.rs
+++ b/uefi-test-runner/src/proto/network/pxe.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::proto::network::pxe::{BaseCode, DhcpV4Packet, IpFilter, IpFilters, UdpOpFlags};
 use uefi::proto::network::IpAddress;
 use uefi::{boot, CStr8};

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::proto::network::snp::{InterruptStatus, ReceiveFlags, SimpleNetwork};
 use uefi::proto::network::MacAddress;
 use uefi::{boot, Status};

--- a/uefi-test-runner/src/proto/pi/mod.rs
+++ b/uefi-test-runner/src/proto/pi/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub fn test() {
     info!("Testing Platform Initialization protocols");
 

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::ffi::c_void;
 use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};

--- a/uefi-test-runner/src/proto/rng.rs
+++ b/uefi-test-runner/src/proto/rng.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot;
 use uefi::proto::rng::{Rng, RngAlgorithmType};
 

--- a/uefi-test-runner/src/proto/shell_params.rs
+++ b/uefi-test-runner/src/proto/shell_params.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot;
 use uefi::proto::shell_params::ShellParameters;
 

--- a/uefi-test-runner/src/proto/shim.rs
+++ b/uefi-test-runner/src/proto/shim.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::boot;
 use uefi::proto::shim::ShimLock;
 

--- a/uefi-test-runner/src/proto/string/mod.rs
+++ b/uefi-test-runner/src/proto/string/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub fn test() {
     info!("Testing String protocols");
 

--- a/uefi-test-runner/src/proto/string/unicode_collation.rs
+++ b/uefi-test-runner/src/proto/string/unicode_collation.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::cmp::Ordering;
 use uefi::proto::string::unicode_collation::{StrConversionError, UnicodeCollation};
 use uefi::{boot, CStr16, CStr8};

--- a/uefi-test-runner/src/proto/tcg.rs
+++ b/uefi-test-runner/src/proto/tcg.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use alloc::vec::Vec;
 use uefi::boot;
 use uefi::proto::tcg::{v1, v2, AlgorithmId, EventType, HashAlgorithm, PcrIndex};

--- a/uefi-test-runner/src/runtime/mod.rs
+++ b/uefi-test-runner/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod vars;
 
 use uefi::runtime::{self, Daylight, Time, TimeParams};

--- a/uefi-test-runner/src/runtime/vars.rs
+++ b/uefi-test-runner/src/runtime/vars.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use log::info;
 use uefi::prelude::*;
 use uefi::runtime::{VariableAttributes, VariableVendor};

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module implements Rust's global allocator interface using UEFI's memory allocation functions.
 //!
 //! If the `global_allocator` feature is enabled, the [`Allocator`] will be used

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI boot services.
 //!
 //! These functions will panic if called after exiting boot services.

--- a/uefi/src/data_types/chars.rs
+++ b/uefi/src/data_types/chars.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI character handling
 //!
 //! UEFI uses both Latin-1 and UCS-2 character encoding, this module implements

--- a/uefi/src/data_types/guid.rs
+++ b/uefi/src/data_types/guid.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub use uguid::Guid;
 
 /// Several entities in the UEFI specification can be referred to by their GUID,

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Data type definitions
 //!
 //! This module defines the basic data types that are used throughout uefi-rs

--- a/uefi/src/data_types/opaque.rs
+++ b/uefi/src/data_types/opaque.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /// Create an opaque struct suitable for use as an FFI pointer.
 ///
 /// The internal representation uses the recommendation in the [nomicon].

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::chars::{Char16, NUL_16};
 use super::strs::{CStr16, FromSliceWithNulError};
 use crate::data_types::strs::EqStrUntilNul;

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::chars::{Char16, Char8, NUL_16, NUL_8};
 use super::UnalignedSlice;
 use crate::polyfill::maybe_uninit_slice_assume_init_ref;

--- a/uefi/src/data_types/unaligned_slice.rs
+++ b/uefi/src/data_types/unaligned_slice.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for directory iteration. See [`UefiDirectoryIter`].
 
 use super::*;

--- a/uefi/src/fs/file_system/error.rs
+++ b/uefi/src/fs/file_system/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::fs::{PathBuf, PathError};
 use alloc::string::FromUtf8Error;
 use core::fmt::{self, Debug, Display, Formatter};

--- a/uefi/src/fs/file_system/fs.rs
+++ b/uefi/src/fs/file_system/fs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for [`FileSystem`].
 
 use crate::fs::*;

--- a/uefi/src/fs/file_system/mod.rs
+++ b/uefi/src/fs/file_system/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod error;
 mod fs;
 

--- a/uefi/src/fs/mod.rs
+++ b/uefi/src/fs/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! A high-level file system API for UEFI applications close to the `std::fs`
 //! module from Rust's standard library. The main export of this module is
 //! [`FileSystem`].

--- a/uefi/src/fs/path/mod.rs
+++ b/uefi/src/fs/path/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module offers the [`Path`] and [`PathBuf`] abstractions.
 //!
 //! # Interoperability with Rust strings

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // allow "path.rs" in "path"
 #![allow(clippy::module_inception)]
 

--- a/uefi/src/fs/path/pathbuf.rs
+++ b/uefi/src/fs/path/pathbuf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::fs::path::Path;
 use crate::fs::SEPARATOR;
 use crate::{CStr16, CString16, Char16};

--- a/uefi/src/fs/path/validation.rs
+++ b/uefi/src/fs/path/validation.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Path validation for the purpose of the [`fs`] module. This is decoupled from
 //! [`Path`] and [`PathBuf`], as the Rust standard library also does it this
 //! way. Instead, the FS implementation is responsible for that.

--- a/uefi/src/fs/uefi_types.rs
+++ b/uefi/src/fs/uefi_types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Re-export of low-level UEFI types but prefixed with `Uefi`. This simplifies
 //! to differ between high-level and low-level types and interfaces in this
 //! module.

--- a/uefi/src/helpers/global_allocator.rs
+++ b/uefi/src/helpers/global_allocator.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::allocator::Allocator;
 
 #[global_allocator]

--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This optional feature adds support for the `log` crate, providing
 //! a custom logger implementation which writes to a UEFI text output protocol.
 //!

--- a/uefi/src/helpers/mod.rs
+++ b/uefi/src/helpers/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module provides miscellaneous opinionated but optional helpers to
 //! better integrate your application with the Rust runtime and the Rust
 //! ecosystem.

--- a/uefi/src/helpers/panic_handler.rs
+++ b/uefi/src/helpers/panic_handler.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{boot, println};
 use cfg_if::cfg_if;
 

--- a/uefi/src/helpers/println.rs
+++ b/uefi/src/helpers/println.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{boot, system};
 use core::fmt::Write;
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Rusty wrapper for the [Unified Extensible Firmware Interface][UEFI].
 //!
 //! This crate makes it easy to develop Rust software that leverages **safe**,

--- a/uefi/src/macros.rs
+++ b/uefi/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /// Encode a string literal as a [`&CStr8`].
 ///
 /// The encoding is done at compile time, so the result can be used in a

--- a/uefi/src/mem/memory_map/api.rs
+++ b/uefi/src/mem/memory_map/api.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for the traits [`MemoryMap`] and [`MemoryMapMut`].
 
 use super::*;

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for [`MemoryMapOwned`], [`MemoryMapRef`], and [`MemoryMapRefMut`],
 //! as well as relevant helper types, such as [`MemoryMapBackingMemory`].
 

--- a/uefi/src/mem/memory_map/iter.rs
+++ b/uefi/src/mem/memory_map/iter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::*;
 
 /// An iterator for [`MemoryMap`].

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Bundles all relevant types and helpers to work with the UEFI memory map.
 //!
 //! To work with the memory map, you should use one of the structs

--- a/uefi/src/mem/mod.rs
+++ b/uefi/src/mem/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Types, functions, traits, and other helpers to work with memory in UEFI
 //! libraries and applications.
 

--- a/uefi/src/mem/util.rs
+++ b/uefi/src/mem/util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This is a utility module with helper methods for allocations/memory.
 
 use crate::data_types::Align;

--- a/uefi/src/polyfill.rs
+++ b/uefi/src/polyfill.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Polyfills for functions in the standard library that are currently gated
 //! behind unstable features.
 

--- a/uefi/src/prelude.rs
+++ b/uefi/src/prelude.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module is used to simplify importing the most common UEFI types.
 //!
 //! This includes the system table modules, `Status` codes, etc.

--- a/uefi/src/proto/boot_policy.rs
+++ b/uefi/src/proto/boot_policy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for the [`BootPolicy`] helper type.
 
 use core::fmt::{Display, Formatter};

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Graphics output protocol.
 //!
 //! The UEFI GOP is meant to replace existing [VGA][vga] hardware interfaces.

--- a/uefi/src/proto/console/mod.rs
+++ b/uefi/src/proto/console/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Console support protocols.
 //!
 //! The console represents the various input and output methods

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Pointer device access.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Abstraction over byte stream devices, also known as serial I/O devices.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::proto::unsafe_protocol;
 use crate::{Char16, Event, Result, Status, StatusExt};
 use core::mem::MaybeUninit;

--- a/uefi/src/proto/console/text/mod.rs
+++ b/uefi/src/proto/console/text/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Text I/O.
 
 mod input;

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::proto::unsafe_protocol;
 use crate::{CStr16, Result, ResultExt, Status, StatusExt};
 use core::fmt;

--- a/uefi/src/proto/debug/context.rs
+++ b/uefi/src/proto/debug/context.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // note from the spec:
 // When the context record field is larger than the register being stored in it, the upper bits of the
 // context record field are unused and ignored

--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /// Represents supported CPU exceptions.
 #[repr(C)]
 #[derive(Debug)]

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Provides support for the UEFI debugging protocol.
 //!
 //! This protocol is designed to allow debuggers to query the state of the firmware,

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Utilities for creating new [`DevicePaths`].
 //!
 //! This module contains [`DevicePathBuilder`], as well as submodules

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // DO NOT EDIT
 //
 // This file was automatically generated with:

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Device Path protocol
 //!
 //! A UEFI device path is a very flexible structure for encoding a

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Protocols for converting between UEFI strings and [`DevicePath`]/[`DevicePathNode`].
 
 // Note on return types: the specification of the conversion functions

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // This module defines the `ComponentName1` type and marks it deprecated. That
 // causes warnings for uses within this module (e.g. the `impl ComponentName1`
 // block), so turn off deprecated warnings. It's not yet possible to make this

--- a/uefi/src/proto/driver/mod.rs
+++ b/uefi/src/proto/driver/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI driver model protocols.
 
 mod component_name;

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `LoadedImage` protocol.
 
 use crate::data_types::FromSliceWithNulError;

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Block I/O protocols.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Disk I/O protocols.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{File, FileHandle, FileInfo, FromUefi, RegularFile};
 use crate::data_types::Align;
 use crate::Result;

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::FileAttribute;
 use crate::data_types::Align;
 use crate::runtime::Time;

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! This module provides the `FileHandle` structure as well as the more specific `RegularFile` and
 //! `Directory` structures. This module also provides the `File` trait for opening, querying,
 //! creating, reading, and writing files.

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{File, FileHandle, FileInternal};
 use crate::{Error, Result, Status, StatusExt};
 

--- a/uefi/src/proto/media/fs.rs
+++ b/uefi/src/proto/media/fs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! File system support protocols.
 
 use super::file::{Directory, FileHandle};

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! LoadFile and LoadFile2 protocols.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/media/mod.rs
+++ b/uefi/src/proto/media/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Media access protocols.
 //!
 //! These protocols can be used to enumerate and access various media devices.

--- a/uefi/src/proto/media/partition.rs
+++ b/uefi/src/proto/media/partition.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Partition information protocol.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/misc.rs
+++ b/uefi/src/proto/misc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Miscellaneous protocols.
 
 use uefi_raw::protocol::misc::{

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Protocol definitions.
 //!
 //! Protocols are sets of related functionality identified by a unique

--- a/uefi/src/proto/network/mod.rs
+++ b/uefi/src/proto/network/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Network access protocols.
 //!
 //! These protocols can be used to interact with network resources.

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! PXE Base Code protocol.
 
 use core::ffi::c_void;

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Simple Network Protocol
 //!
 //! Provides a packet level interface to a network adapter.

--- a/uefi/src/proto/pi/mod.rs
+++ b/uefi/src/proto/pi/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Platform Initialization protocols.
 //!
 //! Contains protocols defined in UEFI's

--- a/uefi/src/proto/pi/mp.rs
+++ b/uefi/src/proto/pi/mp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Multi-processor management protocols.
 //!
 //! On any system with more than one logical processor we can categorize them as:

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `Rng` protocol.
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/security/memory_protection.rs
+++ b/uefi/src/proto/security/memory_protection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::data_types::PhysicalAddress;
 use crate::mem::memory_map::MemoryAttribute;
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/security/mod.rs
+++ b/uefi/src/proto/security/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Protocols related to secure technologies.
 
 mod memory_protection;

--- a/uefi/src/proto/shell_params.rs
+++ b/uefi/src/proto/shell_params.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `ShellParams` protocol
 
 use crate::proto::unsafe_protocol;

--- a/uefi/src/proto/shim/mod.rs
+++ b/uefi/src/proto/shim/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Shim lock protocol.
 
 #![cfg(any(

--- a/uefi/src/proto/string/mod.rs
+++ b/uefi/src/proto/string/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! String protocols.
 //!
 //! The protocols provide some string operations like

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! The Unicode Collation Protocol.
 //!
 //! This protocol is used in the boot services environment to perform

--- a/uefi/src/proto/tcg/mod.rs
+++ b/uefi/src/proto/tcg/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocols.
 //!
 //! These protocols provide access to the [TPM][tpm] (Trusted Platform Module).

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
 //! Module) 1.1 and 1.2.
 //!

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! [TCG] (Trusted Computing Group) protocol for [TPM] (Trusted Platform
 //! Module) 2.0.
 //!

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Module for UEFI-specific error encodings. See [`Error`].
 
 use super::Status;

--- a/uefi/src/result/mod.rs
+++ b/uefi/src/result/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Facilities for dealing with UEFI operation results.
 
 use core::fmt::Debug;

--- a/uefi/src/result/status.rs
+++ b/uefi/src/result/status.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{Error, Result};
 use core::fmt::Debug;
 

--- a/uefi/src/runtime.rs
+++ b/uefi/src/runtime.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! UEFI runtime services.
 //!
 //! These services are available both before and after exiting boot

--- a/uefi/src/system.rs
+++ b/uefi/src/system.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Functions for accessing fields of the system table.
 //!
 //! Some of these functions use a callback argument rather than returning a

--- a/uefi/src/table/cfg.rs
+++ b/uefi/src/table/cfg.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Configuration table utilities.
 //!
 //! The configuration table is an array of GUIDs and pointers to extra system tables.

--- a/uefi/src/table/header.rs
+++ b/uefi/src/table/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::Revision;
 
 /// All standard UEFI tables begin with a common header.

--- a/uefi/src/table/mod.rs
+++ b/uefi/src/table/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Standard UEFI tables.
 
 pub mod cfg;

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use core::ptr::{self, NonNull};
 
 /// Copy the bytes of `val` to `ptr`, then advance pointer to just after the

--- a/uefi/tests/memory_map.rs
+++ b/uefi/tests/memory_map.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use uefi::mem::memory_map::*;
 
 /// This test imitates a kernel that receives the UEFI memory map as boot

--- a/xtask/src/arch.rs
+++ b/xtask/src/arch.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::arch::UefiArch;
 use anyhow::{bail, Result};
 use std::env;

--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Validate various properties of the code in the `uefi-raw` package.
 //!
 //! For example, this checks that no Rust enums are used, that structs have an

--- a/xtask/src/device_path/field.rs
+++ b/xtask/src/device_path/field.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::device_path::util::is_doc_attr;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/xtask/src/device_path/group.rs
+++ b/xtask/src/device_path/group.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::node::{is_node_attr, Node};
 use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod field;
 mod group;
 mod node;

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -24,7 +24,8 @@ fn code_to_string(code: TokenStream) -> Result<String> {
     let code = code.to_string().replace('}', "}\n\n");
 
     let output = format!(
-        "
+        "// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // DO NOT EDIT
 //
 // This file was automatically generated with:

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::field::NodeField;
 use super::group::DeviceType;
 use crate::device_path::util::is_doc_attr;

--- a/xtask/src/device_path/spec.rs
+++ b/xtask/src/device_path/spec.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // See the README in this directory for details of what this file is.
 //
 // The nodes here are in the same order as in the UEFI Specification.

--- a/xtask/src/device_path/util.rs
+++ b/xtask/src/device_path/util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use std::io::Write;
 use std::process::{Command, Stdio};

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use anyhow::Result;
 use fatfs::{Date, DateTime, FileSystem, FormatVolumeOptions, FsOptions, Time};
 use mbrman::{MBRPartitionEntry, BOOT_INACTIVE, CHS, MBR};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -245,13 +245,10 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
             Err(e) => {
                 if fmt_opt.check {
                     eprintln!("❌ {e:#?}");
-                    // TODO: Make this a hard error after all the headers have
-                    // been added.
-                    eprintln!("...ignoring for now");
                 } else {
                     eprintln!("❌ rust formatter failed: {e:#?}");
-                    any_errors = true;
                 }
+                any_errors = true;
             }
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -233,6 +233,27 @@ fn run_host_tests(test_opt: &TestOpt) -> Result<()> {
 fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
     let mut any_errors = false;
 
+    {
+        eprintln!("Formatting: file headers");
+
+        match format_file_headers(fmt_opt) {
+            Ok(_) => {
+                eprintln!("✅ expected file headers present")
+            }
+            Err(e) => {
+                if fmt_opt.check {
+                    eprintln!("❌ {e:#?}");
+                    // TODO: Make this a hard error after all the headers have
+                    // been added.
+                    eprintln!("...ignoring for now");
+                } else {
+                    eprintln!("❌ rust formatter failed: {e:#?}");
+                    any_errors = true;
+                }
+            }
+        }
+    }
+
     // fmt rust
     {
         eprintln!("Formatting: rust");
@@ -318,6 +339,67 @@ fn run_fmt_project(fmt_opt: &FmtOpt) -> Result<()> {
 
     if any_errors {
         bail!("one or more formatting errors");
+    }
+
+    Ok(())
+}
+
+/// Check that SPDX file headers are present.
+///
+/// If not in check mode, add any missing headers.
+fn format_file_headers(fmt_opt: &FmtOpt) -> Result<()> {
+    const EXPECTED_HEADER: &str = "// SPDX-License-Identifier: MIT OR Apache-2.0\n\n";
+
+    // Path prefixes that should not be checked/formatted.
+    const EXCLUDE_PATH_PREFIXES: &[&str] = &[
+        // A user copying the template or uefi-std-example does not need to use
+        // our license.
+        "template/src/main.rs",
+        "uefi-std-example/src/main.rs",
+        // This directory contains short code snippets used in `trybuild` tests,
+        // no license needed.
+        "uefi-macros/tests/ui/",
+    ];
+
+    // Recursively get Rust files
+    let mut cmd = Command::new("git");
+    cmd.args(["ls-files", "*.rs"]);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!("command failed: {}", output.status);
+    }
+    let mut paths: Vec<&str> = std::str::from_utf8(&output.stdout)?.lines().collect();
+
+    // Filter out excluded paths.
+    paths.retain(|path| {
+        !EXCLUDE_PATH_PREFIXES
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+    });
+
+    // Paths that are missing the file header (only used in check mode).
+    let mut missing = Vec::new();
+
+    // Format or check each path.
+    for path in paths {
+        let text = fs_err::read_to_string(path)?;
+        if text.starts_with(EXPECTED_HEADER) {
+            // File header is present, nothing to do.
+            continue;
+        }
+
+        if fmt_opt.check {
+            // Add to the list of paths missing file headers.
+            missing.push(path);
+        } else {
+            // Rewrite the file to prepend the header.
+            let text = EXPECTED_HEADER.to_owned() + &text;
+            fs_err::write(path, text)?;
+        }
+    }
+
+    if fmt_opt.check && !missing.is_empty() {
+        bail!("expected header missing from {}", missing.join(", "));
     }
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod arch;
 mod cargo;
 mod check_raw;

--- a/xtask/src/net.rs
+++ b/xtask/src/net.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::arch::UefiArch;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::ops::Deref;

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::platform;
 use crate::qemu::Io;
 use anyhow::Result;

--- a/xtask/src/platform.rs
+++ b/xtask/src/platform.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Functions to determine the host platform.
 //!
 //! Use the functions where possible instead of `#[cfg(...)]` so that

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::arch::UefiArch;
 use crate::disk::{check_mbr_test_disk, create_mbr_test_disk};
 use crate::opt::QemuOpt;

--- a/xtask/src/tpm.rs
+++ b/xtask/src/tpm.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::opt::TpmVersion;
 use crate::util::command_to_string;
 use anyhow::Result;

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use anyhow::{bail, Result};
 use std::process::Command;
 


### PR DESCRIPTION
* The first commit adds SPDX headers to the two generated source files.
* The second commit adds `xtask` code for checking/adding SPDX headers.
* The next five commits add the SPDX headers to `uefi-macros`, `uefi-raw`, `uefi-test-runner`, `uefi`, and `xtask` directories
* The final commit makes the `xtask` header check fatal if any headers are missing.

Closes https://github.com/rust-osdev/uefi-rs/issues/1511

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
