### PR TITLE
Fix unwanted rebuilds in xtask commands

### DIFF
--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -8,12 +8,15 @@ use std::process::Command;
 /// Example: "VAR=val program --arg1 arg2".
 pub fn command_to_string(cmd: &Command) -> String {
     // Format env vars as "name=val".
-    let ignore_var = ["PATH", "RUSTC", "RUSTDOC"];
     let mut parts = cmd
         .get_envs()
-        // Filter out some internally-set variables that would just
-        // clutter the output.
-        .filter(|(name, _)| !ignore_var.contains(&name.to_str().unwrap_or_default()))
+        // Filter out variables that are set or cleared by
+        // `fix_nested_cargo_env`, as they would clutter the output.
+        .filter(|(name, val)| {
+            *name != "PATH"
+                // Exclude any variables cleared with `Command::env_remove`.
+                && val.is_some()
+        })
         .map(|(name, val)| {
             format!(
                 "{}={}",
@@ -53,13 +56,10 @@ mod tests {
     #[test]
     fn test_command_to_string() {
         let mut cmd = Command::new("MyCommand");
-        cmd.args(["abc", "123"]).envs([
-            ("VAR1", "val1"),
-            ("VAR2", "val2"),
-            ("PATH", "pathval"),
-            ("RUSTC", "rustcval"),
-            ("RUSTDOC", "rustdocval"),
-        ]);
+        cmd.args(["abc", "123"])
+            .envs([("VAR1", "val1"), ("VAR2", "val2"), ("PATH", "pathval")])
+            .env_remove("RUSTC")
+            .env_remove("CARGO");
         assert_eq!(
             command_to_string(&cmd),
             "VAR1=val1 VAR2=val2 MyCommand abc 123"


### PR DESCRIPTION
Recently, `cargo xtask test` started doing a lot of rebuilding. Possibly this started with cargo 1.85, but I'm not sure.
    
The behavior was: `cargo xtask test` builds `xtask` and all of its dependencies in order to launch `xtask`. Then it would rebuild everything again to run the test command. If you then ran `cargo xtask test` a second time, everything would again be rebuilt. In other words, the build cache essentially wasn't working.
    
Fix by clearing all `CARGO` env vars in `fix_nested_cargo_env`.

Also update `command_to_string` to exclude cleared env vars, otherwise the command logging gets quite verbose.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
