### PR TITLE
uefi: Implement CalculateCrc32() boot services function

### DIFF
--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -26,6 +26,8 @@ pub fn test() {
     test_reinstall_protocol_interface();
     test_uninstall_protocol_interface();
     test_install_configuration_table();
+    info!("Testing crc32...");
+    test_calculate_crc32();
 }
 
 fn test_tpl() {
@@ -246,4 +248,12 @@ fn test_install_configuration_table() {
         boot::install_configuration_table(&TABLE_GUID, ptr::null()).unwrap();
         boot::free_pool(config).unwrap();
     }
+}
+
+fn test_calculate_crc32() {
+    let data = "uefi-rs";
+
+    let crc = boot::calculate_crc32(data.as_bytes()).unwrap();
+
+    assert_eq!(crc, 0xcfc96a3e);
 }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `proto::ata::pass_thru::AtaPassThru`.
 - Added `boot::ScopedProtocol::open_params()`.
 - Added `boot::TplGuard::old_tpl()`.
+- Added `boot::calculate_crc32()`.
 
 ## Changed
 - **Breaking:** Removed `BootPolicyError` as `BootPolicy` construction is no

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1461,6 +1461,19 @@ pub fn get_image_file_system(image_handle: Handle) -> Result<ScopedProtocol<Simp
     open_protocol_exclusive(device_handle)
 }
 
+/// Calculates the 32-bit CRC32 for the provided slice.
+///
+/// # Errors
+/// * [`Status::INVALID_PARAMETER`]
+pub fn calculate_crc32(data: &[u8]) -> Result<u32> {
+    let bt = boot_services_raw_panicking();
+    let bt = unsafe { bt.as_ref() };
+    let mut crc = 0u32;
+
+    unsafe { (bt.calculate_crc32)(data.as_ptr().cast(), data.len(), &mut crc) }
+        .to_result_with_val(|| crc)
+}
+
 /// Protocol interface [`Guids`][Guid] that are installed on a [`Handle`] as
 /// returned by [`protocols_per_handle`].
 #[derive(Debug)]


### PR DESCRIPTION
UEFI Boot services includes a helper function (CalculateCrc32) for calculating a 32-bit CRC over a buffer. This is useful in Rust applications as well, so expose it in the boot services API.
