### PR TITLE
Update Protocol/unsafe_protocol docs

### DIFF
--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -25,12 +25,12 @@ macro_rules! err {
 
 /// Attribute macro for marking structs as UEFI protocols.
 ///
-/// The macro takes one argument, either a GUID string or the path to a `Guid`
-/// constant.
+/// The macro can only be applied to a struct, and takes one argument, either a
+/// GUID string or the path to a `Guid` constant.
 ///
-/// The macro can only be applied to a struct. It implements the
-/// [`Protocol`] trait and the `unsafe` [`Identify`] trait for the
-/// struct.
+/// The macro implements the [`Protocol`] trait and the `unsafe` [`Identify`]
+/// trait for the struct. See the [`Protocol`] trait for details of how it is
+/// used.
 ///
 /// # Safety
 ///
@@ -55,7 +55,7 @@ macro_rules! err {
 /// assert_eq!(ExampleProtocol2::GUID, PROTO_GUID);
 /// ```
 ///
-/// [`Identify`]: https://docs.rs/uefi/latest/uefi/trait.Identify.html
+/// [`Identify`]: https://docs.rs/uefi/latest/uefi/data_types/trait.Identify.html
 /// [`Protocol`]: https://docs.rs/uefi/latest/uefi/proto/trait.Protocol.html
 /// [send-and-sync]: https://doc.rust-lang.org/nomicon/send-and-sync.html
 #[proc_macro_attribute]

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -34,10 +34,18 @@ pub use uefi_macros::unsafe_protocol;
 use crate::Identify;
 use core::ffi::c_void;
 
-/// Common trait implemented by all standard UEFI protocols.
+#[cfg(doc)]
+use crate::boot;
+
+/// Marker trait for structures that represent UEFI protocols.
 ///
-/// You can derive the `Protocol` trait and specify the protocol's GUID using
-/// the [`unsafe_protocol`] macro.
+/// Implementing this trait allows a protocol to be opened with
+/// [`boot::open_protocol`] or [`boot::open_protocol_exclusive`]. Note that
+/// implementing this trait does not automatically install a protocol. To
+/// install a protocol, call [`boot::install_protocol_interface`].
+///
+/// As a convenience, you can derive the `Protocol` trait and specify the
+/// protocol's GUID using the [`unsafe_protocol`] macro.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Some minor cleanups of the docs, and specifically note that implementing `Protocol` allows a protocol to be opened with uefi-rs, but installing a protocol is separate.

https://github.com/rust-osdev/uefi-rs/issues/1573

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
