### PR TITLE
uefi: Fix the BufferSize argument in SimpleNetwork::transmit

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `boot::memory_map()` will never return `Status::BUFFER_TOO_SMALL` from now on,
   as this is considered a hard internal error where users can't do anything
   about it anyway. It will panic instead.
+- `SimpleNetwork::transmit` now passes the correct buffer size argument.
+  Previously it incorrectly added the header size to the buffer length, which
+  could cause the firmware to read past the end of the buffer.
 
 
 # uefi - 0.34.1 (2025-02-07)

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -225,7 +225,7 @@ impl SimpleNetwork {
         (self.transmit)(
             self,
             header_size,
-            buffer.len() + header_size,
+            buffer.len(),
             buffer.as_ptr().cast(),
             src_addr.as_ref(),
             dest_addr.as_ref(),


### PR DESCRIPTION
The buffer is supposed to contain both the header and data, so adding `buffer.len() + header_size` tells the firmware the wrong size of the packet.

Fixes https://github.com/rust-osdev/uefi-rs/issues/1549

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
