### PR TITLE
uefi: Enable unsafe_op_in_unsafe_fn lint

### DIFF
--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -143,11 +143,11 @@ impl CStr8 {
     #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char8) -> &'ptr Self {
         let mut len = 0;
-        while *ptr.add(len) != NUL_8 {
+        while unsafe { *ptr.add(len) } != NUL_8 {
             len += 1
         }
         let ptr = ptr.cast::<u8>();
-        Self::from_bytes_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1))
+        unsafe { Self::from_bytes_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1)) }
     }
 
     /// Creates a CStr8 reference from bytes.
@@ -171,7 +171,7 @@ impl CStr8 {
     /// null-terminated string, with no interior null bytes.
     #[must_use]
     pub const unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
-        &*(ptr::from_ref(chars) as *const Self)
+        unsafe { &*(ptr::from_ref(chars) as *const Self) }
     }
 
     /// Returns the inner pointer to this CStr8.
@@ -352,11 +352,11 @@ impl CStr16 {
     #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char16) -> &'ptr Self {
         let mut len = 0;
-        while *ptr.add(len) != NUL_16 {
+        while unsafe { *ptr.add(len) } != NUL_16 {
             len += 1
         }
         let ptr = ptr.cast::<u16>();
-        Self::from_u16_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1))
+        unsafe { Self::from_u16_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1)) }
     }
 
     /// Creates a `&CStr16` from a u16 slice, stopping at the first nul character.
@@ -405,7 +405,7 @@ impl CStr16 {
     /// null-terminated string, with no interior null characters.
     #[must_use]
     pub const unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
-        &*(ptr::from_ref(codes) as *const Self)
+        unsafe { &*(ptr::from_ref(codes) as *const Self) }
     }
 
     /// Creates a `&CStr16` from a [`Char16`] slice, stopping at the first nul character.
@@ -455,7 +455,7 @@ impl CStr16 {
     #[must_use]
     pub const unsafe fn from_char16_with_nul_unchecked(chars: &[Char16]) -> &Self {
         let ptr: *const [Char16] = chars;
-        &*(ptr as *const Self)
+        unsafe { &*(ptr as *const Self) }
     }
 
     /// Convert a [`&str`] to a `&CStr16`, backed by a buffer.

--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -29,7 +29,7 @@ static LOGGER: Logger = Logger::new();
 /// disable() on exit from UEFI boot services.
 pub unsafe fn init() {
     // Connect the logger to stdout.
-    system::with_stdout(|stdout| {
+    system::with_stdout(|stdout| unsafe {
         LOGGER.set_output(stdout);
     });
 

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -224,6 +224,7 @@
     clippy::use_self,
     missing_debug_implementations,
     missing_docs,
+    unsafe_op_in_unsafe_fn,
     unused
 )]
 

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -589,7 +589,7 @@ impl FrameBuffer<'_> {
     #[inline]
     pub unsafe fn write_byte(&mut self, index: usize, value: u8) {
         debug_assert!(index < self.size, "Frame buffer accessed out of bounds");
-        self.base.add(index).write_volatile(value)
+        unsafe { self.base.add(index).write_volatile(value) }
     }
 
     /// Read the i-th byte of the frame buffer
@@ -603,7 +603,7 @@ impl FrameBuffer<'_> {
     #[must_use]
     pub unsafe fn read_byte(&self, index: usize) -> u8 {
         debug_assert!(index < self.size, "Frame buffer accessed out of bounds");
-        self.base.add(index).read_volatile()
+        unsafe { self.base.add(index).read_volatile() }
     }
 
     /// Write a value in the frame buffer, starting at the i-th byte
@@ -624,8 +624,10 @@ impl FrameBuffer<'_> {
             index.saturating_add(size_of::<T>()) <= self.size,
             "Frame buffer accessed out of bounds"
         );
-        let ptr = self.base.add(index).cast::<T>();
-        ptr.write_volatile(value)
+        unsafe {
+            let ptr = self.base.add(index).cast::<T>();
+            ptr.write_volatile(value)
+        }
     }
 
     /// Read a value from the frame buffer, starting at the i-th byte
@@ -647,6 +649,6 @@ impl FrameBuffer<'_> {
             index.saturating_add(size_of::<T>()) <= self.size,
             "Frame buffer accessed out of bounds"
         );
-        (self.base.add(index) as *const T).read_volatile()
+        unsafe { (self.base.add(index) as *const T).read_volatile() }
     }
 }

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -98,7 +98,7 @@ impl DebugSupport {
         }
 
         // Safety: As we've validated the `processor_index`, this should always be safe
-        (self.register_periodic_callback)(self, processor_index, callback).to_result()
+        unsafe { (self.register_periodic_callback)(self, processor_index, callback) }.to_result()
     }
 
     /// Registers a function to be called when a given processor exception occurs.
