### PR TITLE
uefi-raw: Add EXT_SCSI_PASS_THRU protocol binding

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `protocol::network::pxe` module.
 - Added conversions between `MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.
 - Added `DiskInfoProtocol`.
+- Added `ExtScsiPassThruProtocol`.
 
 
 # uefi-raw - 0.10.0 (2025-02-07)


### PR DESCRIPTION
Added a (only raw for now) binding to the EFI_EXT_SCSI_PASS_THRU_PROTOCOL [`143b7632-b81b-4cb7-abd3-b625a5b9bffe`].

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
