### PR TITLE
uefi: Fix io-align == 0 edgecase handling for ata & nvme

### DIFF
--- a/uefi/src/proto/ata/pass_thru.rs
+++ b/uefi/src/proto/ata/pass_thru.rs
@@ -42,7 +42,9 @@ impl AtaPassThru {
     /// The [`AtaPassThruMode`] structure containing configuration details of the protocol.
     #[must_use]
     pub fn mode(&self) -> AtaPassThruMode {
-        unsafe { (*self.0.mode).clone() }
+        let mut mode = unsafe { (*self.0.mode).clone() };
+        mode.io_align = mode.io_align.max(1); // 0 and 1 is the same, says UEFI spec
+        mode
     }
 
     /// Retrieves the I/O buffer alignment required by this SCSI channel.

--- a/uefi/src/proto/nvme/pass_thru.rs
+++ b/uefi/src/proto/nvme/pass_thru.rs
@@ -49,7 +49,9 @@ impl NvmePassThru {
     /// An instance of [`NvmePassThruMode`] describing the NVMe controller's capabilities.
     #[must_use]
     pub fn mode(&self) -> NvmePassThruMode {
-        unsafe { (*self.0.mode).clone() }
+        let mut mode = unsafe { (*self.0.mode).clone() };
+        mode.io_align = mode.io_align.max(1); // 0 and 1 is the same, says UEFI spec
+        mode
     }
 
     /// Retrieves the alignment requirements for I/O buffers.


### PR DESCRIPTION
Accidentally implemented it only for scsi.
And of course ... there are mainboards out there that hit this... and for some reason, they turned out to be in my vicinity (╯°□°）╯ ┻━┻

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
