### PR TITLE
Enable access to hidden RAII guard components

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added `proto::scsi::pass_thru::ExtScsiPassThru`.
 - Added `proto::nvme::pass_thru::NvmePassThru`.
 - Added `proto::ata::pass_thru::AtaPassThru`.
+- Added `boot::ScopedProtocol::open_params()`.
+- Added `boot::TplGuard::old_tpl()`.
 
 ## Changed
 - **Breaking:** Removed `BootPolicyError` as `BootPolicy` construction is no

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1536,6 +1536,14 @@ pub struct ScopedProtocol<P: Protocol + ?Sized> {
     open_params: OpenProtocolParams,
 }
 
+impl<P: Protocol + ?Sized> ScopedProtocol<P> {
+    /// Returns the [`OpenProtocolParams`] used to open the [`ScopedProtocol`].
+    #[must_use]
+    pub const fn open_params(&self) -> OpenProtocolParams {
+        self.open_params
+    }
+}
+
 impl<P: Protocol + ?Sized> Drop for ScopedProtocol<P> {
     fn drop(&mut self) {
         let bt = boot_services_raw_panicking();
@@ -1667,7 +1675,7 @@ pub enum OpenProtocolAttributes {
 }
 
 /// Parameters passed to [`open_protocol`].
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct OpenProtocolParams {
     /// The handle for the protocol to open.
     pub handle: Handle,

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1598,6 +1598,14 @@ pub struct TplGuard {
     old_tpl: Tpl,
 }
 
+impl TplGuard {
+    /// Returns the previous [`Tpl`].
+    #[must_use]
+    pub const fn old_tpl(&self) -> Tpl {
+        self.old_tpl
+    }
+}
+
 impl Drop for TplGuard {
     fn drop(&mut self) {
         let bt = boot_services_raw_panicking();


### PR DESCRIPTION
Enables access to hidden (but not sensitive) components of RAII guards.

Exposing the old `Tpl` value inside `TplGuard` allows for retrieving the current `Tpl` safely as shown below.

```rust
// SAFETY:
//
// Tpl::HIGH_LEVEL is the highest possible `Tpl` level according to the UEFI
// specification and so will be greater than or equal to all valid `Tpl` values.
// Furthermore, we are only in `Tpl::HIGH_LEVEL` for the smallest possible amount of time.
unsafe { raise_tpl(Tpl::HIGH_LEVEL).old_tpl() }
``` 

Exposing the `OpenProtocolParams` inside `ScopedProtocol` allows UEFI drivers to use `uefi` and not have to store duplicate handles in their private data structures, since they can access the one inside of the `ScopedProtocol`.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
