### PR TITLE
release: uefi-raw-0.11.0, uefi-macros-0.18.1, uefi-0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.9.0",
  "uguid",
@@ -1047,7 +1047,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -24,7 +24,7 @@ to your `Cargo.toml`. The resulting `Cargo.toml` should look like that:
 ```toml
 [dependencies]
 log = "0.4.21"
-uefi = { version = "0.34.0", features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.35.0", features = [ "panic_handler", "logger" ] }
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.34.1", features = ["panic_handler"] }
+uefi = { version = "0.35", features = ["panic_handler"] }

--- a/uefi-macros/CHANGELOG.md
+++ b/uefi-macros/CHANGELOG.md
@@ -1,6 +1,11 @@
 # uefi-macros - [Unreleased]
 
 
+# uefi-macros - 0.18.1 (2025-05-04)
+
+Minor documentation updates.
+
+
 # uefi-macros - 0.18.0 (2025-02-07)
 
 As of this release, the project has been relicensed from MPL-2.0 to

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-macros"
-version = "0.18.0"
+version = "0.18.1"
 readme = "README.md"
 description = "Procedural macros for the `uefi` crate."
 

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi-raw - [Unreleased]
 
+
+# uefi-raw - 0.11.0 (2025-05-04)
+
 ## Added
 - MSRV increased to 1.77.
 - Added `Boolean` type

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.10.0"
+version = "0.11.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+
+# uefi - 0.35.0 (2025-05-04)
+
 ## Added
 - Added `boot::signal_event`.
 - Added conversions between `proto::network::IpAddress` and `core::net` types.
@@ -42,7 +45,7 @@
 - The `Display` impl for `CStr8` now excludes the trailing null character.
 - `VariableKeys` initializes with a larger name buffer to work around firmware
   bugs on some devices.
-- The UEFI `allocator::Allocator` has been optimized for page-aligned 
+- The UEFI `allocator::Allocator` has been optimized for page-aligned
   allocations.
 
 

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.34.1"
+version = "0.35.0"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,
@@ -43,8 +43,8 @@ ptr_meta.workspace = true
 uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
-uefi-macros = "0.18.0"
-uefi-raw = "0.10.0"
+uefi-macros = "0.18.1"
+uefi-raw = "0.11.0"
 qemu-exit = { version = "3.0.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Closes https://github.com/rust-osdev/uefi-rs/issues/1608

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
