### PR TITLE
uefi: Move PoolString to enable additional use

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1318,7 +1318,7 @@ unsafe fn get_memory_map_and_exit_boot_services(buf: &mut [u8]) -> Result<Memory
 ///
 /// [`helpers`]: crate::helpers
 /// [`Output`]: crate::proto::console::text::Output
-/// [`PoolString`]: crate::proto::device_path::text::PoolString
+/// [`PoolString`]: crate::data_types::PoolString
 #[must_use]
 pub unsafe fn exit_boot_services(custom_memory_type: Option<MemoryType>) -> MemoryMapOwned {
     // LOADER_DATA is the default and also used by the Linux kernel:

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -169,7 +169,8 @@ mod opaque;
 
 mod strs;
 pub use strs::{
-    CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, UnalignedCStr16Error,
+    CStr16, CStr8, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, PoolString,
+    UnalignedCStr16Error,
 };
 
 /// These functions are used in the implementation of the [`cstr8`] macro.


### PR DESCRIPTION
Move `PoolString` to enable other protocol implementations to utilize its functionality.

In particular, this PR will enable a safe wrapper around `UsbIoProtocol`'s `get_string_descriptor()`.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
