### PR TITLE
uefi-raw: use new Boolean type 

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -59,6 +59,7 @@ Details at <https://github.com/rust-osdev/uefi-rs/issues/1470>.
 - `maximum_capsule_size` of `query_capsule_capabilities` now takes a *mut u64 instead of a *mut usize.
 - `ResetType` now derives the `Default` trait.
 
+
 # uefi-raw - 0.5.2 (2024-04-19)
 
 ## Added

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -33,10 +33,11 @@ pub mod time;
 
 mod status;
 
-use core::ffi::c_void;
-use core::fmt::{self, Debug, Formatter};
 pub use status::Status;
 pub use uguid::{guid, Guid};
+
+use core::ffi::c_void;
+use core::fmt::{self, Debug, Formatter};
 
 /// Handle to an event structure.
 pub type Event = *mut c_void;

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -190,10 +190,10 @@ mod tests {
         assert_eq!(Boolean::from(false).0, 0);
         assert_eq!(Boolean::TRUE.0, 1);
         assert_eq!(Boolean::FALSE.0, 0);
-        assert_eq!(bool::from(Boolean(0b0)), false);
-        assert_eq!(bool::from(Boolean(0b1)), true);
+        assert!(!bool::from(Boolean(0b0)));
+        assert!(bool::from(Boolean(0b1)));
         // We do it as in C: Every bit pattern not 0 is equal to true.
-        assert_eq!(bool::from(Boolean(0b11111110)), true);
-        assert_eq!(bool::from(Boolean(0b11111111)), true);
+        assert!(bool::from(Boolean(0b11111110)));
+        assert!(bool::from(Boolean(0b11111111)));
     }
 }

--- a/uefi-raw/src/protocol/block.rs
+++ b/uefi-raw/src/protocol/block.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{guid, Guid, Status};
+use crate::{guid, Boolean, Guid, Status};
 use core::ffi::c_void;
 
 /// Logical block address.
