### PR TITLE
Implement conversions for IpAddress and MacAddress

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Added `Boolean` type
 - Added `protocol::network::pxe` module.
+- Added conversions between `MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.
 
 
 # uefi-raw - 0.10.0 (2025-02-07)

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -175,6 +175,25 @@ impl Default for IpAddress {
 #[repr(transparent)]
 pub struct MacAddress(pub [u8; 32]);
 
+impl From<[u8; 6]> for MacAddress {
+    fn from(octets: [u8; 6]) -> Self {
+        let mut buffer = [0; 32];
+        buffer[0] = octets[0];
+        buffer[1] = octets[1];
+        buffer[2] = octets[2];
+        buffer[3] = octets[3];
+        buffer[4] = octets[4];
+        buffer[5] = octets[5];
+        Self(buffer)
+    }
+}
+
+impl From<MacAddress> for [u8; 6] {
+    fn from(MacAddress(o): MacAddress) -> Self {
+        [o[0], o[1], o[2], o[3], o[4], o[5]]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 - Added `boot::signal_event`.
+- Added conversions between `proto::network::IpAddress` and `core::net` types.
+- Added conversions between `proto::network::MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.
 
 ## Changed
 - **Breaking:** Removed `BootPolicyError` as `BootPolicy` construction is no

--- a/uefi/src/proto/network/mod.rs
+++ b/uefi/src/proto/network/mod.rs
@@ -34,3 +34,40 @@ impl IpAddress {
         Self(ip_addr)
     }
 }
+
+impl From<core::net::Ipv4Addr> for IpAddress {
+    fn from(t: core::net::Ipv4Addr) -> Self {
+        Self::new_v4(t.octets())
+    }
+}
+
+impl From<IpAddress> for core::net::Ipv4Addr {
+    fn from(IpAddress(o): IpAddress) -> Self {
+        Self::from([o[0], o[1], o[2], o[3]])
+    }
+}
+
+impl From<core::net::Ipv6Addr> for IpAddress {
+    fn from(t: core::net::Ipv6Addr) -> Self {
+        Self::new_v6(t.octets())
+    }
+}
+
+impl From<IpAddress> for core::net::Ipv6Addr {
+    fn from(value: IpAddress) -> Self {
+        Self::from(value.0)
+    }
+}
+
+impl From<core::net::IpAddr> for IpAddress {
+    fn from(t: core::net::IpAddr) -> Self {
+        match t {
+            core::net::IpAddr::V4(a) => a.into(),
+            core::net::IpAddr::V6(a) => a.into(),
+        }
+    }
+}
+
+// NOTE: We cannot impl From<IpAddress> for core::net::IpAddr
+// because IpAddress is a raw union, with nothing indicating
+// whether it should be considered v4 or v6.


### PR DESCRIPTION
- I've added conversions for IpAddress so that it can be converted to `core::net::*` types.
- I also added a conversion for MacAddress to `[u8; 6]` because most other utilities that consume MAC addresses want that type.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