@@ -122,8 +122,10 @@ impl DebugSupport {
         }
 
         // Safety: As we've validated the `processor_index`, this should always be safe
-        (self.register_exception_callback)(self, processor_index, callback, exception_type)
-            .to_result()
+        unsafe {
+            (self.register_exception_callback)(self, processor_index, callback, exception_type)
+        }
+        .to_result()
     }
 
     /// Invalidates processor instruction cache for a memory range for a given `processor_index`.
@@ -144,7 +146,8 @@ impl DebugSupport {
 
         // per the UEFI spec, this call should only return EFI_SUCCESS
         // Safety: As we've validated the `processor_index`, this should always be safe
-        (self.invalidate_instruction_cache)(self, processor_index, start, length).to_result()
+        unsafe { (self.invalidate_instruction_cache)(self, processor_index, start, length) }
+            .to_result()
     }
 }
 

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -173,10 +173,10 @@ impl DevicePathNode {
     /// that lifetime.
     #[must_use]
     pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a Self {
-        let header = *ptr.cast::<DevicePathHeader>();
+        let header = unsafe { *ptr.cast::<DevicePathHeader>() };
 
         let data_len = usize::from(header.length) - size_of::<DevicePathHeader>();
-        &*ptr_meta::from_raw_parts(ptr.cast(), data_len)
+        unsafe { &*ptr_meta::from_raw_parts(ptr.cast(), data_len) }
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
@@ -368,11 +368,11 @@ pub struct DevicePath {
 
 impl ProtocolPointer for DevicePath {
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self {
-        ptr_meta::from_raw_parts(ptr.cast(), Self::size_in_bytes_from_ptr(ptr))
+        ptr_meta::from_raw_parts(ptr.cast(), unsafe { Self::size_in_bytes_from_ptr(ptr) })
     }
 
     unsafe fn mut_ptr_from_ffi(ptr: *mut c_void) -> *mut Self {
-        ptr_meta::from_raw_parts_mut(ptr.cast(), Self::size_in_bytes_from_ptr(ptr))
+        ptr_meta::from_raw_parts_mut(ptr.cast(), unsafe { Self::size_in_bytes_from_ptr(ptr) })
     }
 }
 
@@ -384,13 +384,13 @@ impl DevicePath {
         let mut ptr = ptr.cast::<u8>();
         let mut total_size_in_bytes: usize = 0;
         loop {
-            let node = DevicePathNode::from_ffi_ptr(ptr.cast::<FfiDevicePath>());
+            let node = unsafe { DevicePathNode::from_ffi_ptr(ptr.cast::<FfiDevicePath>()) };
             let node_size_in_bytes = usize::from(node.length());
             total_size_in_bytes += node_size_in_bytes;
             if node.is_end_entire() {
                 break;
             }
-            ptr = ptr.add(node_size_in_bytes);
+            ptr = unsafe { ptr.add(node_size_in_bytes) };
         }
 
         total_size_in_bytes
@@ -434,7 +434,7 @@ impl DevicePath {
     /// that lifetime.
     #[must_use]
     pub unsafe fn from_ffi_ptr<'a>(ptr: *const FfiDevicePath) -> &'a Self {
-        &*Self::ptr_from_ffi(ptr.cast::<c_void>())
+        unsafe { &*Self::ptr_from_ffi(ptr.cast::<c_void>()) }
     }
 
     /// Cast to a [`FfiDevicePath`] pointer.
@@ -669,11 +669,15 @@ pub struct LoadedImageDevicePath(DevicePath);
 
 impl ProtocolPointer for LoadedImageDevicePath {
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self {
-        ptr_meta::from_raw_parts(ptr.cast(), DevicePath::size_in_bytes_from_ptr(ptr))
+        ptr_meta::from_raw_parts(ptr.cast(), unsafe {
+            DevicePath::size_in_bytes_from_ptr(ptr)
+        })
     }
 
     unsafe fn mut_ptr_from_ffi(ptr: *mut c_void) -> *mut Self {
-        ptr_meta::from_raw_parts_mut(ptr.cast(), DevicePath::size_in_bytes_from_ptr(ptr))
+        ptr_meta::from_raw_parts_mut(ptr.cast(), unsafe {
+            DevicePath::size_in_bytes_from_ptr(ptr)
+        })
     }
 }
 

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -150,7 +150,7 @@ impl LoadedImage {
         unload: extern "efiapi" fn(image_handle: Handle) -> Status,
     ) {
         let unload: unsafe extern "efiapi" fn(image_handle: uefi_raw::Handle) -> uefi_raw::Status =
-            mem::transmute(unload);
+            unsafe { mem::transmute(unload) };
         self.0.unload = Some(unload);
     }
 

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -130,8 +130,10 @@ impl DiskIo2 {
         buffer: *mut u8,
     ) -> Result {
         let token = opt_nonnull_to_ptr(token);
-        (self.0.read_disk_ex)(&self.0, media_id, offset, token.cast(), len, buffer.cast())
-            .to_result()
+        unsafe {
+            (self.0.read_disk_ex)(&self.0, media_id, offset, token.cast(), len, buffer.cast())
+        }
+        .to_result()
     }
 
     /// Writes bytes to the disk device.
@@ -164,14 +166,16 @@ impl DiskIo2 {
         buffer: *const u8,
     ) -> Result {
         let token = opt_nonnull_to_ptr(token);
-        (self.0.write_disk_ex)(
-            &mut self.0,
-            media_id,
-            offset,
-            token.cast(),
-            len,
-            buffer.cast(),
-        )
+        unsafe {
+            (self.0.write_disk_ex)(
+                &mut self.0,
+                media_id,
+                offset,
+                token.cast(),
+                len,
+                buffer.cast(),
+            )
+        }
         .to_result()
     }
 

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -25,7 +25,7 @@ impl Directory {
     /// doing otherwise is unsafe.
     #[must_use]
     pub const unsafe fn new(handle: FileHandle) -> Self {
-        Self(RegularFile::new(handle))
+        Self(unsafe { RegularFile::new(handle) })
     }
 
     /// Read the next directory entry.

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -407,14 +407,18 @@ mod tests {
         )
         .unwrap();
         let required_size = size_of_val(info);
-        if *buffer_size < required_size {
-            *buffer_size = required_size;
+        if unsafe { *buffer_size } < required_size {
+            unsafe {
+                *buffer_size = required_size;
+            }
             Status::BUFFER_TOO_SMALL
         } else {
             unsafe {
                 ptr::copy_nonoverlapping((info as *const FileInfo).cast(), buffer, required_size);
             }
-            *buffer_size = required_size;
+            unsafe {
+                *buffer_size = required_size;
+            }
             Status::SUCCESS
         }
     }

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -95,7 +95,7 @@ impl PcrEvent {
     pub(super) const unsafe fn from_ptr<'a>(ptr: *const u8) -> &'a Self {
         // Get the `event_size` field.
         let ptr_u32: *const u32 = ptr.cast();
-        let event_size = ptr_u32.add(7).read_unaligned();
+        let event_size = unsafe { ptr_u32.add(7).read_unaligned() };
         let event_size = usize_from_u32(event_size);
         unsafe { &*ptr_meta::from_raw_parts(ptr.cast(), event_size) }
     }

--- a/uefi/src/runtime.rs
+++ b/uefi/src/runtime.rs
@@ -75,7 +75,7 @@ pub unsafe fn set_time(time: &Time) -> Result {
     let rt = unsafe { rt.as_ref() };
 
     let time: *const Time = time;
-    (rt.set_time)(time.cast()).to_result()
+    unsafe { (rt.set_time)(time.cast()) }.to_result()
 }
 
 /// Checks if a variable exists.
@@ -549,10 +549,11 @@ pub unsafe fn set_virtual_address_map(
     let entry_size = size_of::<MemoryDescriptor>();
     let entry_version = MemoryDescriptor::VERSION;
     let map_ptr = map.as_mut_ptr();
-    (rt.set_virtual_address_map)(map_size, entry_size, entry_version, map_ptr).to_result()?;
+    unsafe { (rt.set_virtual_address_map)(map_size, entry_size, entry_version, map_ptr) }
+        .to_result()?;
 
     // Update the global system table pointer.
-    table::set_system_table(new_system_table_virtual_addr);
+    unsafe { table::set_system_table(new_system_table_virtual_addr) };
 
     Ok(())
 }

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -5,8 +5,10 @@ use core::ptr::{self, NonNull};
 /// Copy the bytes of `val` to `ptr`, then advance pointer to just after the
 /// newly-copied bytes.
 pub unsafe fn ptr_write_unaligned_and_add<T>(ptr: &mut *mut u8, val: T) {
-    ptr.cast::<T>().write_unaligned(val);
-    *ptr = ptr.add(size_of::<T>());
+    unsafe {
+        ptr.cast::<T>().write_unaligned(val);
+        *ptr = ptr.add(size_of::<T>());
+    }
 }
 
 /// Convert from a `u32` to a `usize`. Panic if the input does fit. On typical


### PR DESCRIPTION
These are all very mechanical changes, just adding `unsafe { ... }` blocks where needed.

https://github.com/rust-osdev/uefi-rs/issues/1584

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
