### PR TITLE
xtask: Allow clippy::collapsible_if lint

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![allow(clippy::collapsible_if)]
+
 mod arch;
 mod cargo;
 mod check_raw;


### PR DESCRIPTION
Let-chains are being stabilized in 1.88, so this lint triggers on nightly. Since current stable is 1.87, we can't change the code to fix this lint, and we also can't use `expect` here. For now, the best solution is just to allow the lint.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
