### PR TITLE
uefi-raw: Add DiskInfo protocol binding

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `Boolean` type
 - Added `protocol::network::pxe` module.
 - Added conversions between `MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.
+- Added `DiskInfoProtocol`.
 
 
 # uefi-raw - 0.10.0 (2025-02-07)

--- a/uefi-raw/src/protocol/disk.rs
+++ b/uefi-raw/src/protocol/disk.rs
@@ -64,3 +64,42 @@ impl DiskIo2Protocol {
     pub const GUID: Guid = guid!("151c8eae-7f2c-472c-9e54-9828194f6a88");
     pub const REVISION: u64 = 0x00020000;
 }
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DiskInfoProtocol {
+    pub interface: Guid,
+    pub inquiry: unsafe extern "efiapi" fn(
+        this: *const Self,
+        inquiry_data: *mut c_void,
+        inquiry_data_size: *mut u32,
+    ) -> Status,
+    pub identify: unsafe extern "efiapi" fn(
+        this: *const Self,
+        identify_data: *mut c_void,
+        identify_data_size: *mut u32,
+    ) -> Status,
+    pub sense_data: unsafe extern "efiapi" fn(
+        this: *const Self,
+        sense_data: *mut c_void,
+        sense_data_size: *mut u32,
+        sense_data_number: *mut u8,
+    ) -> Status,
+    pub which_ide: unsafe extern "efiapi" fn(
+        this: *const Self,
+        ide_channel: *mut u32,
+        ide_device: *mut u32,
+    ) -> Status,
+}
+
+impl DiskInfoProtocol {
+    pub const GUID: Guid = guid!("d432a67f-14dc-484b-b3bb-3f0291849327");
+
+    pub const IDE_INTERFACE_GUID: Guid = guid!("5e948fe3-26d3-42b5-af17-610287188dec");
+    pub const UFS_INTERFACE_GUID: Guid = guid!("4b3029cc-6b98-47fb-bc96-76dcb80441f0");
+    pub const USB_INTERFACE_GUID: Guid = guid!("cb871572-c11a-47b5-b492-675eafa77727");
+    pub const AHCI_INTERFACE_GUID: Guid = guid!("9e498932-4abc-45af-a34d-0247787be7c6");
+    pub const NVME_INTERFACE_GUID: Guid = guid!("3ab14680-5d3f-4a4d-bcdc-cc380018c7f7");
+    pub const SCSI_INTERFACE_GUID: Guid = guid!("08f74baa-ea36-41d9-9521-21a70f8780bc");
+    pub const SD_MMC_INTERFACE_GUID: Guid = guid!("8deec992-d39c-4a5c-ab6b-986e14242b9d");
+}


### PR DESCRIPTION
Added a (only raw for now) binding to the UEFI DiskInfo protocol [`d432a67f-14dc-484b-b3bb-3f0291849327`].

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
