### PR TITLE
uefi: Improve handling of null-address allocations in allocate_pages

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -13,6 +13,9 @@
 - `SimpleNetwork::transmit` now passes the correct buffer size argument.
   Previously it incorrectly added the header size to the buffer length, which
   could cause the firmware to read past the end of the buffer.
+- `boot::allocate_pages` no longer panics if the allocation is at address
+  zero. The allocation is retried instead, and in all failure cases an error is
+  returned rather than panicking.
 
 
 # uefi - 0.34.1 (2025-02-07)


### PR DESCRIPTION
The firmware is allowed to return an allocation at address zero. This is not compatible with Rust, since it's UB to write through a null pointer. If a null address is returned, retry the allocation. If that second allocation still fails, return an error rather than panicking.

Fixes https://github.com/rust-osdev/uefi-rs/issues/1557

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
