### PR TITLE
uefi: Consistently use `&mut self` for pxe::BaseCode methods

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -9,6 +9,9 @@
 - **Breaking:** Removed `BootPolicyError` as `BootPolicy` construction is no
   longer fallible. `BootPolicy` now tightly integrates the new `Boolean` type
   of `uefi-raw`.
+- **Breaking:** The `pxe::BaseCode::tftp_read_dir` and
+  `pxe::BaseCode::mtftp_read_dir` methods now take `&mut self` instead of
+  `&self`.
 - `boot::memory_map()` will never return `Status::BUFFER_TOO_SMALL` from now on,
   as this is considered a hard internal error where users can't do anything
   about it anyway. It will panic instead.

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -233,7 +233,7 @@ impl BaseCode {
 
     /// Reads a directory listing of a directory on a TFTP server.
     pub fn tftp_read_dir<'a>(
-        &self,
+        &mut self,
         server_ip: &IpAddress,
         directory_name: &CStr8,
         buffer: &'a mut [u8],
@@ -366,7 +366,7 @@ impl BaseCode {
 
     /// Reads a directory listing of a directory on a MTFTP server.
     pub fn mtftp_read_dir<'a>(
-        &self,
+        &mut self,
         server_ip: &IpAddress,
         buffer: &'a mut [u8],
         info: &MtftpInfo,


### PR DESCRIPTION
Although these methods are just reading data, they are almost certainly modifying internal state in the UEFI protocol and so should be `&mut`.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
