### PR TITLE
clippy: fix

### DIFF
--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -15,11 +15,11 @@ pub struct Pointer(SimplePointerProtocol);
 impl Pointer {
     /// Resets the pointer device hardware.
     ///
+    /// # Arguments
     /// The `extended_verification` parameter is used to request that UEFI
     /// performs an extended check and reset of the input device.
     ///
     /// # Errors
-    ///
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -184,6 +184,7 @@ impl ComponentName {
     ///
     /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
     /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
+    #[allow(clippy::missing_const_for_fn)] // false-positive since Rust 1.86
     pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
         match self {
             Self::V1(cn1) => cn1.supported_languages(),

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -23,11 +23,12 @@ impl BlockIO {
     /// Resets the block device hardware.
     ///
     /// # Arguments
-    /// * `extended_verification`   Indicates that the driver may perform a more exhaustive verification operation of
-    ///     the device during reset.
+    /// * `extended_verification` Indicates that the driver may perform a more
+    ///   exhaustive verification operation of the device during reset.
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning correctly and could not be reset.
+    /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning
+    ///   correctly and could not be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
@@ -41,13 +42,13 @@ impl BlockIO {
     ///
     /// # Errors
     /// * `uefi::Status::DEVICE_ERROR`       The device reported an error while attempting to perform the read
-    ///     operation.
+    ///   operation.
     /// * `uefi::Status::NO_MEDIA`           There is no media in the device.
     /// * `uefi::Status::MEDIA_CHANGED`      The `media_id` is not for the current media.
     /// * `uefi::Status::BAD_BUFFER_SIZE`    The buffer size parameter is not a multiple of the intrinsic block size of
-    ///     the device.
+    ///   the device.
     /// * `uefi::Status::INVALID_PARAMETER`  The read request contains LBAs that are not valid, or the buffer is not on
-    ///     proper alignment.
+    ///   proper alignment.
     pub fn read_blocks(&self, media_id: u32, lba: Lba, buffer: &mut [u8]) -> Result {
         let buffer_size = buffer.len();
         unsafe {
@@ -74,11 +75,11 @@ impl BlockIO {
     /// * `uefi::Status::NO_MEDIA`              There is no media in the device.
     /// * `uefi::Status::MEDIA_CHANGED`         The `media_id` is not for the current media.
     /// * `uefi::Status::DEVICE_ERROR`          The device reported an error while attempting to perform the write
-    ///     operation.
+    ///   operation.
     /// * `uefi::Status::BAD_BUFFER_SIZE`       The buffer size parameter is not a multiple of the intrinsic block size
-    ///     of the device.
+    ///   of the device.
     /// * `uefi::Status::INVALID_PARAMETER`     The write request contains LBAs that are not valid, or the buffer is not
-    ///     on proper alignment.
+    ///   on proper alignment.
     pub fn write_blocks(&mut self, media_id: u32, lba: Lba, buffer: &[u8]) -> Result {
         let buffer_size = buffer.len();
         unsafe {

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -95,8 +95,7 @@ impl DiskIo2 {
     /// Terminates outstanding asynchronous requests to the device.
     ///
     /// # Errors:
-    /// * [`Status::DEVICE_ERROR`]  The device reported an error while performing
-    ///                                 the cancel operation.
+    /// * [`Status::DEVICE_ERROR`] The device reported an error while performing
     pub fn cancel(&mut self) -> Result {
         unsafe { (self.0.cancel)(&mut self.0) }.to_result()
     }

--- a/uefi/src/runtime.rs
+++ b/uefi/src/runtime.rs
@@ -884,6 +884,7 @@ pub struct VariableKey {
 impl VariableKey {
     /// Name of the variable.
     #[deprecated = "Use the VariableKey.name field instead"]
+    #[allow(clippy::missing_const_for_fn)] // false-positive since Rust 1.86
     pub fn name(&self) -> core::result::Result<&CStr16, crate::data_types::FromSliceWithNulError> {
         Ok(&self.name)
     }


### PR DESCRIPTION
This unblocks #1600.

Instead of applying the fixes, it is better to ignore the lints. In once case, we have false positives. In the other case, we actually like the old style. For instance:

We prefer

```
/// # Parameters
/// * `some_param` This parameter has a
///    very long description
```

over

```
/// # Parameters
/// * `some_param` This parameter has a
/// very long description
```

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