@@ -11,11 +11,11 @@ pub type Lba = u64;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct BlockIoMedia {
     pub media_id: u32,
-    pub removable_media: bool,
-    pub media_present: bool,
-    pub logical_partition: bool,
-    pub read_only: bool,
-    pub write_caching: bool,
+    pub removable_media: Boolean,
+    pub media_present: Boolean,
+    pub logical_partition: Boolean,
+    pub read_only: Boolean,
+    pub write_caching: Boolean,
     pub block_size: u32,
     pub io_align: u32,
     pub last_block: Lba,
@@ -33,7 +33,7 @@ pub struct BlockIoMedia {
 pub struct BlockIoProtocol {
     pub revision: u64,
     pub media: *const BlockIoMedia,
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub read_blocks: unsafe extern "efiapi" fn(
         this: *const Self,
         media_id: u32,

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -2,7 +2,7 @@
 
 pub mod serial;
 
-use crate::{guid, Char16, Event, Guid, PhysicalAddress, Status};
+use crate::{guid, Boolean, Char16, Event, Guid, PhysicalAddress, Status};
 use bitflags::bitflags;
 use core::ptr;
 
@@ -44,7 +44,7 @@ pub struct AbsolutePointerState {
 #[derive(Debug)]
 #[repr(C)]
 pub struct AbsolutePointerProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: u8) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub get_state:
         unsafe extern "efiapi" fn(this: *const Self, state: *mut AbsolutePointerState) -> Status,
     pub wait_for_input: Event,
@@ -65,7 +65,7 @@ pub struct InputKey {
 #[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextInputProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub read_key_stroke: unsafe extern "efiapi" fn(this: *mut Self, key: *mut InputKey) -> Status,
     pub wait_for_key: Event,
 }
@@ -82,13 +82,13 @@ pub struct SimpleTextOutputMode {
     pub attribute: i32,
     pub cursor_column: i32,
     pub cursor_row: i32,
-    pub cursor_visible: bool,
+    pub cursor_visible: Boolean,
 }
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct SimpleTextOutputProtocol {
-    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended: bool) -> Status,
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended: Boolean) -> Status,
     pub output_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const Char16) -> Status,
     pub test_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const Char16) -> Status,
     pub query_mode: unsafe extern "efiapi" fn(
@@ -102,7 +102,7 @@ pub struct SimpleTextOutputProtocol {
     pub clear_screen: unsafe extern "efiapi" fn(this: *mut Self) -> Status,
     pub set_cursor_position:
         unsafe extern "efiapi" fn(this: *mut Self, column: usize, row: usize) -> Status,
-    pub enable_cursor: unsafe extern "efiapi" fn(this: *mut Self, visible: bool) -> Status,
+    pub enable_cursor: unsafe extern "efiapi" fn(this: *mut Self, visible: Boolean) -> Status,
     pub mode: *mut SimpleTextOutputMode,
 }
 
@@ -126,8 +126,8 @@ pub struct SimplePointerState {
     pub relative_movement_x: i32,
     pub relative_movement_y: i32,
     pub relative_movement_z: i32,
-    pub left_button: u8,
-    pub right_button: u8,
+    pub left_button: Boolean,
+    pub right_button: Boolean,
 }
 
 #[derive(Debug)]
@@ -135,7 +135,7 @@ pub struct SimplePointerState {
 pub struct SimplePointerProtocol {
     pub reset: unsafe extern "efiapi" fn(
         this: *mut SimplePointerProtocol,
-        extended_verification: bool,
+        extended_verification: Boolean,
     ) -> Status,
     pub get_state: unsafe extern "efiapi" fn(
         this: *mut SimplePointerProtocol,

--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -2,7 +2,7 @@
 
 mod device_path_gen;
 
-use crate::{guid, Char16, Guid};
+use crate::{guid, Boolean, Char16, Guid};
 
 pub use device_path_gen::{acpi, bios_boot_spec, end, hardware, media, messaging};
 
@@ -189,13 +189,13 @@ impl DeviceSubType {
 pub struct DevicePathToTextProtocol {
     pub convert_device_node_to_text: unsafe extern "efiapi" fn(
         device_node: *const DevicePathProtocol,
-        display_only: bool,
-        allow_shortcuts: bool,
+        display_only: Boolean,
+        allow_shortcuts: Boolean,
     ) -> *const Char16,
     pub convert_device_path_to_text: unsafe extern "efiapi" fn(
         device_path: *const DevicePathProtocol,
-        display_only: bool,
-        allow_shortcuts: bool,
+        display_only: Boolean,
+        allow_shortcuts: Boolean,
     ) -> *const Char16,
 }
 

--- a/uefi-raw/src/protocol/file_system.rs
+++ b/uefi-raw/src/protocol/file_system.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::time::Time;
-use crate::{guid, Char16, Event, Guid, Status};
+use crate::{guid, Boolean, Char16, Event, Guid, Status};
 use bitflags::bitflags;
 use core::ffi::c_void;
 
@@ -153,7 +153,7 @@ impl FileInfo {
 #[repr(C)]
 pub struct FileSystemInfo {
     pub size: u64,
-    pub read_only: u8,
+    pub read_only: Boolean,
     pub volume_size: u64,
     pub free_space: u64,
     pub block_size: u32,

--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::protocol::device_path::DevicePathProtocol;
-use crate::{guid, Guid, Status};
+use crate::{guid, Boolean, Guid, Status};
 use core::ffi::c_void;
 
 #[derive(Debug)]
@@ -10,7 +10,7 @@ pub struct LoadFileProtocol {
     pub load_file: unsafe extern "efiapi" fn(
         this: *mut LoadFileProtocol,
         file_path: *const DevicePathProtocol,
-        boot_policy: bool,
+        boot_policy: Boolean,
         buffer_size: *mut usize,
         buffer: *mut c_void,
     ) -> Status,
@@ -26,7 +26,7 @@ pub struct LoadFile2Protocol {
     pub load_file: unsafe extern "efiapi" fn(
         this: *mut LoadFile2Protocol,
         file_path: *const DevicePathProtocol,
-        boot_policy: bool,
+        boot_policy: Boolean,
         buffer_size: *mut usize,
         buffer: *mut c_void,
     ) -> Status,

--- a/uefi-raw/src/protocol/network/dhcp4.rs
+++ b/uefi-raw/src/protocol/network/dhcp4.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{guid, Char8, Event, Guid, Ipv4Address, MacAddress, Status};
+use crate::{guid, Boolean, Char8, Event, Guid, Ipv4Address, MacAddress, Status};
 use core::ffi::c_void;
 
 newtype_enum! {
@@ -150,7 +150,7 @@ pub struct Dhcp4Protocol {
     pub start: unsafe extern "efiapi" fn(this: *mut Self, completion_event: Event) -> Status,
     pub renew_rebind: unsafe extern "efiapi" fn(
         this: *mut Self,
-        rebind_request: bool,
+        rebind_request: Boolean,
         completion_event: Event,
     ) -> Status,
     pub release: unsafe extern "efiapi" fn(this: *mut Self) -> Status,

--- a/uefi-raw/src/protocol/network/http.rs
+++ b/uefi-raw/src/protocol/network/http.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{guid, Char16, Char8, Event, Guid, Ipv4Address, Ipv6Address, Status};
+use crate::{guid, Boolean, Char16, Char8, Event, Guid, Ipv4Address, Ipv6Address, Status};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};
 use core::ptr;
@@ -10,7 +10,7 @@ use core::ptr;
 pub struct HttpConfigData {
     pub http_version: HttpVersion,
     pub time_out_millisec: u32,
-    pub local_addr_is_ipv6: bool,
+    pub local_addr_is_ipv6: Boolean,
     pub access_point: HttpAccessPoint,
 }
 
@@ -26,7 +26,7 @@ newtype_enum! {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(C)]
 pub struct HttpV4AccessPoint {
-    pub use_default_addr: bool,
+    pub use_default_addr: Boolean,
     pub local_address: Ipv4Address,
     pub local_subnet: Ipv4Address,
     pub local_port: u16,

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -4,7 +4,7 @@
 
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::table::Header;
-use crate::{Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress};
+use crate::{Boolean, Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::ops::RangeInclusive;
@@ -106,7 +106,7 @@ pub struct BootServices {
 
     // Image services
     pub load_image: unsafe extern "efiapi" fn(
-        boot_policy: u8,
+        boot_policy: Boolean,
         parent_image_handle: Handle,
         device_path: *const DevicePathProtocol,
         source_buffer: *const u8,
@@ -143,7 +143,7 @@ pub struct BootServices {
         controller: Handle,
         driver_image: Handle,
         remaining_device_path: *const DevicePathProtocol,
-        recursive: bool,
+        recursive: Boolean,
     ) -> Status,
     pub disconnect_controller: unsafe extern "efiapi" fn(
         controller: Handle,

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -6,7 +6,7 @@ use crate::capsule::CapsuleHeader;
 use crate::table::boot::MemoryDescriptor;
 use crate::table::Header;
 use crate::time::Time;
-use crate::{guid, Char16, Guid, PhysicalAddress, Status};
+use crate::{guid, Boolean, Char16, Guid, PhysicalAddress, Status};
 use bitflags::bitflags;
 use core::ffi::c_void;
 
@@ -117,7 +117,7 @@ pub struct TimeCapabilities {
 
     /// Whether a time set operation clears the device's time below the
     /// "resolution" reporting level. False for normal PC-AT CMOS RTC devices.
-    pub sets_to_zero: bool,
+    pub sets_to_zero: Boolean,
 }
 
 bitflags! {

--- a/uefi-test-runner/src/proto/load.rs
+++ b/uefi-test-runner/src/proto/load.rs
@@ -13,12 +13,12 @@ use uefi::proto::BootPolicy;
 use uefi::{boot, Guid, Handle};
 use uefi_raw::protocol::device_path::DevicePathProtocol;
 use uefi_raw::protocol::media::{LoadFile2Protocol, LoadFileProtocol};
-use uefi_raw::Status;
+use uefi_raw::{Boolean, Status};
 
 unsafe extern "efiapi" fn raw_load_file(
     this: *mut LoadFile2Protocol,
     _file_path: *const DevicePathProtocol,
-    _boot_policy: bool,
+    _boot_policy: Boolean,
     buffer_size: *mut usize,
     buffer: *mut c_void,
 ) -> Status {

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # uefi - [Unreleased]
 
+## Changed
+- **Breaking:** Removed `BootPolicyError` as `BootPolicy` construction is no
+  longer fallible. `BootPolicy` now tightly integrates the new `Boolean` type
+  of `uefi-raw`.
 
 # uefi - 0.34.1 (2025-02-07)
 
@@ -53,7 +57,6 @@ details of the deprecated items that were removed in this release.
   users.
 - The `VariableKeys` iterator will now yield an error item if a variable name is
   not UCS-2.
-
 
 # uefi - 0.32.0 (2024-09-09)
 

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -563,7 +563,7 @@ pub fn connect_controller(
                 .map(|dp| dp.as_ffi_ptr())
                 .unwrap_or(ptr::null())
                 .cast(),
-            recursive,
+            recursive.into(),
         )
     }
     .to_result_with_err(|_| ())

--- a/uefi/src/proto/boot_policy.rs
+++ b/uefi/src/proto/boot_policy.rs
@@ -7,8 +7,8 @@ use uefi_raw::Boolean;
 /// The UEFI boot policy is a property that influences the behaviour of
 /// various UEFI functions that load files (typically UEFI images).
 ///
-/// This type is not ABI compatible. On the ABI level, this is an UEFI
-/// boolean.
+/// This type is not ABI compatible. On the ABI level, this corresponds to
+/// a [`Boolean`].
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum BootPolicy {
     /// Indicates that the request originates from the boot manager, and that
@@ -17,20 +17,20 @@ pub enum BootPolicy {
     ///
     /// Boot selection refers to what a user has chosen in the (GUI) boot menu.
     ///
-    /// This corresponds to the `TRUE` value in the UEFI spec.
+    /// This corresponds to the underlying [`Boolean`] being `true`.
     BootSelection,
     /// The provided `file_path` must match an exact file to be loaded.
     ///
-    /// This corresponds to the `FALSE` value in the UEFI spec.
+    /// This corresponds to the underlying [`Boolean`] being `false`.
     #[default]
     ExactMatch,
 }
 
-impl From<BootPolicy> for bool {
+impl From<BootPolicy> for Boolean {
     fn from(value: BootPolicy) -> Self {
         match value {
-            BootPolicy::BootSelection => Boolean::TRUE,
-            BootPolicy::ExactMatch => Boolean::FALSE,
+            BootPolicy::BootSelection => Self::TRUE,
+            BootPolicy::ExactMatch => Self::FALSE,
         }
     }
 }
@@ -51,20 +51,15 @@ mod tests {
 
     #[test]
     fn boot_policy() {
-        assert_eq!(bool::from(BootPolicy::ExactMatch), false);
-        assert_eq!(bool::from(BootPolicy::BootSelection), true);
-
-        assert_eq!(BootPolicy::from(false), BootPolicy::ExactMatch);
-        assert_eq!(BootPolicy::from(true), BootPolicy::BootSelection);
-
-        assert_eq!(u8::from(BootPolicy::ExactMatch), 0);
-        assert_eq!(u8::from(BootPolicy::BootSelection), 1);
-
-        assert_eq!(BootPolicy::try_from(0), Ok(BootPolicy::ExactMatch));
-        assert_eq!(BootPolicy::try_from(1), Ok(BootPolicy::BootSelection));
         assert_eq!(
-            BootPolicy::try_from(2),
-            Err(BootPolicyError::InvalidInteger(2))
+            BootPolicy::try_from(Boolean::TRUE).unwrap(),
+            BootPolicy::BootSelection
         );
+        assert_eq!(
+            BootPolicy::try_from(Boolean::FALSE).unwrap(),
+            BootPolicy::ExactMatch
+        );
+        assert_eq!(Boolean::from(BootPolicy::BootSelection), Boolean::TRUE);
+        assert_eq!(Boolean::from(BootPolicy::ExactMatch), Boolean::FALSE);
     }
 }

--- a/uefi/src/proto/boot_policy.rs
+++ b/uefi/src/proto/boot_policy.rs
@@ -2,27 +2,7 @@
 
 //! Module for the [`BootPolicy`] helper type.
 
-use core::fmt::{Display, Formatter};
-
-/// Errors that can happen when working with [`BootPolicy`].
-#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Eq, Ord)]
-pub enum BootPolicyError {
-    /// Only `0` and `1` are valid integers, all other values are undefined.
-    InvalidInteger(u8),
-}
-
-impl Display for BootPolicyError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        let s = match self {
-            Self::InvalidInteger(_) => {
-                "Only `0` and `1` are valid integers, all other values are undefined."
-            }
-        };
-        f.write_str(s)
-    }
-}
-
-impl core::error::Error for BootPolicyError {}
+use uefi_raw::Boolean;
 
 /// The UEFI boot policy is a property that influences the behaviour of
 /// various UEFI functions that load files (typically UEFI images).
@@ -49,37 +29,18 @@ pub enum BootPolicy {
 impl From<BootPolicy> for bool {
     fn from(value: BootPolicy) -> Self {
         match value {
-            BootPolicy::BootSelection => true,
-            BootPolicy::ExactMatch => false,
+            BootPolicy::BootSelection => Boolean::TRUE,
+            BootPolicy::ExactMatch => Boolean::FALSE,
         }
     }
 }
 
-impl From<bool> for BootPolicy {
-    fn from(value: bool) -> Self {
-        match value {
+impl From<Boolean> for BootPolicy {
+    fn from(value: Boolean) -> Self {
+        let boolean: bool = value.into();
+        match boolean {
             true => Self::BootSelection,
             false => Self::ExactMatch,
-        }
-    }
-}
-
-impl From<BootPolicy> for u8 {
-    fn from(value: BootPolicy) -> Self {
-        match value {
-            BootPolicy::BootSelection => 1,
-            BootPolicy::ExactMatch => 0,
-        }
-    }
-}
-
-impl TryFrom<u8> for BootPolicy {
-    type Error = BootPolicyError;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::ExactMatch),
-            1 => Ok(Self::BootSelection),
-            err => Err(Self::Error::InvalidInteger(err)),
         }
     }
 }

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -22,7 +22,7 @@ impl Pointer {
     ///
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Retrieves the pointer device's current state, if a state change occurred

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -21,7 +21,7 @@ impl Input {
     ///
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Reads the next keystroke from the input device, if any.

--- a/uefi/src/proto/console/text/output.rs
+++ b/uefi/src/proto/console/text/output.rs
@@ -30,7 +30,7 @@ pub struct Output(SimpleTextOutputProtocol);
 impl Output {
     /// Resets and clears the text output device hardware.
     pub fn reset(&mut self, extended: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended.into()) }.to_result()
     }
 
     /// Clears the output screen.
@@ -118,8 +118,8 @@ impl Output {
 
     /// Returns whether the cursor is currently shown or not.
     #[must_use]
-    pub const fn cursor_visible(&self) -> bool {
-        self.data().cursor_visible
+    pub fn cursor_visible(&self) -> bool {
+        self.data().cursor_visible.into()
     }
 
     /// Make the cursor visible or invisible.
@@ -127,7 +127,7 @@ impl Output {
     /// The output device may not support this operation, in which case an
     /// `Unsupported` error will be returned.
     pub fn enable_cursor(&mut self, visible: bool) -> Result {
-        unsafe { (self.0.enable_cursor)(&mut self.0, visible) }.to_result()
+        unsafe { (self.0.enable_cursor)(&mut self.0, visible.into()) }.to_result()
     }
 
     /// Returns the column and row of the cursor.

--- a/uefi/src/proto/device_path/text.rs
+++ b/uefi/src/proto/device_path/text.rs
@@ -116,8 +116,8 @@ impl DevicePathToText {
         let text = unsafe {
             (self.0.convert_device_node_to_text)(
                 device_node.as_ffi_ptr().cast(),
-                display_only.0,
-                allow_shortcuts.0,
+                display_only.0.into(),
+                allow_shortcuts.0.into(),
             )
         };
         PoolString::new(text.cast())
@@ -138,8 +138,8 @@ impl DevicePathToText {
         let text = unsafe {
             (self.0.convert_device_path_to_text)(
                 device_path.as_ffi_ptr().cast(),
-                display_only.0,
-                allow_shortcuts.0,
+                display_only.0.into(),
+                allow_shortcuts.0.into(),
             )
         };
         PoolString::new(text.cast())

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -29,7 +29,7 @@ impl BlockIO {
     /// # Errors
     /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning correctly and could not be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        unsafe { (self.0.reset)(&mut self.0, extended_verification) }.to_result()
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
     /// Read the requested number of blocks from the device.
@@ -117,32 +117,32 @@ impl BlockIOMedia {
 
     /// True if the media is removable.
     #[must_use]
-    pub const fn is_removable_media(&self) -> bool {
-        self.0.removable_media
+    pub fn is_removable_media(&self) -> bool {
+        self.0.removable_media.into()
     }
 
     /// True if there is a media currently present in the device.
     #[must_use]
-    pub const fn is_media_present(&self) -> bool {
-        self.0.media_present
+    pub fn is_media_present(&self) -> bool {
+        self.0.media_present.into()
     }
 
     /// True if block IO was produced to abstract partition structure.
     #[must_use]
-    pub const fn is_logical_partition(&self) -> bool {
-        self.0.logical_partition
+    pub fn is_logical_partition(&self) -> bool {
+        self.0.logical_partition.into()
     }
 
     /// True if the media is marked read-only.
     #[must_use]
-    pub const fn is_read_only(&self) -> bool {
-        self.0.read_only
+    pub fn is_read_only(&self) -> bool {
+        self.0.read_only.into()
     }
 
     /// True if `writeBlocks` function writes data.
     #[must_use]
-    pub const fn is_write_caching(&self) -> bool {
-        self.0.write_caching
+    pub fn is_write_caching(&self) -> bool {
+        self.0.write_caching.into()
     }
 
     /// The intrinsic block size of the device.

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -11,6 +11,7 @@ use {
     crate::{mem::make_boxed, proto::device_path::DevicePath, Result, StatusExt},
     alloc::boxed::Box,
     uefi::proto::BootPolicy,
+    uefi_raw::Boolean,
 };
 
 /// Load File Protocol.
@@ -143,7 +144,7 @@ impl LoadFile2 {
                 (self.0.load_file)(
                     this,
                     file_path.as_ffi_ptr().cast(),
-                    false, /* always false - see spec */
+                    Boolean::FALSE, /* always false - see spec */
                     &mut size,
                     buf.as_mut_ptr().cast(),
                 )

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -28,7 +28,7 @@ pub mod tcg;
 
 mod boot_policy;
 
-pub use boot_policy::{BootPolicy, BootPolicyError};
+pub use boot_policy::BootPolicy;
 pub use uefi_macros::unsafe_protocol;
 
 use crate::Identify;


### PR DESCRIPTION
Use the new type introduced in ec6e0e6b (#1536). This adds the changes originally proposed in #1307. 

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
