### PR TITLE
uefi: alloc_pages() and alloc_pool() now return NonNull<[u8]>

### DIFF
--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -43,15 +43,17 @@ fn test_allocate_pages() {
 }
 
 fn test_allocate_pool() {
-    let ptr = boot::allocate_pool(MemoryType::LOADER_DATA, 10).unwrap();
+    let mut ptr = boot::allocate_pool(MemoryType::LOADER_DATA, 10).unwrap();
+    let buffer = unsafe { ptr.as_mut() };
 
     // Verify the allocation can be written to.
     {
-        let ptr = ptr.as_ptr();
-        unsafe { ptr.write_volatile(0xff) };
-        unsafe { ptr.add(9).write_volatile(0xff) };
+        buffer[0] = 0xff;
+        buffer[9] = 0xff;
+        assert_eq!(buffer[0], 0xff);
+        assert_eq!(buffer[9], 0xff);
     }
-    unsafe { boot::free_pool(ptr) }.unwrap();
+    unsafe { boot::free_pool(ptr.cast()) }.unwrap();
 }
 
 // Simple test to ensure our custom allocator works with the `alloc` crate.

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -222,13 +222,14 @@ fn test_install_configuration_table() {
     let initial_table_count = system::with_config_table(|t| t.len());
 
     // Create the entry data.
-    let config: NonNull<u8> = boot::allocate_pool(MemoryType::RUNTIME_SERVICES_DATA, 1).unwrap();
-    unsafe { config.write(123u8) };
+    let mut config_ptr = boot::allocate_pool(MemoryType::RUNTIME_SERVICES_DATA, 1).unwrap();
+    let buffer = unsafe { config_ptr.as_mut() };
+    buffer[0] = 123;
 
     // Install the table.
     const TABLE_GUID: Guid = guid!("4bec53c4-5fc1-48a1-ab12-df214907d29f");
     unsafe {
-        boot::install_configuration_table(&TABLE_GUID, config.as_ptr().cast()).unwrap();
+        boot::install_configuration_table(&TABLE_GUID, config_ptr.as_ptr().cast()).unwrap();
     }
 
     // Verify the installation.
@@ -244,6 +245,6 @@ fn test_install_configuration_table() {
     // Uninstall the table and free the memory.
     unsafe {
         boot::install_configuration_table(&TABLE_GUID, ptr::null()).unwrap();
-        boot::free_pool(config).unwrap();
+        boot::free_pool(config_ptr.cast()).unwrap();
     }
 }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -25,6 +25,9 @@
   `proto::device_path::text` to `proto::device_path`.
 - **Breaking:** `exit_boot_services` now consumes a `Option<MemoryType>` which
   defaults to the recommended value of `MemoryType::LOADER_DATA`.
+- **Breaking**: `allocate_pages` now returns `NonNull<[u8]>` to align it with
+  the Rust allocator API. There is an example in the documentation of that
+  function.
 - `boot::memory_map()` will never return `Status::BUFFER_TOO_SMALL` from now on,
   as this is considered a hard internal error where users can't do anything
   about it anyway. It will panic instead.

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -28,6 +28,9 @@
 - **Breaking**: `allocate_pages` now returns `NonNull<[u8]>` to align it with
   the Rust allocator API. There is an example in the documentation of that
   function.
+- **Breaking**: `allocate_pool` now returns `NonNull<[u8]>` to align it with
+  the Rust allocator API. There is an example in the documentation of that
+  function.
 - `boot::memory_map()` will never return `Status::BUFFER_TOO_SMALL` from now on,
   as this is considered a hard internal error where users can't do anything
   about it anyway. It will panic instead.

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -281,7 +281,7 @@ impl MemoryMapBackingMemory {
     pub(crate) fn new(memory_type: MemoryType) -> crate::Result<Self> {
         let memory_map_meta = boot::memory_map_size();
         let len = Self::safe_allocation_size_hint(memory_map_meta);
-        let ptr = boot::allocate_pool(memory_type, len)?.as_ptr();
+        let ptr = boot::allocate_pool(memory_type, len)?.cast::<u8>().as_ptr();
 
         // Should be fine as UEFI always has  allocations with a guaranteed
         // alignment of 8 bytes.


### PR DESCRIPTION
uefi: alloc_pages() and alloc_pool() now return `NonNull<[u8]>`. This aligns the signature with the Rust allocator API and also makes more sense.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
