### PR TITLE
snp network test fixes

### DIFF
--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -17,14 +17,12 @@ pub fn test() {
         let simple_network = simple_network.unwrap();
 
         // Check shutdown
-        simple_network
-            .shutdown()
-            .expect("Failed to shutdown Simple Network");
+        let res = simple_network.shutdown();
+        assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
 
         // Check stop
-        simple_network
-            .stop()
-            .expect("Failed to stop Simple Network");
+        let res = simple_network.stop();
+        assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
 
         // Check start
         simple_network

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -45,7 +45,7 @@ pub fn test() {
         // Set receive filters
         simple_network
             .receive_filters(
-                ReceiveFlags::UNICAST | ReceiveFlags::MULTICAST | ReceiveFlags::BROADCAST,
+                ReceiveFlags::UNICAST | ReceiveFlags::BROADCAST,
                 ReceiveFlags::empty(),
                 false,
                 None,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -153,9 +153,8 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
         features.push(Feature::DebugSupport);
     }
 
-    // Enable the PXE test unless networking is disabled or the arch doesn't
-    // support it.
-    if *opt.target == UefiArch::X86_64 && !opt.disable_network {
+    // Enable the PXE test unless networking is disabled
+    if !opt.disable_network {
         features.push(Feature::Pxe);
     }
 

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -503,8 +503,10 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // examples since it slows down the boot some.
     let echo_service = if !opt.disable_network && opt.example.is_none() {
         cmd.args([
-            "-nic",
-            "user,model=e1000,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",
+            "-netdev",
+            "user,id=net0,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",
+            "-device",
+            "virtio-net-pci,netdev=net0",
         ]);
         Some(net::EchoService::start())
     } else {


### PR DESCRIPTION
- **test/snp: NOT_STARTED error is not a test failure**
- **test/snp: UNSUPPORTED for statistics is not a test failure**
- **test/snp: drop multicast from packet filter.**
- **xtask/qemu: switch to virtio-net nic.**
