### PR TITLE
ci: fix typos

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,8 +3,8 @@ on: [merge_group, push, pull_request]
 jobs:
   spellcheck:
     name: Spellcheck
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # Executes "typos ."
-      - uses: crate-ci/typos@v1.29.9
+      - uses: crate-ci/typos@v1.30.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -17,4 +17,6 @@ extend-ignore-identifiers-re = [
 HD = "HD"
 
 [default.extend-identifiers]
+# We sometimes use "typ" as "type" is a reserved keyword
+typ = "typ"
 


### PR DESCRIPTION
Fix `typos` >= v1.30

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
