### PR TITLE
ci: fix failing MSRV uefi-raw job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "uguid"
-version = "2.2.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
+checksum = "ab14ea9660d240e7865ce9d54ecdbd1cd9fa5802ae6f4512f093c7907e921533"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ rust-version = "1.81"
 bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
-uguid = "2.1.0"
+# Pinned to keep uefi-raw's MSRV.
+uguid = "=2.2.0"
 
 [patch.crates-io]
 uefi = { path = "uefi" }


### PR DESCRIPTION
Fix the CI that is broken since https://github.com/rust-osdev/uefi-rs/pull/1648#issuecomment-2841154287.


The MSRV was bumped upstream as part of a minor fix update: https://github.com/google/gpt-disk-rs/commit/02d38c2da469aa01519f094d2fd23dffde451761#r156105778



## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
