### PR TITLE
Fix uefi-raw MSRV build, and improve CI for MSRV

### DIFF
--- a/.github/workflows/msrv_toolchain.toml
+++ b/.github/workflows/msrv_toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.81"
-targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,13 +120,20 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Set toolchain
-        run: cp .github/workflows/msrv_toolchain.toml rust-toolchain.toml
+        run: |
+          # Extract the MSRV using cargo.
+          msrv=$(cargo metadata --no-deps --format-version=1 | jq --raw-output '.packages[] | select(.name == "uefi") | .rust_version')
+          echo "MSRV: ${msrv}"
+          # Set the MSRV in the toolchain config.
+          sed -i "s:stable:${msrv}:" rust-toolchain.toml
       - uses: Swatinem/rust-cache@v2
       - name: Build
         # Build uefi-test-runner since its dependency tree includes all the
         # library packages. Note that xtask isn't used or built here; since it's
         # just a dev tool we don't care about the MSRV for that package.
-        run: cargo build --target x86_64-unknown-uefi -p uefi-test-runner
+        run: |
+          cargo --version
+          cargo build --target x86_64-unknown-uefi -p uefi-test-runner
   # This job requires the nightly channel, but keep it as a separate job from
   # `nightly_channel` because it takes a while to run.
   build_feature_permutations:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,6 +134,25 @@ jobs:
         run: |
           cargo --version
           cargo build --target x86_64-unknown-uefi -p uefi-test-runner
+  # The uefi-raw crate has its own MSRV. Check that the crate builds correctly
+  # with that version of the toolchain.
+  build_msrv_raw:
+    name: Build (uefi-raw MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Set toolchain
+        run: |
+          # Extract the MSRV using cargo.
+          msrv=$(cargo metadata --no-deps --format-version=1 | jq --raw-output '.packages[] | select(.name == "uefi-raw") | .rust_version')
+          echo "MSRV: ${msrv}"
+          # Set the MSRV in the toolchain config.
+          sed -i "s:stable:${msrv}:" rust-toolchain.toml
+      - name: Build
+        run: |
+          cargo --version
+          cargo build -p uefi-raw
   # This job requires the nightly channel, but keep it as a separate job from
   # `nightly_channel` because it takes a while to run.
   build_feature_permutations:

--- a/uefi-raw/src/table/system.rs
+++ b/uefi-raw/src/table/system.rs
@@ -6,6 +6,7 @@ use crate::table::configuration::ConfigurationTable;
 use crate::table::runtime::RuntimeServices;
 use crate::table::Header;
 use crate::{Char16, Handle};
+use core::mem::size_of;
 use core::ptr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
`uefi-raw` has a lower MSRV than the `uefi` package, currently 1.70. Fix a minor error that prevented it from building at that MSRV, and add a job to check that package's MSRV build going forward.

Also improve the existing MSRV job so that it uses cargo to get the correct MSRV value, rather than having a separate MSRV toolchain file that has to be updated manually.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
