### PR TITLE
uefi: Make pxe::Mode an opaque struct

### DIFF
--- a/uefi-test-runner/src/proto/network/pxe.rs
+++ b/uefi-test-runner/src/proto/network/pxe.rs
@@ -24,8 +24,8 @@ pub fn test() {
             .dhcp(false)
             .expect("failed to complete a dhcpv4 handshake");
 
-        assert!(base_code.mode().dhcp_ack_received);
-        let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack.as_ref();
+        assert!(base_code.mode().dhcp_ack_received());
+        let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack().as_ref();
         let server_ip = dhcp_ack.bootp_si_addr;
         let server_ip = IpAddress::new_v4(server_ip);
 
@@ -75,7 +75,7 @@ pub fn test() {
 
         let mut src_ip = server_ip;
         let mut src_port = EXAMPLE_SERVICE_PORT;
-        let mut dest_ip = base_code.mode().station_ip;
+        let mut dest_ip = base_code.mode().station_ip();
         let mut dest_port = write_src_port;
         let mut header = [0; 1];
         let mut received = [0; 4];

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -12,6 +12,8 @@
 - **Breaking:** The `pxe::BaseCode::tftp_read_dir` and
   `pxe::BaseCode::mtftp_read_dir` methods now take `&mut self` instead of
   `&self`.
+- **Breaking:** The `pxe::Mode` struct is now opaque. Use method calls to access
+  mode data instead of direct field access.
 - `boot::memory_map()` will never return `Status::BUFFER_TOO_SMALL` from now on,
   as this is considered a hard internal error where users can't do anything
   about it anyway. It will panic instead.

--- a/uefi/src/proto/network/mod.rs
+++ b/uefi/src/proto/network/mod.rs
@@ -34,6 +34,20 @@ impl IpAddress {
         Self(ip_addr)
     }
 
+    /// Construct from a `uefi_raw::IpAddress` union.
+    ///
+    /// # Safety
+    ///
+    /// `is_ipv6` must accurately reflect how the union was initialized.
+    #[must_use]
+    const unsafe fn from_raw(ip_addr: uefi_raw::IpAddress, is_ipv6: bool) -> Self {
+        if is_ipv6 {
+            Self::new_v6(unsafe { ip_addr.v6.0 })
+        } else {
+            Self::new_v4(unsafe { ip_addr.v4.0 })
+        }
+    }
+
     #[must_use]
     const fn as_raw_ptr(&self) -> *const uefi_raw::IpAddress {
         // The uefi-raw type is defined differently, but the layout is


### PR DESCRIPTION
Methods are now provided to access mode data instead of direct field access.

This will help with the `IpAddr` conversion. https://github.com/rust-osdev/uefi-rs/issues/1575

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
