### PR TITLE
Use bitflags definitions from uefi-raw in uefi's pxe module

### DIFF
--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -176,14 +176,28 @@ pub struct PxeBaseCodeMtftpInfo {
 }
 
 bitflags! {
+    /// Flags for UDP read and write operations.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct PxeBaseCodeUdpOpFlags: u16 {
+        /// Receive a packet sent from any IP address in UDP read operations.
         const ANY_SRC_IP = 0x0001;
+
+        /// Receive a packet sent from any UDP port in UDP read operations. If
+        /// the source port is not specified in UDP write operations, the
+        /// source port will be automatically selected.
         const ANY_SRC_PORT = 0x0002;
+
+        /// Receive a packet sent to any IP address in UDP read operations.
         const ANY_DEST_IP = 0x0004;
+
+        /// Receive a packet sent to any UDP port in UDP read operations.
         const ANY_DEST_PORT = 0x0008;
+
+        /// The software filter is used in UDP read operations.
         const USE_FILTER = 0x0010;
+
+        /// If required, a UDP write operation may be broken up across multiple packets.
         const MAY_FRAGMENT = 0x0020;
     }
 }

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -294,12 +294,20 @@ pub struct PxeBaseCodeIpFilter {
 }
 
 bitflags! {
+    /// IP receive filters.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct PxeBaseCodeIpFilterFlags: u8 {
+        /// Enable the Station IP address.
         const STATION_IP = 0x01;
+
+        /// Enable IPv4 broadcast addresses.
         const BROADCAST = 0x02;
+
+        /// Enable all addresses.
         const PROMISCUOUS = 0x04;
+
+        /// Enable all multicast addresses.
         const PROMISCUOUS_MULTICAST = 0x08;
     }
 }

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -18,7 +18,9 @@ use crate::{CStr8, Char8, Result, Status, StatusExt};
 
 use super::{IpAddress, MacAddress};
 
-pub use uefi_raw::protocol::network::pxe::PxeBaseCodeUdpOpFlags as UdpOpFlags;
+pub use uefi_raw::protocol::network::pxe::{
+    PxeBaseCodeIpFilterFlags as IpFilters, PxeBaseCodeUdpOpFlags as UdpOpFlags,
+};
 
 /// PXE Base Code protocol
 #[derive(Debug)]
@@ -871,22 +873,6 @@ impl IpFilter {
     #[must_use]
     pub fn ip_list(&self) -> &[IpAddress] {
         &self.ip_list[..usize::from(self.ip_cnt)]
-    }
-}
-
-bitflags! {
-    /// IP receive filters.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-    #[repr(transparent)]
-    pub struct IpFilters: u8 {
-        /// Enable the Station IP address.
-        const STATION_IP = 0x01;
-        /// Enable IPv4 broadcast addresses.
-        const BROADCAST = 0x02;
-        /// Enable all addresses.
-        const PROMISCUOUS = 0x04;
-        /// Enable all multicast addresses.
-        const PROMISCUOUS_MULTICAST = 0x08;
     }
 }
 

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -18,6 +18,8 @@ use crate::{CStr8, Char8, Result, Status, StatusExt};
 
 use super::{IpAddress, MacAddress};
 
+pub use uefi_raw::protocol::network::pxe::PxeBaseCodeUdpOpFlags as UdpOpFlags;
+
 /// PXE Base Code protocol
 #[derive(Debug)]
 #[repr(C)]
@@ -827,29 +829,6 @@ pub struct MtftpInfo {
     /// The number of seconds a client should wait for a packet from the server
     /// before retransmitting the previous open request or data ack packet.
     pub transmit_timeout: u16,
-}
-
-// No corresponding type in the UEFI spec, it just uses UINT16.
-bitflags! {
-    /// Flags for UDP read and write operations.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-    #[repr(transparent)]
-    pub struct UdpOpFlags: u16 {
-        /// Receive a packet sent from any IP address in UDP read operations.
-        const ANY_SRC_IP = 0x0001;
-        /// Receive a packet sent from any UDP port in UDP read operations. If
-        /// the source port is no specified in UDP write operations, the
-        /// source port will be automatically selected.
-        const ANY_SRC_PORT = 0x0002;
-        /// Receive a packet sent to any IP address in UDP read operations.
-        const ANY_DEST_IP = 0x0004;
-        /// Receive a packet sent to any UDP port in UDP read operations.
-        const ANY_DEST_PORT = 0x0008;
-        /// The software filter is used in UDP read operations.
-        const USE_FILTER = 0x0010;
-        /// If required, a UDP write operation may be broken up across multiple packets.
-        const MAY_FRAGMENT = 0x0020;
-    }
 }
 
 /// IP receive filter settings


### PR DESCRIPTION
Move the docstrings to uefi-raw, then re-export the types in uefi.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
