### PR TITLE
uefi-raw: Redefine UsbPortStatus and UsbTransferStatus

### DIFF
--- a/uefi-raw/src/protocol/usb/host_controller.rs
+++ b/uefi-raw/src/protocol/usb/host_controller.rs
@@ -55,9 +55,38 @@ pub struct TransactionTranslator {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
-pub struct PortStatus {
-    pub port_status: u16,
-    pub port_change_status: u16,
+pub struct UsbPortStatus {
+    pub port_status: PortStatus,
+    pub port_change_status: PortChangeStatus,
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct PortStatus: u16 {
+        const CONNECTION = 0x0001;
+        const ENABLE = 0x0002;
+        const SUSPEND = 0x0004;
+        const OVER_CURRENT = 0x0008;
+        const RESET = 0x0010;
+        const POWER = 0x0100;
+        const LOW_SPEED = 0x0200;
+        const HIGH_SPEED = 0x0400;
+        const SUPER_SPEED = 0x0800;
+        const OWNER = 0x2000;
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct PortChangeStatus: u16 {
+        const CONNECTION = 0x0001;
+        const ENABLE = 0x0002;
+        const SUSPEND = 0x0004;
+        const OVER_CURRENT = 0x0008;
+        const RESET = 0x0010;
+    }
 }
 
 newtype_enum! {
@@ -170,7 +199,7 @@ pub struct Usb2HostControllerProtocol {
     pub get_root_hub_port_status: unsafe extern "efiapi" fn(
         this: *mut Self,
         port_number: u8,
-        port_status: *mut PortStatus,
+        port_status: *mut UsbPortStatus,
     ) -> Status,
     pub set_root_hub_port_feature: unsafe extern "efiapi" fn(
         this: *mut Self,

--- a/uefi-raw/src/protocol/usb/mod.rs
+++ b/uefi-raw/src/protocol/usb/mod.rs
@@ -2,6 +2,8 @@
 
 use core::ffi;
 
+use bitflags::bitflags;
+
 use crate::Status;
 
 pub mod host_controller;
@@ -25,9 +27,25 @@ pub struct DeviceRequest {
     pub length: u16,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct UsbTransferStatus(pub u32);
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct UsbTransferStatus: u32 {
+        const NOT_EXECUTE = 0x0001;
+        const STALL = 0x0002;
+        const BUFFER = 0x0004;
+        const BABBLE = 0x0008;
+        const NAK = 0x0010;
+        const CRC = 0x0020;
+        const TIMEOUT = 0x0040;
+        const BIT_STUFF = 0x0080;
+        const SYSTEM = 0x0100;
+    }
+}
+
+impl UsbTransferStatus {
+    pub const SUCCESS: Self = Self::empty();
+}
 
 pub type AsyncUsbTransferCallback = unsafe extern "efiapi" fn(
     data: *mut ffi::c_void,


### PR DESCRIPTION
Change the definitions of `UsbPortStatus` and `UsbTransferStatus` to better align with the UEFI specification, primarily by adding the defined flags.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
