### PR TITLE
uefi: use Duration for boot::stall

### DIFF
--- a/uefi-test-runner/examples/hello_world.rs
+++ b/uefi-test-runner/examples/hello_world.rs
@@ -7,6 +7,7 @@
 // ANCHOR_END: features
 
 // ANCHOR: use
+use core::time::Duration;
 use log::info;
 use uefi::prelude::*;
 // ANCHOR_END: use
@@ -20,7 +21,7 @@ fn main() -> Status {
     // ANCHOR_END: services
     // ANCHOR: log
     info!("Hello world!");
-    boot::stall(10_000_000);
+    boot::stall(Duration::from_secs(10));
     // ANCHOR_END: log
     // ANCHOR: return
     Status::SUCCESS

--- a/uefi-test-runner/examples/loaded_image.rs
+++ b/uefi-test-runner/examples/loaded_image.rs
@@ -4,6 +4,7 @@
 #![no_main]
 #![no_std]
 
+use core::time::Duration;
 use log::info;
 use uefi::boot::{self, SearchType};
 use uefi::prelude::*;
@@ -20,7 +21,7 @@ fn main() -> Status {
 
     print_image_path().unwrap();
 
-    boot::stall(10_000_000);
+    boot::stall(Duration::from_secs(10));
     Status::SUCCESS
 }
 // ANCHOR_END: main

--- a/uefi-test-runner/examples/timestamp.rs
+++ b/uefi-test-runner/examples/timestamp.rs
@@ -8,13 +8,12 @@
 
 extern crate alloc;
 
-use log::{info, warn};
-
 // ANCHOR: use
+use core::time::Duration;
+use log::{info, warn};
 use uefi::boot;
 use uefi::prelude::*;
 use uefi::proto::misc::Timestamp;
-
 // ANCHOR_END: use
 
 // ANCHOR: entry
@@ -30,7 +29,7 @@ fn main() -> Status {
     // ANCHOR_END: params
 
     // ANCHOR: stall
-    boot::stall(10_000_000);
+    boot::stall(Duration::from_secs(10));
     // ANCHOR_END: stall
 
     // ANCHOR: return

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use core::time::Duration;
+
 use uefi::proto::network::snp::{InterruptStatus, ReceiveFlags, SimpleNetwork};
 use uefi::proto::network::MacAddress;
 use uefi::{boot, Status};
@@ -106,7 +108,7 @@ pub fn test() {
         if simple_network.receive(&mut buffer, None, None, None, None)
             == Err(Status::NOT_READY.into())
         {
-            boot::stall(1_000_000);
+            boot::stall(Duration::from_secs(1));
 
             simple_network
                 .receive(&mut buffer, None, None, None, None)

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -76,7 +76,7 @@ extern "efiapi" fn proc_increment_atomic(arg: *mut c_void) {
 }
 
 extern "efiapi" fn proc_wait_100ms(_: *mut c_void) {
-    boot::stall(100_000);
+    boot::stall(Duration::from_millis(100));
 }
 
 fn test_startup_all_aps(mps: &MpServices) {

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # uefi - [Unreleased]
 
+## Changed
+- **Breaking:** `boot::stall` now take `Duration` instead of
+  `usize`.
+
 
 # uefi - 0.35.0 (2025-05-04)
 

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -43,6 +43,7 @@ use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicPtr, Ordering};
+use core::time::Duration;
 use core::{mem, slice};
 use uefi_raw::table::boot::{InterfaceType, TimerDelay};
 #[cfg(feature = "alloc")]
@@ -1423,10 +1424,12 @@ pub fn set_watchdog_timer(
         .to_result()
 }
 
-/// Stalls execution for the given number of microseconds.
-pub fn stall(microseconds: usize) {
+/// Stalls execution for the given duration.
+pub fn stall(duration: Duration) {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
+
+    let microseconds = duration.as_micros() as usize;
 
     unsafe {
         // No error conditions are defined in the spec for this function, so

--- a/uefi/src/helpers/panic_handler.rs
+++ b/uefi/src/helpers/panic_handler.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use core::time::Duration;
+
 use crate::{boot, println};
 use cfg_if::cfg_if;
 
@@ -9,7 +11,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     // Give the user some time to read the message
     if boot::are_boot_services_active() {
-        boot::stall(10_000_000);
+        boot::stall(Duration::from_secs(10));
     } else {
         let mut dummy = 0u64;
         // FIXME: May need different counter values in debug & release builds

--- a/uefi/src/proto/network/ip4config2.rs
+++ b/uefi/src/proto/network/ip4config2.rs
@@ -7,6 +7,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::c_void;
+use core::time::Duration;
 
 use uefi::boot::ScopedProtocol;
 use uefi::prelude::*;
@@ -137,7 +138,7 @@ impl Ip4Config2 {
             if verbose {
                 print!(".");
             }
-            boot::stall(1_000_000);
+            boot::stall(Duration::from_secs(1));
             let info = self.get_interface_info()?;
             if info.station_addr != no_address {
                 if verbose {


### PR DESCRIPTION
Before:
```rust
pub fn stall(microseconds: usize) {
```

After:
```rust
pub fn stall(duration: Duration) {
```