### PR TITLE
SNP Integration Test: Improve Clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,10 +346,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -437,6 +456,12 @@ dependencies = [
  "byteorder",
  "crc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "mbrman"
@@ -751,6 +776,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smoltcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "heapless",
+ "managed",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +994,7 @@ version = "0.2.0"
 dependencies = [
  "log",
  "qemu-exit",
+ "smoltcp",
  "uefi",
  "uefi-raw",
 ]

--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 [dependencies]
 uefi-raw = { path = "../uefi-raw" }
 uefi = { path = "../uefi", features = ["alloc", "global_allocator", "panic_handler", "logger", "qemu", "log-debugcon"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["medium-ethernet", "proto-ipv4", "socket-udp"] }
 
 log.workspace = true
 

--- a/uefi-test-runner/src/proto/network/mod.rs
+++ b/uefi-test-runner/src/proto/network/mod.rs
@@ -5,6 +5,9 @@ pub fn test() {
 
     http::test();
     pxe::test();
+    // Currently, we are in the unfortunate situation that the SNP test
+    // depends on the PXE test, as it assigns an IPv4 address to the
+    // interface via DHCP.
     snp::test();
 }
 

--- a/uefi-test-runner/src/proto/network/pxe.rs
+++ b/uefi-test-runner/src/proto/network/pxe.rs
@@ -26,8 +26,11 @@ pub fn test() {
 
         assert!(base_code.mode().dhcp_ack_received());
         let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack().as_ref();
-        let server_ip = dhcp_ack.bootp_si_addr;
-        let server_ip = IpAddress::new_v4(server_ip);
+
+        info!("DHCP: Server IP: {:?}", dhcp_ack.bootp_si_addr);
+        info!("DHCP: Client IP: {:?}", dhcp_ack.bootp_yi_addr);
+
+        let server_ip = IpAddress::new_v4(dhcp_ack.bootp_si_addr);
 
         const EXAMPLE_FILE_NAME: &[u8] = b"example-file.txt\0";
         const EXAMPLE_FILE_CONTENT: &[u8] = b"Hello world!";

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -10,6 +10,7 @@ use uefi_raw::protocol::network::snp::NetworkState;
 
 /// The MAC address configured for the interface.
 const EXPECTED_MAC: [u8; 6] = [0x52, 0x54, 0, 0, 0, 0x1];
+const ETHERNET_PROTOCOL_IPV4: u16 = 0x0800;
 
 fn find_network_device() -> Option<ScopedProtocol<SimpleNetwork>> {
     let mut maybe_handle = None;
@@ -118,7 +119,6 @@ pub fn test() {
             \xa9\xe4\
             \x04\x01\x02\x03\x04";
 
-    let dest_addr = MacAddress([0xffu8; 32]);
     assert!(
         !simple_network
             .get_interrupt_status()
@@ -132,8 +132,8 @@ pub fn test() {
             simple_network.mode().media_header_size as usize,
             payload,
             None,
-            Some(dest_addr),
-            Some(0x0800),
+            Some(simple_network.mode().broadcast_address),
+            Some(ETHERNET_PROTOCOL_IPV4),
         )
         .expect("Failed to transmit frame");
 

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -2,9 +2,44 @@
 
 use core::time::Duration;
 
+use uefi::boot::ScopedProtocol;
 use uefi::proto::network::MacAddress;
 use uefi::proto::network::snp::{InterruptStatus, ReceiveFlags, SimpleNetwork};
 use uefi::{Status, boot};
+
+/// The MAC address configured for the interface.
+const EXPECTED_MAC: [u8; 6] = [0x52, 0x54, 0, 0, 0, 0x1];
+
+fn find_network_device() -> Option<ScopedProtocol<SimpleNetwork>> {
+    let mut maybe_handle = None;
+
+    let handles = boot::find_handles::<SimpleNetwork>().unwrap_or_default();
+
+    // We iterate over all handles until we found the right network device.
+    for handle in handles {
+        let Ok(handle) = boot::open_protocol_exclusive::<SimpleNetwork>(handle) else {
+            continue;
+        };
+
+        // Check media is present
+        if !bool::from(handle.mode().media_present_supported)
+            || !bool::from(handle.mode().media_present)
+        {
+            continue;
+        }
+
+        // Check MAC address
+        let has_mac = handle.mode().current_address.0[0..6] == EXPECTED_MAC
+            && handle.mode().permanent_address.0[0..6] == EXPECTED_MAC;
+        if !has_mac {
+            continue;
+        }
+
+        maybe_handle.replace(handle);
+    }
+
+    maybe_handle
+}
 
 pub fn test() {
     // This test currently depends on the PXE test running first.
@@ -14,59 +49,55 @@ pub fn test() {
 
     info!("Testing the simple network protocol");
 
-    let handles = boot::find_handles::<SimpleNetwork>().unwrap_or_default();
+    // The handle to our specific network device, as the test requires also a
+    // specific environment. We do not test all possible handles.
+    let simple_network = find_network_device().unwrap_or_else(|| panic!(
+        "Failed to find SNP handle for network device with MAC address {:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
+        EXPECTED_MAC[0],
+        EXPECTED_MAC[1],
+        EXPECTED_MAC[2],
+        EXPECTED_MAC[3],
+        EXPECTED_MAC[4],
+        EXPECTED_MAC[5]
+    ));
 
-    for handle in handles {
-        let simple_network = boot::open_protocol_exclusive::<SimpleNetwork>(handle);
-        if simple_network.is_err() {
-            continue;
-        }
-        let simple_network = simple_network.unwrap();
+    // Check shutdown
+    let res = simple_network.shutdown();
+    assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
 
-        // Check shutdown
-        let res = simple_network.shutdown();
-        assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
+    // Check stop
+    let res = simple_network.stop();
+    assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
 
-        // Check stop
-        let res = simple_network.stop();
-        assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
+    // Check start
+    simple_network
+        .start()
+        .expect("Failed to start Simple Network");
 
-        // Check start
-        simple_network
-            .start()
-            .expect("Failed to start Simple Network");
+    // Check initialize
+    simple_network
+        .initialize(0, 0)
+        .expect("Failed to initialize Simple Network");
 
-        // Check initialize
-        simple_network
-            .initialize(0, 0)
-            .expect("Failed to initialize Simple Network");
+    // edk2 virtio-net driver does not support statistics, so
+    // allow UNSUPPORTED (same for collect_statistics below).
+    let res = simple_network.reset_statistics();
+    assert!(res == Ok(()) || res == Err(Status::UNSUPPORTED.into()));
 
-        // edk2 virtio-net driver does not support statistics, so
-        // allow UNSUPPORTED (same for collect_statistics below).
-        let res = simple_network.reset_statistics();
-        assert!(res == Ok(()) || res == Err(Status::UNSUPPORTED.into()));
+    // Reading the interrupt status clears it
+    simple_network.get_interrupt_status().unwrap();
 
-        // Reading the interrupt status clears it
-        simple_network.get_interrupt_status().unwrap();
+    // Set receive filters
+    simple_network
+        .receive_filters(
+            ReceiveFlags::UNICAST | ReceiveFlags::BROADCAST,
+            ReceiveFlags::empty(),
+            false,
+            None,
+        )
+        .expect("Failed to set receive filters");
 
-        // Set receive filters
-        simple_network
-            .receive_filters(
-                ReceiveFlags::UNICAST | ReceiveFlags::BROADCAST,
-                ReceiveFlags::empty(),
-                false,
-                None,
-            )
-            .expect("Failed to set receive filters");
-
-        // Check media
-        if !bool::from(simple_network.mode().media_present_supported)
-            || !bool::from(simple_network.mode().media_present)
-        {
-            continue;
-        }
-
-        let payload = b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
+    let payload = b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
             \x45\x00\
             \x00\x21\
             \x00\x01\
@@ -82,64 +113,62 @@ pub fn test() {
             \xa9\xe4\
             \x04\x01\x02\x03\x04";
 
-        let dest_addr = MacAddress([0xffu8; 32]);
-        assert!(
-            !simple_network
-                .get_interrupt_status()
-                .unwrap()
-                .contains(InterruptStatus::TRANSMIT)
-        );
-
-        // Send the frame
-        simple_network
-            .transmit(
-                simple_network.mode().media_header_size as usize,
-                payload,
-                None,
-                Some(dest_addr),
-                Some(0x0800),
-            )
-            .expect("Failed to transmit frame");
-
-        info!("Waiting for the transmit");
-        while !simple_network
+    let dest_addr = MacAddress([0xffu8; 32]);
+    assert!(
+        !simple_network
             .get_interrupt_status()
             .unwrap()
             .contains(InterruptStatus::TRANSMIT)
-        {}
+    );
 
-        // Attempt to receive a frame
-        let mut buffer = [0u8; 1500];
+    // Send the frame
+    simple_network
+        .transmit(
+            simple_network.mode().media_header_size as usize,
+            payload,
+            None,
+            Some(dest_addr),
+            Some(0x0800),
+        )
+        .expect("Failed to transmit frame");
 
-        info!("Waiting for the reception");
-        if simple_network.receive(&mut buffer, None, None, None, None)
-            == Err(Status::NOT_READY.into())
-        {
-            boot::stall(Duration::from_secs(1));
+    info!("Waiting for the transmit");
+    while !simple_network
+        .get_interrupt_status()
+        .unwrap()
+        .contains(InterruptStatus::TRANSMIT)
+    {}
 
-            simple_network
-                .receive(&mut buffer, None, None, None, None)
-                .unwrap();
+    // Attempt to receive a frame
+    let mut buffer = [0u8; 1500];
+
+    info!("Waiting for the reception");
+    if simple_network.receive(&mut buffer, None, None, None, None) == Err(Status::NOT_READY.into())
+    {
+        boot::stall(Duration::from_secs(1));
+
+        simple_network
+            .receive(&mut buffer, None, None, None, None)
+            .unwrap();
+    }
+
+    assert_eq!(buffer[42..47], [4, 4, 3, 2, 1]);
+
+    // Get stats
+    let res = simple_network.collect_statistics();
+    match res {
+        Ok(stats) => {
+            info!("Stats: {:?}", stats);
+
+            // One frame should have been transmitted and one received
+            assert_eq!(stats.tx_total_frames().unwrap(), 1);
+            assert_eq!(stats.rx_total_frames().unwrap(), 1);
         }
-
-        assert_eq!(buffer[42..47], [4, 4, 3, 2, 1]);
-
-        // Get stats
-        let res = simple_network.collect_statistics();
-        match res {
-            Ok(stats) => {
-                info!("Stats: {:?}", stats);
-
-                // One frame should have been transmitted and one received
-                assert_eq!(stats.tx_total_frames().unwrap(), 1);
-                assert_eq!(stats.rx_total_frames().unwrap(), 1);
-            }
-            Err(e) => {
-                if e == Status::UNSUPPORTED.into() {
-                    info!("Stats: unsupported.");
-                } else {
-                    panic!("{e}");
-                }
+        Err(e) => {
+            if e == Status::UNSUPPORTED.into() {
+                info!("Stats: unsupported.");
+            } else {
+                panic!("{e}");
             }
         }
     }

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -41,6 +41,8 @@ fn find_network_device() -> Option<ScopedProtocol<SimpleNetwork>> {
     maybe_handle
 }
 
+/// This test sends a simple UDP/IP packet to the `EchoService` (created by
+/// `cargo xtask run`) and receives its response.
 pub fn test() {
     // This test currently depends on the PXE test running first.
     if cfg!(not(feature = "pxe")) {
@@ -74,7 +76,6 @@ pub fn test() {
         .start()
         .expect("Failed to start Simple Network");
 
-    // Check initialize
     simple_network
         .initialize(0, 0)
         .expect("Failed to initialize Simple Network");
@@ -97,6 +98,12 @@ pub fn test() {
         )
         .expect("Failed to set receive filters");
 
+    // EthernetFrame(IPv4Packet(UDPPacket(Payload))).
+    // The ethernet frame header will be filled by `transmit()`.
+    // The UDP packet contains the byte sequence `4, 4, 3, 2, 1`.
+    //
+    // The packet is sent to the `EchoService` created by
+    // `cargo xtask run`. It runs on UDP port 21572.
     let payload = b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\
             \x45\x00\
             \x00\x21\
@@ -152,6 +159,7 @@ pub fn test() {
             .unwrap();
     }
 
+    // Check payload in UDP packet that was reversed by our EchoService.
     assert_eq!(buffer[42..47], [4, 4, 3, 2, 1]);
 
     // Get stats

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -7,6 +7,11 @@ use uefi::proto::network::snp::{InterruptStatus, ReceiveFlags, SimpleNetwork};
 use uefi::{Status, boot};
 
 pub fn test() {
+    // This test currently depends on the PXE test running first.
+    if cfg!(not(feature = "pxe")) {
+        return;
+    }
+
     info!("Testing the simple network protocol");
 
     let handles = boot::find_handles::<SimpleNetwork>().unwrap_or_default();

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -6,6 +6,7 @@ use uefi::boot::ScopedProtocol;
 use uefi::proto::network::MacAddress;
 use uefi::proto::network::snp::{InterruptStatus, ReceiveFlags, SimpleNetwork};
 use uefi::{Status, boot};
+use uefi_raw::protocol::network::snp::NetworkState;
 
 /// The MAC address configured for the interface.
 const EXPECTED_MAC: [u8; 6] = [0x52, 0x54, 0, 0, 0, 0x1];
@@ -63,15 +64,12 @@ pub fn test() {
         EXPECTED_MAC[5]
     ));
 
-    // Check shutdown
-    let res = simple_network.shutdown();
-    assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
+    assert_eq!(
+        simple_network.mode().state,
+        NetworkState::STOPPED,
+        "Should be in stopped state"
+    );
 
-    // Check stop
-    let res = simple_network.stop();
-    assert!(res == Ok(()) || res == Err(Status::NOT_STARTED.into()));
-
-    // Check start
     simple_network
         .start()
         .expect("Failed to start Simple Network");
@@ -180,4 +178,7 @@ pub fn test() {
             }
         }
     }
+
+    simple_network.stop().unwrap();
+    simple_network.shutdown().unwrap();
 }

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -254,6 +254,10 @@ pub fn test() {
         }
     }
 
-    simple_network.stop().unwrap();
+    // Workaround for OVMF firmware. `stop()` works in CI on x86_64, but not
+    // x86 or aarch64.
+    if simple_network.mode().state == NetworkState::STARTED {
+        simple_network.stop().unwrap();
+    }
     simple_network.shutdown().unwrap();
 }

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -498,7 +498,8 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
             "-netdev",
             "user,id=net0,net=192.168.17.0/24,tftp=uefi-test-runner/tftp/,bootfile=fake-boot-file",
             "-device",
-            "virtio-net-pci,netdev=net0",
+            // Some integration tests depend on this specific MAC.
+            "virtio-net-pci,netdev=net0,mac=52:54:00:00:00:01",
         ]);
         Some(net::EchoService::start())
     } else {


### PR DESCRIPTION
**TL;DR**: This adds more clarity to facilitate future debugging and improvements for #1617.

Wow, working on #1617 was an unexpected major time sink. The problem is that if `snp::test` runs before `pxe::test`, `snp.receive()` receives an Ethernet ARP package rather than a Ethernet IPv4 packet.

I tried two solutions:
- perform DHCP in SNP via PXEBaseCode protocol
- Send a raw ethernet frame

I've got none of the approaches to work, unfortunately. So instead, this adds more clarity to ease future debugging and improvements. Relates to #1617 opened by @kraxel.

## Steps to Undraft
- [x] merge and rebase onto #1664
- [x] split this into more reviewable commits

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
