### PR TITLE
xtask: Update OVMF release to EDK2_STABLE202502_R2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -475,9 +475,9 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "ovmf-prebuilt"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54830fd518fa4cdeb0cd5fad927f0ff6627a41e9705fe874679671108142ccfa"
+checksum = "190088f8c186fed557e7ac7ea795cb72f281a6600ccc743898db7871ad8f68b8"
 dependencies = [
  "log",
  "lzma-rs",
@@ -604,7 +604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -780,7 +780,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1034,7 +1034,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.14.0"
 log.workspace = true
 mbrman = "0.5.1"
 nix = { version = "0.29.0", default-features = false, features = ["fs"] }
-ovmf-prebuilt = "0.2.0"
+ovmf-prebuilt = "0.2.3"
 proc-macro2 = { version = "1.0.46", features = ["span-locations"] }
 quote = "1.0.21"
 regex = "1.10.2"

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -20,11 +20,8 @@ use tempfile::TempDir;
 #[cfg(target_os = "linux")]
 use {std::fs::Permissions, std::os::unix::fs::PermissionsExt};
 
-/// Name of the ovmf-prebuilt release tag.
-const OVMF_PREBUILT_TAG: &str = "edk2-stable202402-r1";
-
-/// SHA-256 hash of the release tarball.
-const OVMF_PREBUILT_HASH: &str = "91f3148ef146794241c77810a49cfa3e925c83eb55c5cc90f34718cc1b10e9eb";
+/// Name of the ovmf-prebuilt release to use by default.
+const OVMF_PREBUILT_SOURCE: Source = Source::EDK2_STABLE202502_R2;
 
 /// Directory into which the prebuilts will be download (relative to the repo root).
 const OVMF_PREBUILT_DIR: &str = "target/ovmf";
@@ -104,13 +101,7 @@ impl OvmfPaths {
                 );
             }
         } else {
-            let prebuilt = Prebuilt::fetch(
-                Source {
-                    tag: OVMF_PREBUILT_TAG,
-                    sha256: OVMF_PREBUILT_HASH,
-                },
-                OVMF_PREBUILT_DIR,
-            )?;
+            let prebuilt = Prebuilt::fetch(OVMF_PREBUILT_SOURCE, OVMF_PREBUILT_DIR)?;
 
             Ok(prebuilt.get_file(arch.into(), file_type))
         }


### PR DESCRIPTION
This will allow https requests to work.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
