### PR TITLE
uefi-raw: Add conversions to/from core::net IP address types

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,6 +1,7 @@
 # uefi-raw - [Unreleased]
 
 ## Added
+- MSRV increased to 1.77.
 - Added `Boolean` type
 - Added `protocol::network::pxe` module.
 - Added conversions between `MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added `Boolean` type
 - Added `protocol::network::pxe` module.
 - Added conversions between `MacAddress` and the `[u8; 6]` type that's more commonly used to represent MAC addresses.
+- Implemented `From` conversions between the `core::net` and `uefi_raw` IP
+  address types.
 - Added `DiskInfoProtocol`.
 - Added `ExtScsiPassThruProtocol`.
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -16,7 +16,7 @@ license.workspace = true
 repository.workspace = true
 # uefi-raw is much less likely to need the latest bleeding-edge features.
 # Hence, it is okay to not use the workspace MSRV.
-rust-version = "1.70"
+rust-version = "1.77"
 
 [dependencies]
 bitflags.workspace = true


### PR DESCRIPTION
This will help with the implementation of https://github.com/rust-osdev/uefi-rs/issues/1575.

Note that this bumps the MSRV of uefi-raw to 1.77 so that `core::net` is available.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
