### PR TITLE
test-runner: Fix clippy::uninlined_format_args lint

### DIFF
--- a/uefi-test-runner/examples/timestamp.rs
+++ b/uefi-test-runner/examples/timestamp.rs
@@ -51,14 +51,14 @@ pub fn test_timestamp() {
                     .expect("Founded Timestamp Protocol but open failed");
             // ANCHOR: text
             let timestamp = timestamp_proto.get_timestamp();
-            info!("Timestamp Protocol's timestamp: {:?}", timestamp);
+            info!("Timestamp Protocol's timestamp: {timestamp:?}");
 
             let properties = timestamp_proto.get_properties();
-            info!("Timestamp Protocol's properties: {:?}", properties);
+            info!("Timestamp Protocol's properties: {properties:?}");
             // ANCHOR_END: text
         }
         Err(err) => {
-            warn!("Failed to found Timestamp Protocol: {:?}", err);
+            warn!("Failed to found Timestamp Protocol: {err}");
         }
     }
 }

--- a/uefi-test-runner/src/proto/ata/pass_thru.rs
+++ b/uefi-test-runner/src/proto/ata/pass_thru.rs
@@ -48,7 +48,7 @@ fn is_testdrive_present() -> bool {
                     });
                 let serial = core::str::from_utf8(&serial_bfr).unwrap().trim();
                 if serial == "AtaPassThru" {
-                    info!("Found Testdisk at handle: {:?}", handle);
+                    info!("Found Testdisk at handle: {handle:?}");
                     return true; // found our testdrive!
                 }
             }

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -18,7 +18,7 @@ pub fn test() {
         .expect("Failed to retrieve pointer state");
 
     if let Some(state) = state {
-        info!("New pointer State: {:#?}", state);
+        info!("New pointer State: {state:#?}");
     } else {
         info!("Pointer state has not changed since the last query");
     }

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -28,7 +28,7 @@ pub fn test(stdout: &mut Output) {
 // Retrieves and prints the current output mode.
 fn get_current_mode(stdout: &mut Output) {
     let current_mode = stdout.current_mode().unwrap();
-    info!("UEFI standard output current mode: {:?}", current_mode);
+    info!("UEFI standard output current mode: {current_mode:?}");
 }
 
 // Switch to the maximum supported text mode.

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -86,7 +86,7 @@ fn test_debug_support() {
             );
 
             info!("- Architecture: {:?}", debug_support.arch());
-            info!("- Maximum Processor Index: {:?}", maximum_processor_index);
+            info!("- Maximum Processor Index: {maximum_processor_index:?}");
 
             match debug_support.arch() {
                 // This arm is the only match when testing on QEMU w/ OVMF, regardless of the machine arch.

--- a/uefi-test-runner/src/proto/loaded_image.rs
+++ b/uefi-test-runner/src/proto/loaded_image.rs
@@ -10,11 +10,8 @@ pub fn test() {
         .expect("Failed to open LoadedImage protocol");
 
     let load_options = loaded_image.load_options_as_bytes();
-    info!("LoadedImage options: {:?}", load_options);
+    info!("LoadedImage options: {load_options:?}");
 
     let (image_base, image_size) = loaded_image.info();
-    info!(
-        "LoadedImage image address: {:?}, image size: {} bytes",
-        image_base, image_size
-    );
+    info!("LoadedImage image address: {image_base:?}, image size: {image_size} bytes");
 }

--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -124,7 +124,7 @@ fn test_existing_file(directory: &mut Directory) {
     let mut buffer = vec![0; 128];
     let size = file.read(&mut buffer).expect("failed to read file");
     let buffer = &buffer[..size];
-    info!("Successfully read {}", input_file_path);
+    info!("Successfully read {input_file_path}");
     assert_eq!(buffer, b"test input data");
 
     // Check file metadata.
@@ -370,7 +370,7 @@ fn test_disk_info() {
         let vendor_id = core::str::from_utf8(&inquiry_bfr[8..16]).unwrap().trim();
         let product_id = core::str::from_utf8(&inquiry_bfr[16..32]).unwrap().trim();
         if vendor_id == "uefi-rs" && product_id == "ExtScsiPassThru" {
-            info!("Found Testdisk at Handle: {:?}", handle);
+            info!("Found Testdisk at Handle: {handle:?}");
             found_drive = true;
         }
     }
@@ -385,7 +385,7 @@ fn test_partition_info(disk_handle: Handle) {
 
     let mbr = pi.mbr_partition_record().expect("Not an MBR disk");
 
-    info!("MBR partition: {:?}", mbr);
+    info!("MBR partition: {mbr:?}");
 
     assert_eq!(mbr.boot_indicator, 0);
     assert_eq!({ mbr.starting_lba }, 1);

--- a/uefi-test-runner/src/proto/misc.rs
+++ b/uefi-test-runner/src/proto/misc.rs
@@ -25,20 +25,14 @@ pub fn test_reset_notification() {
         data: *const u8,
     ) {
         info!("Inside the event callback, hi, efi_reset_fn");
-        info!("rt: {:?} status: {:?}", rt, status);
-        info!("size: {:?} data: {:?}", data_size, data);
+        info!("rt: {rt:?} status: {status:?}");
+        info!("size: {data_size:?} data: {data:?}");
         // do what you want
     }
 
     let result = reset_notif_proto.register_reset_notify(efi_reset_fn);
-    info!(
-        "ResetNotification Protocol register efi_reset_fn test: {:?}",
-        result
-    );
+    info!("ResetNotification Protocol register efi_reset_fn test: {result:?}");
 
     let result = reset_notif_proto.unregister_reset_notify(efi_reset_fn);
-    info!(
-        "ResetNotification Protocol unregister efi_reset_fn test: {:?}",
-        result
-    );
+    info!("ResetNotification Protocol unregister efi_reset_fn test: {result:?}");
 }

--- a/uefi-test-runner/src/proto/network/http.rs
+++ b/uefi-test-runner/src/proto/network/http.rs
@@ -12,39 +12,39 @@ use uefi_raw::protocol::network::http::HttpStatusCode;
 
 pub fn print_handle_devpath(prefix: &str, handle: &Handle) {
     let Ok(dp) = boot::open_protocol_exclusive::<DevicePath>(*handle) else {
-        info!("{}no device path for handle", prefix);
+        info!("{prefix}no device path for handle");
         return;
     };
     if let Ok(string) = dp.to_string(DisplayOnly(true), AllowShortcuts(true)) {
-        info!("{}{}", prefix, string);
+        info!("{prefix}{string}");
     }
 }
 
 fn fetch_http(handle: Handle, url: &str) -> Option<Vec<u8>> {
-    info!("http: fetching {} ...", url);
+    info!("http: fetching {url} ...");
 
     let http_res = HttpHelper::new(handle);
     if let Err(e) = http_res {
-        error!("http new: {}", e);
+        error!("http new: {e}");
         return None;
     }
     let mut http = http_res.unwrap();
 
     let res = http.configure();
     if let Err(e) = res {
-        error!("http configure: {}", e);
+        error!("http configure: {e}");
         return None;
     }
 
     let res = http.request_get(url);
     if let Err(e) = res {
-        error!("http request: {}", e);
+        error!("http request: {e}");
         return None;
     }
 
     let res = http.response_first(true);
     if let Err(e) = res {
-        error!("http response: {}", e);
+        error!("http response: {e}");
         return None;
     }
 
@@ -64,7 +64,7 @@ fn fetch_http(handle: Handle, url: &str) -> Option<Vec<u8>> {
         error!("parse content length ({})", cl_hdr.1);
         return None;
     };
-    info!("http: size is {} bytes", cl);
+    info!("http: size is {cl} bytes");
 
     let mut data = rsp.body;
     loop {
@@ -74,7 +74,7 @@ fn fetch_http(handle: Handle, url: &str) -> Option<Vec<u8>> {
 
         let res = http.response_more();
         if let Err(e) = res {
-            error!("read response: {}", e);
+            error!("read response: {e}");
             return None;
         }
 

--- a/uefi-test-runner/src/proto/network/snp.rs
+++ b/uefi-test-runner/src/proto/network/snp.rs
@@ -73,7 +73,7 @@ fn receive(simple_network: &mut SimpleNetwork, buffer: &mut [u8]) -> uefi::Resul
         debug!("Received:");
         debug!("  src_mac       =  {:x?}", &recv_src_mac.0[0..6]);
         debug!("  dst_mac       =  {:x?}", &recv_dst_mac.0[0..6]);
-        debug!("  ethernet_proto=0x{:x?}", recv_ethernet_protocol);
+        debug!("  ethernet_proto=0x{recv_ethernet_protocol:x?}");
 
         // Assert the ethernet frame was sent to the expected interface.
         {
@@ -239,7 +239,7 @@ pub fn test() {
     let res = simple_network.collect_statistics();
     match res {
         Ok(stats) => {
-            info!("Stats: {:?}", stats);
+            info!("Stats: {stats:?}");
 
             // One frame should have been transmitted and one received
             assert_eq!(stats.tx_total_frames().unwrap(), 1);

--- a/uefi-test-runner/src/proto/nvme/pass_thru.rs
+++ b/uefi-test-runner/src/proto/nvme/pass_thru.rs
@@ -29,7 +29,7 @@ fn has_nvme_drive() -> bool {
         let device_path_str = device_path
             .to_string(DisplayOnly(true), AllowShortcuts(false))
             .unwrap();
-        info!("- Successfully opened NVMe: {}", device_path_str);
+        info!("- Successfully opened NVMe: {device_path_str}");
         let mut nvme_ctrl = nvme_pt.controller();
 
         let request = NvmeRequestBuilder::new(nvme_pt.io_align(), 0x06, NvmeQueueType::ADMIN)
@@ -42,7 +42,7 @@ fn has_nvme_drive() -> bool {
         if let Ok(result) = result {
             let bfr = result.transfer_buffer().unwrap();
             let serial = core::str::from_utf8(&bfr[4..24]).unwrap().trim();
-            info!("Found NVMe with serial: '{}'", serial);
+            info!("Found NVMe with serial: '{serial}'");
             if serial == "uefi-rsNvmePassThru" {
                 return true;
             }

--- a/uefi-test-runner/src/proto/pci/root_bridge.rs
+++ b/uefi-test-runner/src/proto/pci/root_bridge.rs
@@ -55,14 +55,7 @@ pub fn test() {
                     }
 
                     log::info!(
-                        "PCI Device: [{}, {}, {}]: vendor={:04X}, device={:04X}, class={:02X}, subclass={:02X}",
-                        bus,
-                        dev,
-                        fun,
-                        vendor_id,
-                        device_id,
-                        class_code,
-                        subclass_code
+                        "PCI Device: [{bus}, {dev}, {fun}]: vendor={vendor_id:04X}, device={device_id:04X}, class={class_code:02X}, subclass={subclass_code:02X}"
                     );
                 }
             }

--- a/uefi-test-runner/src/proto/rng.rs
+++ b/uefi-test-runner/src/proto/rng.rs
@@ -14,12 +14,12 @@ pub fn test() {
     let mut list = [RngAlgorithmType::EMPTY_ALGORITHM; 4];
 
     let list = rng.get_info(&mut list).unwrap();
-    info!("Supported rng algorithms : {:?}", list);
+    info!("Supported rng algorithms : {list:?}");
 
     let mut buf = [0u8; 4];
 
     rng.get_rng(Some(list[0]), &mut buf).unwrap();
 
     assert_ne!([0u8; 4], buf);
-    info!("Random buffer : {:?}", buf);
+    info!("Random buffer : {buf:?}");
 }

--- a/uefi-test-runner/src/runtime/mod.rs
+++ b/uefi-test-runner/src/runtime/mod.rs
@@ -34,6 +34,6 @@ fn test_time() {
 
     // Print the new time and check that the year was successfully changed.
     let now = runtime::get_time().unwrap();
-    info!("After setting time: {}", now);
+    info!("After setting time: {now}");
     assert_eq!(now.year(), 2020);
 }


### PR DESCRIPTION
Partial fix for https://github.com/rust-osdev/uefi-rs/issues/1687

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
