### PR TITLE
uefi: Update license info in docstring

### DIFF
--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -186,18 +186,14 @@
 //! # License
 //! <!-- Keep in Sync with README! -->
 //!
-//! The code in this repository is licensed under the Mozilla Public License 2.
-//! This license allows you to use the crate in proprietary programs, but any
-//! modifications to the files must be open-sourced.
-//!
-//! The full text of the license is available in the [license file][LICENSE].
+//! Licensed under either of [Apache License, Version 2.0][apache] or
+//! [MIT license][mit] at your option.
 //!
 //! # Terminology
 //!
 //! Both "EFI" and "UEFI" can be used interchangeably, such as "UEFI image" or
 //! "EFI image". We prefer "UEFI" in our crate and its documentation.
 //!
-//! [LICENSE]: https://github.com/rust-osdev/uefi-rs/blob/main/uefi/LICENSE
 //! [Rust UEFI Book]: https://rust-osdev.github.io/uefi-rs/HEAD/
 //! [UEFI]: https://uefi.org/
 //! [Zulip]: https://rust-osdev.zulipchat.com
@@ -206,8 +202,10 @@
 //! [`entry-macro`]: uefi_macros::entry
 //! [`r-efi`]: https://crates.io/crates/r-efi
 //! [`unsafe_protocol`]: proto::unsafe_protocol
+//! [apache]: https://github.com/rust-osdev/uefi-rs/blob/main/uefi/LICENSE-APACHE
 //! [contributing]: https://github.com/rust-osdev/uefi-rs/blob/main/CONTRIBUTING.md
 //! [issue tracker]: https://github.com/rust-osdev/uefi-rs/issues
+//! [mit]: https://github.com/rust-osdev/uefi-rs/blob/main/uefi/LICENSE-MIT
 //! [rustc-uefi-std]: https://doc.rust-lang.org/nightly/rustc/platform-support/unknown-uefi.html
 //! [spec]: https://uefi.org/specifications
 //! [template]: https://github.com/rust-osdev/uefi-rs/tree/main/template


### PR DESCRIPTION
Missed this one in the previous cleanup.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
