### PR TITLE
ci: Temporarily pin to older nightly

### DIFF
--- a/.github/workflows/nightly_toolchain.toml
+++ b/.github/workflows/nightly_toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2025-06-01"
 targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -187,7 +187,7 @@ jobs:
         run: cp .github/workflows/nightly_toolchain.toml rust-toolchain.toml
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo +nightly build --target x86_64-unknown-uefi --verbose -p uefi-std-example
+        run: cargo build --target x86_64-unknown-uefi --verbose -p uefi-std-example
   coverage:
     name: Test Coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
There are a bunch of new lint errors that need to be addressed before we can successfully build with latest nightly.

(Note that the `+nightly` is dropped here from the `build_standard_uefi_binary` job, because it overrides the toolchain specified in `rust-toolchain.toml`.)

https://github.com/rust-osdev/uefi-rs/issues/1687

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
