### PR TITLE
doc: streamline Error and Argument sections

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -125,11 +125,10 @@ pub unsafe fn raise_tpl(tpl: Tpl) -> TplGuard {
 /// UEFI OS loaders should allocate memory of the type `LoaderData`.
 ///
 /// # Errors
-///
-/// * [`Status::OUT_OF_RESOURCES`]: allocation failed.
-/// * [`Status::INVALID_PARAMETER`]: `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
+/// * [`Status::OUT_OF_RESOURCES`] when allocation failed.
+/// * [`Status::INVALID_PARAMETER`] when `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
 ///   [`MemoryType::UNACCEPTED`], or in the range [`MemoryType::MAX`]`..=0x6fff_ffff`.
-/// * [`Status::NOT_FOUND`]: the requested pages could not be found.
+/// * [`Status::NOT_FOUND`] if the requested pages could not be found.
 pub fn allocate_pages(ty: AllocateType, mem_ty: MemoryType, count: usize) -> Result<NonNull<u8>> {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -178,9 +177,8 @@ pub fn allocate_pages(ty: AllocateType, mem_ty: MemoryType, count: usize) -> Res
 /// and that the memory at the allocation is not used after it is freed.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: `ptr` was not allocated by [`allocate_pages`].
-/// * [`Status::INVALID_PARAMETER`]: `ptr` is not page aligned or is otherwise invalid.
+/// * [`Status::NOT_FOUND`] if `ptr` was not allocated by [`allocate_pages`].
+/// * [`Status::INVALID_PARAMETER`] if `ptr` is not page aligned or is otherwise invalid.
 pub unsafe fn free_pages(ptr: NonNull<u8>, count: usize) -> Result {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -192,9 +190,8 @@ pub unsafe fn free_pages(ptr: NonNull<u8>, count: usize) -> Result {
 /// Allocates from a memory pool. The pointer will be 8-byte aligned.
 ///
 /// # Errors
-///
-/// * [`Status::OUT_OF_RESOURCES`]: allocation failed.
-/// * [`Status::INVALID_PARAMETER`]: `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
+/// * [`Status::OUT_OF_RESOURCES`] when is allocation failed.
+/// * [`Status::INVALID_PARAMETER`] when `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
 ///   [`MemoryType::UNACCEPTED`], or in the range [`MemoryType::MAX`]`..=0x6fff_ffff`.
 pub fn allocate_pool(mem_ty: MemoryType, size: usize) -> Result<NonNull<u8>> {
     let bt = boot_services_raw_panicking();
@@ -215,7 +212,6 @@ pub fn allocate_pool(mem_ty: MemoryType, size: usize) -> Result<NonNull<u8>> {
 /// and that the memory at the allocation is not used after it is freed.
 ///
 /// # Errors
-///
 /// * [`Status::INVALID_PARAMETER`]: `ptr` is invalid.
 pub unsafe fn free_pool(ptr: NonNull<u8>) -> Result {
     let bt = boot_services_raw_panicking();
@@ -276,24 +272,21 @@ pub(crate) fn memory_map_size() -> MemoryMapMeta {
 /// the right allocation size for the memory map to prevent
 /// [`Status::BUFFER_TOO_SMALL`].
 ///
-/// # Parameters
-///
-/// - `mt`: The memory type for the backing memory on the UEFI heap.
+/// # Arguments
+/// - `memory_type`: The memory type for the backing memory on the UEFI heap.
 ///   Usually, this is [`MemoryType::LOADER_DATA`]. You can also use a
 ///   custom type.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: Invalid [`MemoryType`]
-/// * [`Status::OUT_OF_RESOURCES`]: allocation failed.
+/// * [`Status::INVALID_PARAMETER`] when the [`MemoryType`] is invalid.
+/// * [`Status::OUT_OF_RESOURCES`] when the allocation failed.
 ///
 /// # Panics
-///
 /// Panics if the memory map can't be retrieved because of
 /// [`Status::BUFFER_TOO_SMALL`]. This behaviour was chosen explicitly as
 /// callers can't do anything about it anyway.
-pub fn memory_map(mt: MemoryType) -> Result<MemoryMapOwned> {
-    let mut buffer = MemoryMapBackingMemory::new(mt)?;
+pub fn memory_map(memory_type: MemoryType) -> Result<MemoryMapOwned> {
+    let mut buffer = MemoryMapBackingMemory::new(memory_type)?;
 
     let meta = get_memory_map(buffer.as_mut_slice());
 
@@ -365,9 +358,9 @@ pub(crate) fn get_memory_map(buf: &mut [u8]) -> Result<MemoryMapMeta> {
 /// services correctly.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: an invalid combination of parameters was provided.
-/// * [`Status::OUT_OF_RESOURCES`]: the event could not be allocated.
+/// * [`Status::INVALID_PARAMETER`] when an invalid combination of parameters
+///   was provided.
+/// * [`Status::OUT_OF_RESOURCES`] when the event could not be allocated.
 pub unsafe fn create_event(
     event_ty: EventType,
     notify_tpl: Tpl,
@@ -428,13 +421,12 @@ pub unsafe fn create_event(
 /// will fail with [`Status::UNSUPPORTED`].
 ///
 /// # Safety
-///
 /// The caller must ensure they are passing a valid `Guid` as `event_group`, if applicable.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: an invalid combination of parameters was provided.
-/// * [`Status::OUT_OF_RESOURCES`]: the event could not be allocated.
+/// * [`Status::INVALID_PARAMETER`] when an invalid combination of parameters
+///   was provided.
+/// * [`Status::OUT_OF_RESOURCES`] when the event could not be allocated.
 pub unsafe fn create_event_ex(
     event_type: EventType,
     notify_tpl: Tpl,
@@ -478,11 +470,10 @@ pub unsafe fn create_event_ex(
 /// if the event is not in the signaled state.
 ///
 /// # Errors
-///
 /// Note: Instead of returning [`Status::NOT_READY`] as listed in the UEFI
 /// Specification, this function will return `Ok(false)`.
 ///
-/// * [`Status::INVALID_PARAMETER`]: `event` is of type [`NOTIFY_SIGNAL`].
+/// * [`Status::INVALID_PARAMETER`] when `event` is of type [`NOTIFY_SIGNAL`].
 ///
 /// [`NOTIFY_SIGNAL`]: EventType::NOTIFY_SIGNAL
 pub fn check_event(event: Event) -> Result<bool> {
@@ -511,7 +502,6 @@ pub fn check_event(event: Event) -> Result<bool> {
 /// group, signal it and then close the event to remove it from the group.
 ///
 /// # Errors
-///
 /// The specification does not list any errors.
 ///
 /// [`NOTIFY_SIGNAL`]: EventType::NOTIFY_SIGNAL
@@ -529,7 +519,6 @@ pub fn signal_event(event: &Event) -> Result {
 /// corresponding notify function is allowed.
 ///
 /// # Errors
-///
 /// The specification does not list any errors, however implementations are
 /// allowed to return an error if needed.
 pub fn close_event(event: Event) -> Result {
@@ -542,8 +531,7 @@ pub fn close_event(event: Event) -> Result {
 /// Sets the trigger for an event of type [`TIMER`].
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `event` is not valid.
+/// * [`Status::INVALID_PARAMETER`] when `event` is not valid.
 ///
 /// [`TIMER`]: EventType::TIMER
 pub fn set_timer(event: &Event, trigger_time: TimerTrigger) -> Result {
@@ -585,9 +573,8 @@ pub fn set_timer(event: &Event, trigger_time: TimerTrigger) -> Result {
 /// [`check_event`] interface may be used.
 ///
 /// # Errors
-///
 /// * [`Status::INVALID_PARAMETER`]: `events` is empty, or one of the events of
-///   of type [`NOTIFY_SIGNAL`].
+///   type [`NOTIFY_SIGNAL`].
 /// * [`Status::UNSUPPORTED`]: the current TPL is not [`Tpl::APPLICATION`].
 ///
 /// [`NOTIFY_SIGNAL`]: EventType::NOTIFY_SIGNAL
@@ -618,10 +605,9 @@ pub fn wait_for_event(events: &mut [Event]) -> Result<usize, Option<usize>> {
 /// a block handle after your app modified disk partitions.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: there are no driver-binding protocol instances
+/// * [`Status::NOT_FOUND`] if there are no driver-binding protocol instances
 ///   present in the system, or no drivers are connected to `controller`.
-/// * [`Status::SECURITY_VIOLATION`]: the caller does not have permission to
+/// * [`Status::SECURITY_VIOLATION`] if the caller does not have permission to
 ///   start drivers associated with `controller`.
 pub fn connect_controller(
     controller: Handle,
@@ -651,14 +637,13 @@ pub fn connect_controller(
 /// See also [`connect_controller`].
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `driver_image` is set but does not manage
+/// * [`Status::INVALID_PARAMETER`] if `driver_image` is set but does not manage
 ///   `controller`, or does not support the driver binding protocol, or one of
 ///   the handles is invalid.
-/// * [`Status::OUT_OF_RESOURCES`]: not enough resources available to disconnect
-///   drivers.
-/// * [`Status::DEVICE_ERROR`]: the controller could not be disconnected due to
-///   a device error.
+/// * [`Status::OUT_OF_RESOURCES`] if not enough resources available to
+///   disconnect drivers.
+/// * [`Status::DEVICE_ERROR`] if the controller could not be disconnected due
+///   to a device error.
 pub fn disconnect_controller(
     controller: Handle,
     driver_image: Option<Handle>,
@@ -689,9 +674,9 @@ pub fn disconnect_controller(
 /// The caller is responsible for ensuring that they pass a valid `Guid` for `protocol`.
 ///
 /// # Errors
-///
-/// * [`Status::OUT_OF_RESOURCES`]: failed to allocate a new handle.
-/// * [`Status::INVALID_PARAMETER`]: this protocol is already installed on the handle.
+/// * [`Status::OUT_OF_RESOURCES`] if UEFI failed to allocate a new handle.
+/// * [`Status::INVALID_PARAMETER`] if this protocol is already installed on the
+///   `handle`.
 pub unsafe fn install_protocol_interface(
     handle: Option<Handle>,
     protocol: &Guid,
@@ -725,9 +710,9 @@ pub unsafe fn install_protocol_interface(
 /// removed.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: the old interface was not found on the handle.
-/// * [`Status::ACCESS_DENIED`]: the old interface is still in use and cannot be uninstalled.
+/// * [`Status::NOT_FOUND`] if the old interface was not found on the `handle`.
+/// * [`Status::ACCESS_DENIED`]: if the old interface is still in use and cannot
+///   be uninstalled.
 pub unsafe fn reinstall_protocol_interface(
     handle: Handle,
     protocol: &Guid,
@@ -755,9 +740,9 @@ pub unsafe fn reinstall_protocol_interface(
 /// The caller is responsible for ensuring that they pass a valid `Guid` for `protocol`.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: the interface was not found on the handle.
-/// * [`Status::ACCESS_DENIED`]: the interface is still in use and cannot be uninstalled.
+/// * [`Status::NOT_FOUND`] if the interface was not found on the `handle`.
+/// * [`Status::ACCESS_DENIED`] if the interface is still in use and cannot be
+///   uninstalled.
 pub unsafe fn uninstall_protocol_interface(
     handle: Handle,
     protocol: &Guid,
@@ -779,8 +764,7 @@ pub unsafe fn uninstall_protocol_interface(
 /// Events can be unregistered from protocol interface notification by calling [`close_event`].
 ///
 /// # Errors
-///
-/// * [`Status::OUT_OF_RESOURCES`]: the event could not be allocated.
+/// * [`Status::OUT_OF_RESOURCES`] if the event could not be allocated.
 pub fn register_protocol_notify(
     protocol: &'static Guid,
     event: &Event,
@@ -801,9 +785,8 @@ pub fn register_protocol_notify(
 /// on a [`Handle`].
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `handle` is invalid.
-/// * [`Status::OUT_OF_RESOURCES`]: out of memory.
+/// * [`Status::INVALID_PARAMETER`] if the `handle` is invalid.
+/// * [`Status::OUT_OF_RESOURCES`] if UEFI is out of memory.
 pub fn protocols_per_handle(handle: Handle) -> Result<ProtocolsPerHandle> {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -831,8 +814,7 @@ pub fn protocols_per_handle(handle: Handle) -> Result<ProtocolsPerHandle> {
 /// multi-instance device path, the function will operate on the first instance.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: no matching handles.
+/// * [`Status::NOT_FOUND`] if no matching [`Handle`]s were found.
 pub fn locate_device_path<P: ProtocolPointer + ?Sized>(
     device_path: &mut &DevicePath,
 ) -> Result<Handle> {
@@ -856,10 +838,10 @@ pub fn locate_device_path<P: ProtocolPointer + ?Sized>(
 /// Enumerates all handles installed on the system which match a certain query.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: no matching handles found.
-/// * [`Status::BUFFER_TOO_SMALL`]: the buffer is not large enough. The required
-///   size (in number of handles, not bytes) will be returned in the error data.
+/// * [`Status::NOT_FOUND`] if no matching handles were found.
+/// * [`Status::BUFFER_TOO_SMALL`] if the buffer is not large enough. The
+///   required size (in number of handles, not bytes) will be returned in the
+///   error data.
 pub fn locate_handle<'buf>(
     search_ty: SearchType,
     buffer: &'buf mut [MaybeUninit<Handle>],
@@ -881,6 +863,7 @@ pub fn locate_handle<'buf>(
         unsafe { (bt.locate_handle)(ty, guid, key, &mut buffer_size, buffer.as_mut_ptr().cast()) };
 
     let num_handles = buffer_size / size_of::<Handle>();
+    assert_eq!(buffer_size % size_of::<Handle>(), 0);
 
     match status {
         Status::SUCCESS => {
@@ -900,9 +883,8 @@ pub fn locate_handle<'buf>(
 /// See [`SearchType`] for details of the available search operations.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: no matching handles.
-/// * [`Status::OUT_OF_RESOURCES`]: out of memory.
+/// * [`Status::NOT_FOUND`] if no matching handles were found.
+/// * [`Status::OUT_OF_RESOURCES`] if UEFI is out of memory.
 pub fn locate_handle_buffer(search_ty: SearchType) -> Result<HandleBuffer> {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -928,8 +910,7 @@ pub fn locate_handle_buffer(search_ty: SearchType) -> Result<HandleBuffer> {
 /// Returns all the handles implementing a certain protocol.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: no matching handles.
+/// * [`Status::NOT_FOUND`] if no matching handles were found.
 #[cfg(feature = "alloc")]
 pub fn find_handles<P: ProtocolPointer + ?Sized>() -> Result<Vec<Handle>> {
     // Search by protocol.
@@ -994,9 +975,8 @@ pub fn find_handles<P: ProtocolPointer + ?Sized>() -> Result<Vec<Handle>> {
 /// ```
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: no matching handle.
-/// * [`Status::OUT_OF_RESOURCES`]: out of memory.
+/// * [`Status::NOT_FOUND`] if no matching handle were found.
+/// * [`Status::OUT_OF_RESOURCES`] if UEFI is out of memory.
 pub fn get_handle_for_protocol<P: ProtocolPointer + ?Sized>() -> Result<Handle> {
     locate_handle_buffer(SearchType::ByProtocol(&P::GUID))?
         .first()
@@ -1030,12 +1010,11 @@ pub fn get_handle_for_protocol<P: ProtocolPointer + ?Sized>() -> Result<Handle> 
 /// `ScopedProtocol` is dropped.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: an invalid combination of `params` and
+/// * [`Status::INVALID_PARAMETER`] if an invalid combination of `params` and
 ///   `attributes` was provided.
-/// * [`Status::UNSUPPORTED`]: the handle does not support the protocol.
-/// * [`Status::ACCESS_DENIED`] or [`Status::ALREADY_STARTED`]: the protocol is
-///   already open in a way that is incompatible with the new request.
+/// * [`Status::UNSUPPORTED`] if the handle does not support the protocol.
+/// * [`Status::ACCESS_DENIED`] or [`Status::ALREADY_STARTED`] if the protocol
+///   is already open in a way that is incompatible with the new request.
 pub unsafe fn open_protocol<P: ProtocolPointer + ?Sized>(
     params: OpenProtocolParams,
     attributes: OpenProtocolAttributes,
@@ -1073,9 +1052,8 @@ pub unsafe fn open_protocol<P: ProtocolPointer + ?Sized>(
 /// close the protocol interface when dropped.
 ///
 /// # Errors
-///
-/// * [`Status::UNSUPPORTED`]: the handle does not support the protocol.
-/// * [`Status::ACCESS_DENIED`]: the protocol is already open in a way that is
+/// * [`Status::UNSUPPORTED`] if the handle does not support the protocol.
+/// * [`Status::ACCESS_DENIED`] if the protocol is already open in a way that is
 ///   incompatible with the new request.
 pub fn open_protocol_exclusive<P: ProtocolPointer + ?Sized>(
     handle: Handle,
@@ -1100,8 +1078,8 @@ pub fn open_protocol_exclusive<P: ProtocolPointer + ?Sized>(
 /// Returns `Ok(true)` if the handle supports the protocol, `Ok(false)` if not.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: one of the handles in `params` is invalid.
+/// * [`Status::INVALID_PARAMETER`] if one of the handles in `params` is
+///   invalid.
 pub fn test_protocol<P: ProtocolPointer + ?Sized>(params: OpenProtocolParams) -> Result<bool> {
     const TEST_PROTOCOL: u32 = 0x04;
 
@@ -1144,15 +1122,17 @@ pub fn test_protocol<P: ProtocolPointer + ?Sized>(params: OpenProtocolParams) ->
 /// [`unload_image`].
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `source` contains an invalid value.
-/// * [`Status::UNSUPPORTED`]: the image type is not supported.
-/// * [`Status::OUT_OF_RESOURCES`]: insufficient resources to load the image.
-/// * [`Status::LOAD_ERROR`]: the image is invalid.
-/// * [`Status::DEVICE_ERROR`]: failed to load image due to a read error.
-/// * [`Status::ACCESS_DENIED`]: failed to load image due to a security policy.
-/// * [`Status::SECURITY_VIOLATION`]: a security policy specifies that the image
-///   should not be started.
+/// * [`Status::INVALID_PARAMETER`] if `source` contains an invalid value.
+/// * [`Status::UNSUPPORTED`] if the image type is not supported.
+/// * [`Status::OUT_OF_RESOURCES`] if there are insufficient resources to load
+///   the image.
+/// * [`Status::LOAD_ERROR`] if the image is invalid.
+/// * [`Status::DEVICE_ERROR`] if a device error caused a failure to load the
+///   image.
+/// * [`Status::ACCESS_DENIED`] if failed to load image due to a security
+///   policy.
+/// * [`Status::SECURITY_VIOLATION`] if a security policy specifies that the
+///   image should not be started.
 pub fn load_image(parent_image_handle: Handle, source: LoadImageSource) -> Result<Handle> {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -1179,9 +1159,9 @@ pub fn load_image(parent_image_handle: Handle, source: LoadImageSource) -> Resul
 /// Unloads a UEFI image.
 ///
 /// # Errors
-///
-/// * [`Status::UNSUPPORTED`]: the image has been started, and does not support unload.
-/// * [`Status::INVALID_PARAMETER`]: `image_handle` is not valid.
+/// * [`Status::UNSUPPORTED`] if the image has been started, and does not
+///   support unload.
+/// * [`Status::INVALID_PARAMETER`] if `image_handle` is not valid.
 pub fn unload_image(image_handle: Handle) -> Result {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -1192,11 +1172,10 @@ pub fn unload_image(image_handle: Handle) -> Result {
 /// Transfers control to a loaded image's entry point.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `image_handle` is not valid, or the image
+/// * [`Status::INVALID_PARAMETER`] if `image_handle` is not valid, or the image
 ///   has already been initialized with `start_image`.
-/// * [`Status::SECURITY_VIOLATION`]: a security policy specifies that the image
-///   should not be started.
+/// * [`Status::SECURITY_VIOLATION`] if a security policy specifies that the
+///   image should not be started.
 pub fn start_image(image_handle: Handle) -> Result {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
@@ -1294,7 +1273,6 @@ unsafe fn get_memory_map_and_exit_boot_services(buf: &mut [u8]) -> Result<Memory
 ///   [`MemoryType::BOOT_SERVICES_DATA`] will become free memory.
 ///
 /// # Errors
-///
 /// This function will fail if it is unable to allocate memory for
 /// the memory map, if it fails to retrieve the memory map, or if
 /// exiting boot services fails (with up to one retry).
@@ -1347,9 +1325,8 @@ pub unsafe fn exit_boot_services(memory_type: MemoryType) -> MemoryMapOwned {
 /// [`RUNTIME_SERVICES_DATA`]: MemoryType::RUNTIME_SERVICES_DATA
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: tried to delete a nonexistent entry.
-/// * [`Status::OUT_OF_RESOURCES`]: out of memory.
+/// * [`Status::NOT_FOUND`] if the caller tried to delete a nonexistent entry.
+/// * [`Status::OUT_OF_RESOURCES`] if UEFI is out of memory.
 pub unsafe fn install_configuration_table(
     guid_entry: &'static Guid,
     table_ptr: *const c_void,
@@ -1380,10 +1357,9 @@ pub unsafe fn install_configuration_table(
 /// followed by other binary data.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: `watchdog_code` is invalid.
-/// * [`Status::UNSUPPORTED`]: the system does not have a watchdog timer.
-/// * [`Status::DEVICE_ERROR`]: the watchdog timer could not be set due to a
+/// * [`Status::INVALID_PARAMETER`] if `watchdog_code` is invalid.
+/// * [`Status::UNSUPPORTED`] if the system does not have a watchdog timer.
+/// * [`Status::DEVICE_ERROR`] if the watchdog timer could not be set due to a
 ///   hardware error.
 pub fn set_watchdog_timer(
     timeout_in_seconds: usize,
@@ -1423,7 +1399,6 @@ pub fn stall(microseconds: usize) {
 /// image was loaded from.
 ///
 /// # Errors
-///
 /// This function can return errors from [`open_protocol_exclusive`] and
 /// [`locate_device_path`]. See those functions for more details.
 ///

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -362,7 +362,6 @@ impl CStr16 {
     /// Creates a `&CStr16` from a u16 slice, stopping at the first nul character.
     ///
     /// # Errors
-    ///
     /// An error is returned if the slice contains invalid UCS-2 characters, or
     /// if the slice does not contain any nul character.
     pub fn from_u16_until_nul(codes: &[u16]) -> Result<&Self, FromSliceUntilNulError> {
@@ -411,7 +410,6 @@ impl CStr16 {
     /// Creates a `&CStr16` from a [`Char16`] slice, stopping at the first nul character.
     ///
     /// # Errors
-    ///
     /// An error is returned if the slice does not contain any nul character.
     pub fn from_char16_until_nul(chars: &[Char16]) -> Result<&Self, FromSliceUntilNulError> {
         // Find the index of the first null char.

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -275,7 +275,7 @@ pub(crate) struct MemoryMapBackingMemory(NonNull<[u8]>);
 impl MemoryMapBackingMemory {
     /// Constructs a new [`MemoryMapBackingMemory`].
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `memory_type`: The memory type for the memory map allocation.
     ///   Typically, [`MemoryType::LOADER_DATA`] for regular UEFI applications.
     pub(crate) fn new(memory_type: MemoryType) -> crate::Result<Self> {

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -16,11 +16,12 @@ impl Pointer {
     /// Resets the pointer device hardware.
     ///
     /// # Arguments
-    /// The `extended_verification` parameter is used to request that UEFI
-    /// performs an extended check and reset of the input device.
+    /// - `extended_verification`: Request that UEFI performs an extended check
+    ///   and reset of the input device.
     ///
     /// # Errors
-    /// - `DeviceError` if the device is malfunctioning and cannot be reset.
+    /// - [`Status::DEVICE_ERROR`] if the device is malfunctioning and cannot be
+    ///   reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -14,12 +14,13 @@ pub struct Input(SimpleTextInputProtocol);
 impl Input {
     /// Resets the input device hardware.
     ///
-    /// The `extended_verification` parameter is used to request that UEFI
-    /// performs an extended check and reset of the input device.
+    /// # Arguments
+    /// - `extended_verification`: Request that UEFI performs an extended check
+    ///   and reset of the input device.
     ///
     /// # Errors
-    ///
-    /// - `DeviceError` if the device is malfunctioning and cannot be reset.
+    /// - [`Status::DEVICE_ERROR`] if the device is malfunctioning and cannot
+    ///   be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
@@ -33,7 +34,6 @@ impl Input {
     /// [`wait_for_key_event`]: Self::wait_for_key_event
     ///
     /// # Errors
-    ///
     /// - [`Status::DEVICE_ERROR`] if there was an issue with the input device
     ///
     /// # Examples

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -401,7 +401,6 @@ impl DevicePath {
     /// end-entire node.
     ///
     /// # Errors
-    ///
     /// The [`ByteConversionError::InvalidLength`] error will be returned
     /// when the length of the given bytes slice cannot contain the full
     /// [`DevicePath`] represented by the slice.

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -3,6 +3,8 @@
 //! Block I/O protocols.
 
 use crate::proto::unsafe_protocol;
+#[cfg(doc)]
+use crate::Status;
 use crate::{Result, StatusExt};
 
 pub use uefi_raw::protocol::block::{BlockIoProtocol, Lba};
@@ -23,11 +25,11 @@ impl BlockIO {
     /// Resets the block device hardware.
     ///
     /// # Arguments
-    /// * `extended_verification` Indicates that the driver may perform a more
-    ///   exhaustive verification operation of the device during reset.
+    /// * `extended_verification`: Request that UEFI performs an extended check
+    ///   and reset of the input device.
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning
+    /// * [`Status::DEVICE_ERROR`] if the block device is not functioning
     ///   correctly and could not be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
@@ -36,18 +38,20 @@ impl BlockIO {
     /// Read the requested number of blocks from the device.
     ///
     /// # Arguments
-    /// * `media_id` - The media ID that the read request is for.
-    /// * `lba` - The starting logical block address to read from on the device.
-    /// * `buffer` - The target buffer of the read operation
+    /// * `media_id`: The media ID that the read request is for.
+    /// * `lba`: The starting logical block address to read from on the device.
+    /// * `buffer`: The target buffer of the read operation
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error while attempting to perform the read
-    ///   operation.
-    /// * `uefi::Status::NO_MEDIA`           There is no media in the device.
-    /// * `uefi::Status::MEDIA_CHANGED`      The `media_id` is not for the current media.
-    /// * `uefi::Status::BAD_BUFFER_SIZE`    The buffer size parameter is not a multiple of the intrinsic block size of
-    ///   the device.
-    /// * `uefi::Status::INVALID_PARAMETER`  The read request contains LBAs that are not valid, or the buffer is not on
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   attempting to perform the read operation.
+    /// * [`Status::NO_MEDIA`] when there is no media in the device.
+    /// * [`Status::MEDIA_CHANGED`] when `media_id` is not for the current
+    ///   media.
+    /// * [`Status::BAD_BUFFER_SIZE`] when the buffer size parameter is not
+    ///   a multiple of the intrinsic block size of the device.
+    /// * [`Status::INVALID_PARAMETER`] when the read request contains LBAs
+    ///   that are not valid, or the buffer is not on
     ///   proper alignment.
     pub fn read_blocks(&self, media_id: u32, lba: Lba, buffer: &mut [u8]) -> Result {
         let buffer_size = buffer.len();
@@ -66,20 +70,21 @@ impl BlockIO {
     /// Writes the requested number of blocks to the device.
     ///
     /// # Arguments
-    /// * `media_id`    The media ID that the write request is for.
-    /// * `lba`         The starting logical block address to be written.
-    /// * `buffer`      Buffer to be written
+    /// * `media_id`: The media ID that the write request is for.
+    /// * `lba`: The starting logical block address to be written.
+    /// * `buffer`: Buffer to be written
     ///
     /// # Errors
-    /// * `uefi::Status::WRITE_PROTECTED`       The device cannot be written to.
-    /// * `uefi::Status::NO_MEDIA`              There is no media in the device.
-    /// * `uefi::Status::MEDIA_CHANGED`         The `media_id` is not for the current media.
-    /// * `uefi::Status::DEVICE_ERROR`          The device reported an error while attempting to perform the write
-    ///   operation.
-    /// * `uefi::Status::BAD_BUFFER_SIZE`       The buffer size parameter is not a multiple of the intrinsic block size
-    ///   of the device.
-    /// * `uefi::Status::INVALID_PARAMETER`     The write request contains LBAs that are not valid, or the buffer is not
-    ///   on proper alignment.
+    /// * [`Status::WRITE_PROTECTED`] when the device cannot be written to.
+    /// * [`Status::NO_MEDIA`] when there is no media in the device.
+    /// * [`Status::MEDIA_CHANGED`] when the `media_id` is not for the
+    ///   current media.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   attempting to perform the write operation.
+    /// * [`Status::BAD_BUFFER_SIZE`] when the buffer size parameter is not
+    ///   a multiple of the intrinsic block size of the device.
+    /// * [`Status::INVALID_PARAMETER`] The write request contains LBAs that
+    ///   are not valid, or the buffer is not on proper alignment.
     pub fn write_blocks(&mut self, media_id: u32, lba: Lba, buffer: &[u8]) -> Result {
         let buffer_size = buffer.len();
         unsafe {

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -22,16 +22,19 @@ pub struct DiskIo(DiskIoProtocol);
 impl DiskIo {
     /// Reads bytes from the disk device.
     ///
-    /// # Arguments:
-    /// * `media_id` - ID of the medium to be read.
-    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
-    /// * `buffer` - Pointer to a buffer to read into.
+    /// # Arguments
+    /// * `media_id`: ID of the medium to be read.
+    /// * `offset`: Starting byte offset on the logical block I/O device to read from.
+    /// * `buffer`: Pointer to a buffer to read into.
     ///
-    /// # Errors:
-    /// * [`Status::INVALID_PARAMETER`] The read request contains device addresses that are not valid for the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the read operation.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
+    /// # Errors
+    /// * [`Status::INVALID_PARAMETER`] when the read request contains device
+    ///   addresses that are not valid for the device.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   performing the read operation.
+    /// * [`Status::NO_MEDIA`] when there is no medium in the device.
+    /// * [`Status::MEDIA_CHANGED`] when `media_id` is not for the current
+    ///   medium.
     pub fn read_disk(&self, media_id: u32, offset: u64, buffer: &mut [u8]) -> Result {
         unsafe {
             (self.0.read_disk)(
@@ -47,17 +50,20 @@ impl DiskIo {
 
     /// Writes bytes to the disk device.
     ///
-    /// # Arguments:
-    /// * `media_id` - ID of the medium to be written.
-    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
-    /// * `buffer` - Pointer to a buffer to write from.
+    /// # Arguments
+    /// * `media_id`: ID of the medium to be written.
+    /// * `offset`: Starting byte offset on the logical block I/O device to write to.
+    /// * `buffer`: Pointer to a buffer to write from.
     ///
-    /// # Errors:
-    /// * [`Status::INVALID_PARAMETER`] The write request contains device addresses that are not valid for the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the write operation.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    /// # Errors
+    /// * [`Status::INVALID_PARAMETER`] when the write request contains device
+    ///   addresses that are not valid for the device.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   performing the write operation.
+    /// * [`Status::NO_MEDIA`] when there is no medium in the device.
+    /// * [`Status::MEDIA_CHANGED`] then `media_id` is not for the current
+    ///   medium.
+    /// * [`Status::WRITE_PROTECTED`] when the device cannot be written to.
     pub fn write_disk(&mut self, media_id: u32, offset: u64, buffer: &[u8]) -> Result {
         unsafe {
             (self.0.write_disk)(
@@ -94,7 +100,7 @@ pub struct DiskIo2(DiskIo2Protocol);
 impl DiskIo2 {
     /// Terminates outstanding asynchronous requests to the device.
     ///
-    /// # Errors:
+    /// # Errors
     /// * [`Status::DEVICE_ERROR`] The device reported an error while performing
     pub fn cancel(&mut self) -> Result {
         unsafe { (self.0.cancel)(&mut self.0) }.to_result()
@@ -102,24 +108,28 @@ impl DiskIo2 {
 
     /// Reads bytes from the disk device.
     ///
-    /// # Arguments:
-    /// * `media_id` - ID of the medium to be read from.
-    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
-    /// * `token` - Transaction token for asynchronous read.
-    /// * `len` - Buffer size.
-    /// * `buffer` - Buffer to read into.
+    /// # Arguments
+    /// * `media_id`: ID of the medium to be read from.
+    /// * `offset`: Starting byte offset on the logical block I/O device to read from.
+    /// * `token`: Transaction token for asynchronous read.
+    /// * `len`: Buffer size.
+    /// * `buffer`: Buffer to read into.
     ///
     /// # Safety
     ///
     /// Because of the asynchronous nature of the disk transaction, manual lifetime
     /// tracking is required.
     ///
-    /// # Errors:
-    /// * [`Status::INVALID_PARAMETER`] The read request contains device addresses that are not valid for the device.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the read operation.
+    /// # Errors
+    /// * [`Status::INVALID_PARAMETER`] when the read request contains device
+    ///   addresses that are not valid for the device.
+    /// * [`Status::OUT_OF_RESOURCES`] when the request could not be completed
+    ///   due to a lack of resources.
+    /// * [`Status::MEDIA_CHANGED`] when `media_id` is not for the current
+    ///   medium.
+    /// * [`Status::NO_MEDIA`] when there is no medium in the device.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   performing the read operation.
     pub unsafe fn read_disk_raw(
         &self,
         media_id: u32,
@@ -137,25 +147,29 @@ impl DiskIo2 {
 
     /// Writes bytes to the disk device.
     ///
-    /// # Arguments:
-    /// * `media_id` - ID of the medium to write to.
-    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
-    /// * `token` - Transaction token for asynchronous write.
-    /// * `len` - Buffer size.
-    /// * `buffer` - Buffer to write from.
+    /// # Arguments
+    /// * `media_id`: ID of the medium to write to.
+    /// * `offset`: Starting byte offset on the logical block I/O device to write to.
+    /// * `token`: Transaction token for asynchronous write.
+    /// * `len`: Buffer size.
+    /// * `buffer`: Buffer to write from.
     ///
     /// # Safety
     ///
     /// Because of the asynchronous nature of the disk transaction, manual lifetime
     /// tracking is required.
     ///
-    /// # Errors:
-    /// * [`Status::INVALID_PARAMETER`] The write request contains device addresses that are not valid for the device.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`      `media_id` is not for the current medium.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the write operation.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    /// # Errors
+    /// * [`Status::INVALID_PARAMETER`] when the write request contains device
+    ///   addresses that are not valid for the device.
+    /// * [`Status::OUT_OF_RESOURCES`]  when the request could not be completed
+    ///   due to a lack of resources.
+    /// * [`Status::MEDIA_CHANGED`] when `media_id` is not for the current
+    ///   medium.
+    /// * [`Status::NO_MEDIA`] when there is no medium in the device.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   performing the write operation.
+    /// * [`Status::WRITE_PROTECTED`] when the device cannot be written to.
     pub unsafe fn write_disk_raw(
         &mut self,
         media_id: u32,
@@ -180,15 +194,18 @@ impl DiskIo2 {
 
     /// Flushes all modified data to the physical device.
     ///
-    /// # Arguments:
-    /// * `token` - Transaction token for the asynchronous flush.
+    /// # Arguments
+    /// * `token`: Transaction token for the asynchronous flush.
     ///
-    /// # Errors:
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     The medium in the device has changed since the last access.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the flush operation.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    /// # Errors
+    /// * [`Status::OUT_OF_RESOURCES`] when the request could not be completed
+    ///   due to a lack of resources.
+    /// * [`Status::MEDIA_CHANGED`] when the medium in the device has changed
+    ///   since the last access.
+    /// * [`Status::NO_MEDIA`] when there is no medium in the device.
+    /// * [`Status::DEVICE_ERROR`] when the device reported an error while
+    ///   performing the flush operation.
+    /// * [`Status::WRITE_PROTECTED`] when the device cannot be written to.
     pub fn flush_disk(&mut self, token: Option<NonNull<DiskIo2Token>>) -> Result {
         let token = opt_nonnull_to_ptr(token);
         unsafe { (self.0.flush_disk_ex)(&mut self.0, token.cast()) }.to_result()

--- a/uefi/src/proto/media/disk_info.rs
+++ b/uefi/src/proto/media/disk_info.rs
@@ -2,6 +2,8 @@
 
 //! DiskInfo protocol.
 
+#[cfg(doc)]
+use crate::Status;
 use crate::StatusExt;
 use uefi_macros::unsafe_protocol;
 use uefi_raw::protocol::disk::DiskInfoProtocol;
@@ -90,17 +92,20 @@ impl DiskInfo {
 
     /// Performs an inquiry command on the disk device.
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `bfr`: A mutable byte buffer to store the inquiry data.
     ///
     /// # Returns
     /// Length of the response (amount of bytes that were written to the given buffer).
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the InquiryData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided InquiryDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] when the command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] when the device does not support this data
+    ///   class.
+    /// - [`Status::DEVICE_ERROR`] when an error occurred while reading the
+    ///   inquiry data from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] The provided inquiry data size buffer is
+    ///   not large enough to store the required data.
     pub fn inquiry(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         unsafe {
@@ -111,17 +116,20 @@ impl DiskInfo {
 
     /// Performs an identify command on the disk device.
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `bfr`: A mutable byte buffer to store the identification data.
     ///
     /// # Returns
     /// Length of the response (amount of bytes that were written to the given buffer).
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the IdentifyData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided IdentifyDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] when the command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] when the device does not support this data
+    ///   class.
+    /// - [`Status::DEVICE_ERROR`] when an error occurred while reading the
+    ///   identify data from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] when the provided IdentifyDataSize buffer
+    ///   is not large enough to store the required data.
     pub fn identify(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         unsafe {
@@ -132,17 +140,19 @@ impl DiskInfo {
 
     /// Retrieves sense data from the disk device.
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `bfr`: A mutable byte buffer to store the sense data.
     ///
     /// # Returns
     /// [`SenseDataInfo`] struct containing the number of bytes of sense data and the number of sense data structures.
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the SenseData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided SenseDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] when the command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] when the device does not support this data class.
+    /// - [`Status::DEVICE_ERROR`] when an error occurred while reading the
+    ///   sense data from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] when the provided sense data buffer is
+    ///   not large enough to store the required data.
     pub fn sense_data(&self, bfr: &mut [u8]) -> crate::Result<SenseDataInfo> {
         let mut len: u32 = bfr.len() as u32;
         let mut number: u8 = 0;
@@ -164,8 +174,8 @@ impl DiskInfo {
     /// [`DeviceLocationInfo`] struct containing the channel and device numbers.
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The `IdeChannel` and `IdeDevice` values are valid.
-    /// - [`crate::Status::UNSUPPORTED`] Not supported by this disk's interface type.
+    /// - [`Status::SUCCESS`] The `IdeChannel` and `IdeDevice` values are valid.
+    /// - [`Status::UNSUPPORTED`] Not supported by this disk's interface type.
     pub fn bus_location(&self) -> crate::Result<DeviceLocationInfo> {
         let mut ide_channel: u32 = 0; // called ide, but also useful for other interfaces
         let mut ide_device: u32 = 0;

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -38,10 +38,9 @@ impl Directory {
     /// alignment through the `Align` trait (`<FileInfo as Align>::alignment()`).
     ///
     /// # Arguments
-    /// * `buffer`  The target buffer of the read operation
+    /// * `buffer`: The target buffer of the read operation
     ///
     /// # Errors
-    ///
     /// All errors come from calls to [`RegularFile::read`].
     pub fn read_entry<'buf>(
         &mut self,

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -44,29 +44,28 @@ pub trait File: Sized {
     /// Try to open a file relative to this file.
     ///
     /// # Arguments
-    /// * `filename`    Path of file to open, relative to this file
-    /// * `open_mode`   The mode to open the file with
-    /// * `attributes`  Only valid when `FILE_MODE_CREATE` is used as a mode
+    /// * `filename`: Path of file to open, relative to this file
+    /// * `open_mode`: The mode to open the file with
+    /// * `attributes`: Only valid when `FILE_MODE_CREATE` is used as a mode
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.Open()` in the UEFI Specification for more details.
     /// Note that [`INVALID_PARAMETER`] is not listed in the specification as one of the
     /// errors returned by this function, but some implementations (such as EDK2) perform
     /// additional validation and may return that status for invalid inputs.
     ///
-    /// [`INVALID_PARAMETER`]: uefi::Status::INVALID_PARAMETER
+    /// [`INVALID_PARAMETER`]: Status::INVALID_PARAMETER
     ///
-    /// * [`uefi::Status::INVALID_PARAMETER`]
-    /// * [`uefi::Status::NOT_FOUND`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::MEDIA_CHANGED`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::OUT_OF_RESOURCES`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::INVALID_PARAMETER`]
+    /// * [`Status::NOT_FOUND`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::MEDIA_CHANGED`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::OUT_OF_RESOURCES`]
+    /// * [`Status::VOLUME_FULL`]
     fn open(
         &mut self,
         filename: &CStr16,
@@ -111,17 +110,16 @@ pub trait File: Sized {
     /// The buffer must be aligned on an `<Info as Align>::alignment()` boundary.
     ///
     /// # Arguments
-    /// * `buffer`  Buffer that the information should be written into
+    /// * `buffer`: Buffer that the information should be written into
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.GetInfo()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::BUFFER_TOO_SMALL`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::BUFFER_TOO_SMALL`]
     fn get_info<'buf, Info: FileProtocolInfo + ?Sized>(
         &mut self,
         buffer: &'buf mut [u8],
@@ -156,20 +154,19 @@ pub trait File: Sized {
     /// `FileProtocolInfo` type documentation.
     ///
     /// # Arguments
-    /// * `info`  Info that should be set for the file
+    /// * `info`: Info that should be set for the file
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.SetInfo()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
-    /// * [`uefi::Status::BAD_BUFFER_SIZE`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
+    /// * [`Status::BAD_BUFFER_SIZE`]
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
         let info_ptr = ptr::from_ref(info).cast::<c_void>();
         let info_size = size_of_val(info);
@@ -179,15 +176,14 @@ pub trait File: Sized {
     /// Flushes all modified data associated with the file handle to the device
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.Flush()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
     fn flush(&mut self) -> Result {
         unsafe { (self.imp().flush)(self.imp()) }.to_result()
     }

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -31,18 +31,16 @@ impl RegularFile {
     /// actually read.
     ///
     /// # Arguments
-    /// * `buffer`  The target buffer of the read operation
+    /// * `buffer`: The target buffer of the read operation
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.Read()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
     ///
     /// # Quirks
-    ///
     /// Some UEFI implementations have a bug where large reads will incorrectly
     /// return an error. This function avoids that bug by reading in chunks of
     /// no more than 1 MiB. This is handled internally within the function;
@@ -88,15 +86,14 @@ impl RegularFile {
     /// * `buffer`  Buffer to write to file
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.Write()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
     pub fn write(&mut self, buffer: &[u8]) -> Result<(), usize> {
         let mut buffer_size = buffer.len();
         unsafe { (self.imp().write)(self.imp(), &mut buffer_size, buffer.as_ptr().cast()) }
@@ -106,10 +103,9 @@ impl RegularFile {
     /// Get the file's current position
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.GetPosition()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::DEVICE_ERROR`]
+    /// * [`Status::DEVICE_ERROR`]
     pub fn get_position(&mut self) -> Result<u64> {
         let mut pos = 0u64;
         unsafe { (self.imp().get_position)(self.imp(), &mut pos) }.to_result_with_val(|| pos)
@@ -123,13 +119,12 @@ impl RegularFile {
     /// Using a position of RegularFile::END_OF_FILE will seek to the end of the file.
     ///
     /// # Arguments
-    /// * `position` The new absolution position of the file handle
+    /// * `position`: The new absolution position of the file handle
     ///
     /// # Errors
-    ///
     /// See section `EFI_FILE_PROTOCOL.SetPosition()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::DEVICE_ERROR`]
+    /// * [`Status::DEVICE_ERROR`]
     pub fn set_position(&mut self, position: u64) -> Result {
         unsafe { (self.imp().set_position)(self.imp(), position) }.to_result()
     }

--- a/uefi/src/proto/media/fs.rs
+++ b/uefi/src/proto/media/fs.rs
@@ -4,6 +4,8 @@
 
 use super::file::{Directory, FileHandle};
 use crate::proto::unsafe_protocol;
+#[cfg(doc)]
+use crate::Status;
 use crate::{Result, StatusExt};
 use core::ptr;
 use uefi_raw::protocol::file_system::SimpleFileSystemProtocol;
@@ -39,13 +41,13 @@ impl SimpleFileSystem {
     /// `EFI_SIMPLE_FILE SYSTEM_PROTOCOL.OpenVolume()` (this has a space in between FILE and
     /// SYSTEM; it could be a typo in the UEFI spec).
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::OUT_OF_RESOURCES`]
-    /// * [`uefi::Status::MEDIA_CHANGED`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::OUT_OF_RESOURCES`]
+    /// * [`Status::MEDIA_CHANGED`]
     pub fn open_volume(&mut self) -> Result<Directory> {
         let mut ptr = ptr::null_mut();
         unsafe { (self.0.open_volume)(&mut self.0, &mut ptr) }

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -41,27 +41,23 @@ pub struct LoadFile(LoadFileProtocol);
 impl LoadFile {
     /// Causes the driver to load a specified file.
     ///
-    /// # Parameters
-    /// - `file_path` The device specific path of the file to load.
-    /// - `boot_policy` The [`BootPolicy`] to use.
+    /// # Arguments
+    /// - `file_path`: The device specific path of the file to load.
+    /// - `boot_policy`: The [`BootPolicy`] to use.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The file was loaded.
-    /// - [`Status::UNSUPPORTED`] The device does not support the
+    /// - [`Status::UNSUPPORTED`] when the device does not support the
     ///   provided BootPolicy.
-    /// - [`Status::INVALID_PARAMETER`] FilePath is not a valid device
-    ///   path, or BufferSize is NULL.
-    /// - [`Status::NO_MEDIA`] No medium was present to load the file.
-    /// - [`Status::DEVICE_ERROR`] The file was not loaded due to a
+    /// - [`Status::INVALID_PARAMETER`] the `file_path` is not a valid
+    ///   [`DevicePath`]
+    /// - [`Status::NO_MEDIA`] when no medium was present to load the file.
+    /// - [`Status::DEVICE_ERROR`] when the file was not loaded due to a
     ///   device error.
-    /// - [`Status::NO_RESPONSE`] The remote system did not respond.
-    /// - [`Status::NOT_FOUND`] The file was not found.
-    /// - [`Status::ABORTED`] The file load process was manually
+    /// - [`Status::NO_RESPONSE`] when the remote system did not respond.
+    /// - [`Status::NOT_FOUND`] when the file was not found.
+    /// - [`Status::ABORTED`] when the file load process was manually
     ///   cancelled.
-    /// - [`Status::BUFFER_TOO_SMALL`] The BufferSize is too small to
-    ///   read the current directory entry. BufferSize has been updated with the
-    ///   size needed to complete the request.
-    /// - [`Status::WARN_FILE_SYSTEM`] The resulting Buffer contains
+    /// - [`Status::WARN_FILE_SYSTEM`] when the resulting buffer contains
     ///   UEFI-compliant file system.
     ///
     /// [`BootPolicy`]: uefi::proto::BootPolicy
@@ -117,24 +113,19 @@ pub struct LoadFile2(LoadFile2Protocol);
 impl LoadFile2 {
     /// Causes the driver to load a specified file.
     ///
-    /// # Parameters
-    /// - `file_path` The device specific path of the file to load.
+    /// # Arguments
+    /// - `file_path`: The device specific path of the file to load.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The file was loaded.
-    /// - [`Status::UNSUPPORTED`] BootPolicy is TRUE.
-    /// - [`Status::INVALID_PARAMETER`] FilePath is not a valid device
-    ///   path, or BufferSize is NULL.
-    /// - [`Status::NO_MEDIA`] No medium was present to load the file.
-    /// - [`Status::DEVICE_ERROR`] The file was not loaded due to a
+    /// - [`Status::INVALID_PARAMETER`] when `file_path` is not a valid device
+    ///   path, or the buffer size is NULL.
+    /// - [`Status::NO_MEDIA`] when no medium was present to load the file.
+    /// - [`Status::DEVICE_ERROR`] when the file was not loaded due to a
     ///   device error.
-    /// - [`Status::NO_RESPONSE`] The remote system did not respond.
-    /// - [`Status::NOT_FOUND`] The file was not found.
-    /// - [`Status::ABORTED`] The file load process was manually
+    /// - [`Status::NO_RESPONSE`] when the remote system did not respond.
+    /// - [`Status::NOT_FOUND`] when the file was not found.
+    /// - [`Status::ABORTED`] when the file load process was manually
     ///   cancelled.
-    /// - [`Status::BUFFER_TOO_SMALL`] The BufferSize is too small to
-    ///   read the current directory entry. BufferSize has been updated with the
-    ///   size needed to complete the request.
     #[cfg(feature = "alloc")]
     #[allow(clippy::extra_unused_lifetimes)] // false positive, it is used
     pub fn load_file<'a>(&mut self, file_path: &DevicePath) -> Result<Box<[u8]>> {

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -103,7 +103,6 @@ impl PcrEvent {
     /// Create a new `PcrEvent` using a byte buffer for storage.
     ///
     /// # Errors
-    ///
     /// Returns [`Status::BUFFER_TOO_SMALL`] if the `buffer` is not large
     /// enough. The required size will be returned in the error data.
     ///
@@ -147,7 +146,6 @@ impl PcrEvent {
     /// Create a new `PcrEvent` in a [`Box`].
     ///
     /// # Errors
-    ///
     /// Returns [`Status::INVALID_PARAMETER`] if the `event_data` size is too
     /// large.
     #[cfg(feature = "alloc")]

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -130,7 +130,6 @@ impl PcrEventInputs {
     /// Create a new `PcrEventInputs` using a byte buffer for storage.
     ///
     /// # Errors
-    ///
     /// Returns [`Status::BUFFER_TOO_SMALL`] if the `buffer` is not large
     /// enough. The required size will be returned in the error data.
     ///
@@ -174,7 +173,6 @@ impl PcrEventInputs {
     /// Create a new `PcrEventInputs` in a [`Box`].
     ///
     /// # Errors
-    ///
     /// Returns [`Status::INVALID_PARAMETER`] if the `event_data` size is too
     /// large.
     #[cfg(feature = "alloc")]

--- a/uefi/src/runtime.rs
+++ b/uefi/src/runtime.rs
@@ -84,11 +84,11 @@ pub unsafe fn set_time(time: &Time) -> Result {
 /// not exist, or `Err` if the existence of the variable could not be determined.
 ///
 /// # Errors
-///
-/// * [`Status::DEVICE_ERROR`]: variable could not be read due to a hardware error.
-/// * [`Status::SECURITY_VIOLATION`]: variable could not be read due to an
+/// * [`Status::DEVICE_ERROR`] if the variable could not be read due to
+///   hardware error.
+/// * [`Status::SECURITY_VIOLATION`] if the variable could not be read due to an
 ///   authentication error.
-/// * [`Status::UNSUPPORTED`]: this platform does not support variable storage
+/// * [`Status::UNSUPPORTED`] if this platform does not support variable storage
 ///   after exiting boot services.
 pub fn variable_exists(name: &CStr16, vendor: &VariableVendor) -> Result<bool> {
     let rt = runtime_services_raw_panicking();
@@ -126,14 +126,14 @@ pub fn variable_exists(name: &CStr16, vendor: &VariableVendor) -> Result<bool> {
 /// `buf`) and the variable's attributes.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: variable was not found.
-/// * [`Status::BUFFER_TOO_SMALL`]: `buf` is not large enough. The required size
-///   will be returned in the error data.
-/// * [`Status::DEVICE_ERROR`]: variable could not be read due to a hardware error.
-/// * [`Status::SECURITY_VIOLATION`]: variable could not be read due to an
+/// * [`Status::NOT_FOUND`] if the variable was not found.
+/// * [`Status::BUFFER_TOO_SMALL`] if `buf` is not large enough. The required
+///   size will be returned in the error data.
+/// * [`Status::DEVICE_ERROR`] if the variable could not be read due to a
+///   hardware error.
+/// * [`Status::SECURITY_VIOLATION`] if the variable could not be read due to an
 ///   authentication error.
-/// * [`Status::UNSUPPORTED`]: this platform does not support variable storage
+/// * [`Status::UNSUPPORTED`] if this platform does not support variable storage
 ///   after exiting boot services.
 pub fn get_variable<'buf>(
     name: &CStr16,
@@ -165,12 +165,12 @@ pub fn get_variable<'buf>(
 /// Gets the contents and attributes of a variable.
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: variable was not found.
-/// * [`Status::DEVICE_ERROR`]: variable could not be read due to a hardware error.
-/// * [`Status::SECURITY_VIOLATION`]: variable could not be read due to an
+/// * [`Status::NOT_FOUND`] if the variable was not found.
+/// * [`Status::DEVICE_ERROR`] if the variable could not be read due to a
+///   hardware error.
+/// * [`Status::SECURITY_VIOLATION`] if the variable could not be read due to an
 ///   authentication error.
-/// * [`Status::UNSUPPORTED`]: this platform does not support variable storage
+/// * [`Status::UNSUPPORTED`] if this platform does not support variable storage
 ///   after exiting boot services.
 #[cfg(feature = "alloc")]
 pub fn get_variable_boxed(
@@ -213,9 +213,7 @@ pub fn get_variable_boxed(
 /// [`CStr16::from_u16_with_nul`].
 ///
 /// # Errors
-///
-/// * [`Status::NOT_FOUND`]: indicates end of iteration, the last variable keys
-///   was retrieved by the previous call to `get_next_variable_key`.
+/// * [`Status::NOT_FOUND`] if no further variables are found.
 /// * [`Status::BUFFER_TOO_SMALL`]: `name` is not large enough. The required
 ///   size (in `u16` characters, not bytes) will be returned in the error data.
 /// * [`Status::INVALID_PARAMETER`]: `name` does not contain a null character, or
@@ -347,15 +345,14 @@ impl Iterator for VariableKeys {
 /// mode if the firmware requires a reboot for that operation.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: invalid attributes, name, or vendor.
-/// * [`Status::OUT_OF_RESOURCES`]: not enough storage is available to hold
+/// * [`Status::INVALID_PARAMETER`] if `name` or `vendor` are invalid.
+/// * [`Status::OUT_OF_RESOURCES`] if not enough storage is available to hold
 ///   the variable.
-/// * [`Status::WRITE_PROTECTED`]: variable is read-only.
-/// * [`Status::SECURITY_VIOLATION`]: variable could not be written due to an
-///   authentication error.
-/// * [`Status::NOT_FOUND`]: attempted to update a non-existent variable.
-/// * [`Status::UNSUPPORTED`]: this platform does not support variable storage
+/// * [`Status::WRITE_PROTECTED`] if the variable is read-only.
+/// * [`Status::SECURITY_VIOLATION`] if the variable could not be written due to
+///   an authentication error.
+/// * [`Status::NOT_FOUND`] if the variable is non-existent.
+/// * [`Status::UNSUPPORTED`] if this platform does not support variable storage
 ///   after exiting boot services.
 pub fn set_variable(
     name: &CStr16,
@@ -381,13 +378,12 @@ pub fn set_variable(
 /// Deletes a UEFI variable.
 ///
 /// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: invalid name or vendor.
-/// * [`Status::WRITE_PROTECTED`]: variable is read-only.
-/// * [`Status::SECURITY_VIOLATION`]: variable could not be deleted due to an
-///   authentication error.
-/// * [`Status::NOT_FOUND`]: attempted to delete a non-existent variable.
-/// * [`Status::UNSUPPORTED`]: this platform does not support variable storage
+/// * [`Status::INVALID_PARAMETER`] if `name` or `vendor` are invalid.
+/// * [`Status::WRITE_PROTECTED`] if the variable is read-only.
+/// * [`Status::SECURITY_VIOLATION`] if the variable could not be written due to
+///   an authentication error.
+/// * [`Status::NOT_FOUND`] if the variable is non-existent.
+/// * [`Status::UNSUPPORTED`] if this platform does not support variable storage
 ///   after exiting boot services.
 pub fn delete_variable(name: &CStr16, vendor: &VariableVendor) -> Result {
     set_variable(name, vendor, VariableAttributes::empty(), &[])
@@ -429,18 +425,17 @@ pub fn query_variable_info(attributes: VariableAttributes) -> Result<VariableSto
 ///
 /// Capsules are most commonly used to update system firmware.
 ///
-/// # Errors
-///
-/// * [`Status::INVALID_PARAMETER`]: zero capsules were provided, or the
+/// # Errors///
+/// * [`Status::INVALID_PARAMETER`] if zero capsules were provided, or the
 ///   capsules are invalid.
-/// * [`Status::DEVICE_ERROR`]: the capsule update was started but failed to a
-///   device error.
-/// * [`Status::OUT_OF_RESOURCES`]: before exiting boot services, indicates the
+/// * [`Status::DEVICE_ERROR`] if the capsule update was started but failed due
+///   to a device error.
+/// * [`Status::OUT_OF_RESOURCES`] if before exiting boot services, the
 ///   capsule is compatible with the platform but there are insufficient
 ///   resources to complete the update. After exiting boot services, indicates
 ///   the capsule is compatible with the platform but can only be processed
 ///   before exiting boot services.
-/// * [`Status::UNSUPPORTED`]: this platform does not support capsule updates
+/// * [`Status::UNSUPPORTED`] if this platform does not support capsule updates
 ///   after exiting boot services.
 pub fn update_capsule(
     capsule_header_array: &[&CapsuleHeader],
@@ -464,15 +459,14 @@ pub fn update_capsule(
 /// See [`CapsuleInfo`] for details of the information returned.
 ///
 /// # Errors
-///
-/// * [`Status::OUT_OF_RESOURCES`]: before exiting boot services, indicates the
+/// * [`Status::OUT_OF_RESOURCES`] if before exiting boot services, the
 ///   capsule is compatible with the platform but there are insufficient
 ///   resources to complete the update. After exiting boot services, indicates
 ///   the capsule is compatible with the platform but can only be processed
 ///   before exiting boot services.
-/// * [`Status::UNSUPPORTED`]: either the capsule type is not supported by this
-///   platform, or the platform does not support capsule updates after exiting
-///   boot services.
+/// * [`Status::UNSUPPORTED`] if either the capsule type is not supported by
+///   this platform, or the platform does not support capsule updates after
+///   exiting boot services.
 pub fn query_capsule_capabilities(capsule_header_array: &[&CapsuleHeader]) -> Result<CapsuleInfo> {
     let rt = runtime_services_raw_panicking();
     let rt = unsafe { rt.as_ref() };
@@ -527,12 +521,11 @@ pub fn reset(reset_type: ResetType, status: Status, data: Option<&[u8]>) -> ! {
 /// The caller must ensure the memory map is valid.
 ///
 /// # Errors
-///
-/// * [`Status::UNSUPPORTED`]: either boot services haven't been exited, the
+/// * [`Status::UNSUPPORTED`] if either boot services haven't been exited, the
 ///   firmware's addressing mode is already virtual, or the firmware does not
 ///   support this operation.
-/// * [`Status::NO_MAPPING`]: `map` is missing a required range.
-/// * [`Status::NOT_FOUND`]: `map` contains an address that is not in the
+/// * [`Status::NO_MAPPING`] if `map` is missing a required range.
+/// * [`Status::NOT_FOUND`] if `map` contains an address that is not in the
 ///   current memory map.
 pub unsafe fn set_virtual_address_map(
     map: &mut [MemoryDescriptor],

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -113,9 +113,10 @@ impl Feature {
     }
 
     /// Set of features that enables more code in the root uefi crate.
-    /// # Parameters
-    /// - `include_unstable` - add all functionality behind the `unstable` feature
-    /// - `runtime_features` - add all functionality that effect the runtime of Rust
+    ///
+    /// # Arguments
+    /// - `include_unstable`: add all functionality behind the `unstable` feature
+    /// - `runtime_features`: add all functionality that effect the runtime of Rust
     pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
         let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger];
         if include_unstable {


### PR DESCRIPTION
Streamline all `# Errors` and `# Arguments` sections. This is about
the style, not the content. The advantage of this streamlined and
consistent style, is that new contributions can follow the guideline.

This however is only a partial solution, in case we ever want to have a
100% streamlined documentation across the whole crate.

No major changes have been made with a few small exceptions, where I
deleted obviously wrong or irrelevant error codes.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
