### PR TITLE
Fix mismatched_lifetime_syntaxes lint

### DIFF
--- a/uefi-test-runner/src/proto/driver.rs
+++ b/uefi-test-runner/src/proto/driver.rs
@@ -28,7 +28,7 @@ impl ComponentNameInterface for ScopedProtocol<ComponentName1> {
         boot::open_protocol_exclusive::<ComponentName1>(handle)
     }
 
-    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    fn supported_languages(&self) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         (**self).supported_languages()
     }
 
@@ -51,7 +51,7 @@ impl ComponentNameInterface for ScopedProtocol<ComponentName2> {
         boot::open_protocol_exclusive::<ComponentName2>(handle)
     }
 
-    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    fn supported_languages(&self) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         (**self).supported_languages()
     }
 
@@ -74,7 +74,7 @@ impl ComponentNameInterface for ComponentName {
         Self::open(handle)
     }
 
-    fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    fn supported_languages(&self) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         self.supported_languages()
     }
 

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -569,7 +569,7 @@ impl CStr16 {
 
     /// Returns an iterator over this C string
     #[must_use]
-    pub const fn iter(&self) -> CStr16Iter {
+    pub const fn iter(&self) -> CStr16Iter<'_> {
         CStr16Iter {
             inner: self,
             pos: 0,

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -37,7 +37,7 @@ impl Path {
 
     /// Iterator over the components of a path.
     #[must_use]
-    pub fn components(&self) -> Components {
+    pub fn components(&self) -> Components<'_> {
         Components {
             path: self.as_ref(),
             i: 0,

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -104,7 +104,7 @@ impl GraphicsOutput {
 
     /// Returns a [`ModeIter`].
     #[must_use]
-    pub const fn modes(&self) -> ModeIter {
+    pub const fn modes(&self) -> ModeIter<'_> {
         ModeIter {
             gop: self,
             current: 0,
@@ -295,7 +295,7 @@ impl GraphicsOutput {
     }
 
     /// Access the frame buffer directly
-    pub fn frame_buffer(&mut self) -> FrameBuffer {
+    pub fn frame_buffer(&mut self) -> FrameBuffer<'_> {
         assert!(
             self.current_mode_info().pixel_format() != PixelFormat::BltOnly,
             "Cannot access the framebuffer in a Blt-only mode"

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -570,7 +570,7 @@ pub mod acpi {
         /// comes from Table B-2 ACPI 3.0 specification. At least one
         /// ADR value is required.
         #[must_use]
-        pub fn adr(&self) -> UnalignedSlice<u32> {
+        pub fn adr(&self) -> UnalignedSlice<'_, u32> {
             let ptr: *const [u32] = addr_of!(self.adr);
             let (ptr, len): (*const (), usize) = ptr_meta::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u32>(), len) }
@@ -1174,7 +1174,7 @@ pub mod messaging {
 
         /// Last 64 (or fewer) characters of the USB Serial number.
         #[must_use]
-        pub fn serial_number(&self) -> UnalignedSlice<u16> {
+        pub fn serial_number(&self) -> UnalignedSlice<'_, u16> {
             let ptr: *const [u16] = addr_of!(self.serial_number);
             let (ptr, len): (*const (), usize) = ptr_meta::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u16>(), len) }
@@ -2424,7 +2424,7 @@ pub mod messaging {
 
         /// One or more instances of the DNS server address.
         #[must_use]
-        pub fn addresses(&self) -> UnalignedSlice<IpAddress> {
+        pub fn addresses(&self) -> UnalignedSlice<'_, IpAddress> {
             let ptr: *const [IpAddress] = addr_of!(self.addresses);
             let (ptr, len): (*const (), usize) = ptr_meta::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<IpAddress>(), len) }
@@ -2933,7 +2933,7 @@ pub mod media {
     impl FilePath {
         /// Null-terminated path.
         #[must_use]
-        pub fn path_name(&self) -> UnalignedSlice<u16> {
+        pub fn path_name(&self) -> UnalignedSlice<'_, u16> {
             let ptr: *const [u16] = addr_of!(self.path_name);
             let (ptr, len): (*const (), usize) = ptr_meta::to_raw_parts(ptr);
             unsafe { UnalignedSlice::new(ptr.cast::<u16>(), len) }

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -289,7 +289,7 @@ impl DevicePathNode {
 
     /// Convert from a generic [`DevicePathNode`] reference to an enum
     /// of more specific node types.
-    pub fn as_enum(&self) -> Result<DevicePathNodeEnum, NodeConversionError> {
+    pub fn as_enum(&self) -> Result<DevicePathNodeEnum<'_>, NodeConversionError> {
         DevicePathNodeEnum::try_from(self)
     }
 
@@ -365,7 +365,7 @@ impl DevicePathInstance {
     ///
     /// [`DevicePathNodes`]: DevicePathNode
     #[must_use]
-    pub const fn node_iter(&self) -> DevicePathNodeIterator {
+    pub const fn node_iter(&self) -> DevicePathNodeIterator<'_> {
         DevicePathNodeIterator {
             nodes: &self.data,
             stop_condition: StopCondition::AnyEndNode,
@@ -539,7 +539,7 @@ impl DevicePath {
 
     /// Get an iterator over the [`DevicePathInstance`]s in this path.
     #[must_use]
-    pub const fn instance_iter(&self) -> DevicePathInstanceIterator {
+    pub const fn instance_iter(&self) -> DevicePathInstanceIterator<'_> {
         DevicePathInstanceIterator {
             remaining_path: Some(self),
         }
@@ -550,7 +550,7 @@ impl DevicePath {
     /// [`is_end_entire`][DevicePathNode::is_end_entire] is true. That ending
     /// path is not returned by the iterator.
     #[must_use]
-    pub const fn node_iter(&self) -> DevicePathNodeIterator {
+    pub const fn node_iter(&self) -> DevicePathNodeIterator<'_> {
         DevicePathNodeIterator {
             nodes: &self.data,
             stop_condition: StopCondition::EndEntireNode,

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -43,7 +43,9 @@ impl ComponentName1 {
     /// English is encoded as "eng".
     ///
     /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
-    pub const fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    pub const fn supported_languages(
+        &self,
+    ) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V1)
     }
 
@@ -110,7 +112,9 @@ impl ComponentName2 {
     /// as "en".
     ///
     /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
-    pub const fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    pub const fn supported_languages(
+        &self,
+    ) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V2)
     }
 
@@ -185,7 +189,7 @@ impl ComponentName {
     /// [ISO 639-2]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
     /// [RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646
     #[allow(clippy::missing_const_for_fn)] // false-positive since Rust 1.86
-    pub fn supported_languages(&self) -> core::result::Result<LanguageIter, LanguageError> {
+    pub fn supported_languages(&self) -> core::result::Result<LanguageIter<'_>, LanguageError> {
         match self {
             Self::V1(cn1) => cn1.supported_languages(),
             Self::V2(cn2) => cn2.supported_languages(),

--- a/uefi/src/proto/tcg/v1.rs
+++ b/uefi/src/proto/tcg/v1.rs
@@ -276,7 +276,7 @@ impl EventLog<'_> {
 
     /// Iterator of events in the log.
     #[must_use]
-    pub const fn iter(&self) -> EventLogIter {
+    pub const fn iter(&self) -> EventLogIter<'_> {
         EventLogIter {
             log: self,
             location: self.location,
@@ -356,7 +356,7 @@ pub struct StatusCheck<'a> {
 impl Tcg {
     /// Get information about the protocol and TPM device, as well as
     /// the TPM event log.
-    pub fn status_check(&mut self) -> Result<StatusCheck> {
+    pub fn status_check(&mut self) -> Result<StatusCheck<'_>> {
         let mut protocol_capability = TcgBootServiceCapability::default();
         let mut feature_flags = 0;
         let mut event_log_location = 0;

--- a/uefi/src/proto/tcg/v2.rs
+++ b/uefi/src/proto/tcg/v2.rs
@@ -336,7 +336,7 @@ pub struct EventLog<'a> {
 impl EventLog<'_> {
     /// Iterator of events in the log.
     #[must_use]
-    pub fn iter(&self) -> EventLogIter {
+    pub fn iter(&self) -> EventLogIter<'_> {
         if let Some(header) = self.header() {
             // Advance past the header
             let location = unsafe { self.location.add(header.size_in_bytes) };
@@ -356,7 +356,7 @@ impl EventLog<'_> {
     }
 
     /// Header at the beginning of the event log.
-    fn header(&self) -> Option<EventLogHeader> {
+    fn header(&self) -> Option<EventLogHeader<'_>> {
         // The spec is unclear if the header is present when there are
         // no entries, so lets assume that `self.location` will be null
         // if there's no header, and otherwise valid.
@@ -513,7 +513,7 @@ impl<'a> PcrEvent<'a> {
 
     /// Digests of the data hashed for this event.
     #[must_use]
-    pub fn digests(&self) -> PcrEventDigests {
+    pub fn digests(&self) -> PcrEventDigests<'_> {
         PcrEventDigests {
             data: self.digests,
             algorithm_digest_sizes: self.algorithm_digest_sizes.clone(),
@@ -579,7 +579,7 @@ impl Tcg {
 
     /// Get the V1 event log. This provides events in the same format as a V1
     /// TPM, so all events use SHA-1 hashes.
-    pub fn get_event_log_v1(&mut self) -> Result<v1::EventLog> {
+    pub fn get_event_log_v1(&mut self) -> Result<v1::EventLog<'_>> {
         let mut location = 0;
         let mut last_entry = 0;
         let mut truncated = 0;
@@ -608,7 +608,7 @@ impl Tcg {
     }
 
     /// Get the V2 event log. This format allows for a flexible list of hash types.
-    pub fn get_event_log_v2(&mut self) -> Result<EventLog> {
+    pub fn get_event_log_v2(&mut self) -> Result<EventLog<'_>> {
         let mut location = 0;
         let mut last_entry = 0;
         let mut truncated = 0;

--- a/xtask/src/device_path/field.rs
+++ b/xtask/src/device_path/field.rs
@@ -264,7 +264,7 @@ impl NodeField {
                 // In the general case we can't safely return a
                 // reference to the slice since it might be
                 // unaligned, so use `UnalignedSlice`.
-                ret_type = quote!(UnalignedSlice<#slice_elem>);
+                ret_type = quote!(UnalignedSlice<'_, #slice_elem>);
                 ret_val = quote!(
                     let ptr: *const [#slice_elem] = addr_of!(self.#field_name);
                     let (ptr, len): (*const (), usize) = ptr_meta::to_raw_parts(ptr);


### PR DESCRIPTION
Partial fix for https://github.com/rust-osdev/uefi-rs/issues/1687

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
