### PR TITLE
uefi-raw: improve convenience of net types

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -16,6 +16,8 @@
   - `[u8; 32]` --> `MacAddress`
   - `[u8; 4]`  --> `Ipv4Address`, `IpAddress`
   - `[u8; 16]` --> `Ipv6Address`, `IpAddress`
+- Added `::into_core_ip_addr()` for `IpAddress`
+- Added `::try_into_ethernet_mac_addr()` for `MacAddress`
 
 ## Changed
 - **Breaking:** The MSRV is now 1.85.1 and the crate uses the Rust 2024 edition.

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `HiiConfigAccessProtocol`.
 - Added `::octets()` for `Ipv4Address`, `Ipv6Address`, and
   `MacAddress` to streamline the API with `core::net`.
+- Added `::ZERO` constant for `IpAddress`
 
 ## Changed
 - **Breaking:** The MSRV is now 1.85.1 and the crate uses the Rust 2024 edition.

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -8,6 +8,14 @@
 - Added `::octets()` for `Ipv4Address`, `Ipv6Address`, and
   `MacAddress` to streamline the API with `core::net`.
 - Added `::ZERO` constant for `IpAddress`
+- Added comprehensive integration with `core::net::{IpAddr, Ipv4Addr, Ipv6Addr}`
+  via `From` impls to better integrate uefi-raw types `IpAddress`,
+  `Ipv4Address`, and `Ipv6Address` with the Rust ecosystem.
+- Added convenient `From` impls:
+  - `[u8; 6]`  --> `MacAddress`
+  - `[u8; 32]` --> `MacAddress`
+  - `[u8; 4]`  --> `Ipv4Address`, `IpAddress`
+  - `[u8; 16]` --> `Ipv6Address`, `IpAddress`
 
 ## Changed
 - **Breaking:** The MSRV is now 1.85.1 and the crate uses the Rust 2024 edition.

--- a/uefi-raw/src/net.rs
+++ b/uefi-raw/src/net.rs
@@ -388,4 +388,46 @@ mod tests {
             assert_eq!(uefi_mac_addr.octets(), octets);
         }
     }
+
+    /// Tests the expected flow of types in a higher-level UEFI API.
+    #[test]
+    fn test_uefi_flow() {
+        fn efi_retrieve_efi_ip_addr(addr: *mut IpAddress, is_ipv6: bool) {
+            let addr = unsafe { addr.as_mut().unwrap() };
+            // SAFETY: Alignment is guaranteed and memory is initialized.
+            unsafe {
+                addr.v4.0[0] = 42;
+                addr.v4.0[1] = 42;
+                addr.v4.0[2] = 42;
+                addr.v4.0[3] = 42;
+            }
+            if is_ipv6 {
+                unsafe {
+                    addr.v6.0[14] = 42;
+                    addr.v6.0[15] = 42;
+                }
+            }
+        }
+
+        fn high_level_retrieve_ip(is_ipv6: bool) -> core::net::IpAddr {
+            let mut efi_ip_addr = IpAddress::ZERO;
+            efi_retrieve_efi_ip_addr(&mut efi_ip_addr, is_ipv6);
+            unsafe { efi_ip_addr.into_core_ip_addr(is_ipv6) }
+        }
+
+        let ipv4_addr = high_level_retrieve_ip(false);
+        let ipv4_addr: core::net::Ipv4Addr = match ipv4_addr {
+            core::net::IpAddr::V4(ipv4_addr) => ipv4_addr,
+            core::net::IpAddr::V6(_) => panic!("should not happen"),
+        };
+        assert_eq!(ipv4_addr.octets(), [42, 42, 42, 42]);
+
+        let ipv6_addr = high_level_retrieve_ip(true);
+        let ipv6_addr: core::net::Ipv6Addr = match ipv6_addr {
+            core::net::IpAddr::V6(ipv6_addr) => ipv6_addr,
+            core::net::IpAddr::V4(_) => panic!("should not happen"),
+        };
+        let expected = [42, 42, 42, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 42];
+        assert_eq!(ipv6_addr.octets(), expected);
+    }
 }

--- a/uefi-raw/src/net.rs
+++ b/uefi-raw/src/net.rs
@@ -8,7 +8,7 @@
 //! - [`Ipv4Address`]
 //! - [`Ipv6Address`]
 
-use core::fmt::{self, Debug, Formatter};
+use core::fmt::{self, Debug, Display, Formatter};
 
 /// An IPv4 internet protocol address.
 ///
@@ -48,6 +48,13 @@ impl From<[u8; 4]> for Ipv4Address {
     }
 }
 
+impl Display for Ipv4Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let ip = core::net::Ipv4Addr::from(*self);
+        write!(f, "{}", ip)
+    }
+}
+
 /// An IPv6 internet protocol address.
 ///
 /// # Conversions and Relation to [`core::net`]
@@ -83,6 +90,13 @@ impl From<Ipv6Address> for core::net::Ipv6Addr {
 impl From<[u8; 16]> for Ipv6Address {
     fn from(octets: [u8; 16]) -> Self {
         Self(octets)
+    }
+}
+
+impl Display for Ipv6Address {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let ip = core::net::Ipv6Addr::from(*self);
+        write!(f, "{}", ip)
     }
 }
 

--- a/uefi-raw/src/net.rs
+++ b/uefi-raw/src/net.rs
@@ -8,8 +8,7 @@
 //! - [`Ipv4Address`]
 //! - [`Ipv6Address`]
 
-use core::fmt;
-use core::fmt::{Debug, Formatter};
+use core::fmt::{self, Debug, Formatter};
 
 /// An IPv4 internet protocol address.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -83,19 +82,31 @@ pub union IpAddress {
 }
 
 impl IpAddress {
+    /// Zeroed variant where all bytes are guaranteed to be initialized to zero.
+    pub const ZERO: Self = Self { addr: [0; 4] };
+
     /// Construct a new IPv4 address.
+    ///
+    /// The type won't know that it is an IPv6 address and additional context
+    /// is needed.
+    ///
+    /// # Safety
+    /// The constructor only initializes the bytes needed for IPv4 addresses.
     #[must_use]
-    pub const fn new_v4(ip_addr: [u8; 4]) -> Self {
+    pub const fn new_v4(octets: [u8; 4]) -> Self {
         Self {
-            v4: Ipv4Address(ip_addr),
+            v4: Ipv4Address(octets),
         }
     }
 
     /// Construct a new IPv6 address.
+    ///
+    /// The type won't know that it is an IPv6 address and additional context
+    /// is needed.
     #[must_use]
-    pub const fn new_v6(ip_addr: [u8; 16]) -> Self {
+    pub const fn new_v6(octets: [u8; 16]) -> Self {
         Self {
-            v6: Ipv6Address(ip_addr),
+            v6: Ipv6Address(octets),
         }
     }
 }
@@ -111,19 +122,15 @@ impl Debug for IpAddress {
 
 impl Default for IpAddress {
     fn default() -> Self {
-        Self { addr: [0u32; 4] }
+        Self::ZERO
     }
 }
 
 impl From<core::net::IpAddr> for IpAddress {
     fn from(t: core::net::IpAddr) -> Self {
         match t {
-            core::net::IpAddr::V4(ip) => Self {
-                v4: Ipv4Address::from(ip),
-            },
-            core::net::IpAddr::V6(ip) => Self {
-                v6: Ipv6Address::from(ip),
-            },
+            core::net::IpAddr::V4(ip) => Self::new_v4(ip.octets()),
+            core::net::IpAddr::V6(ip) => Self::new_v6(ip.octets()),
         }
     }
 }


### PR DESCRIPTION
This prepares my vision for #1575, a split-out from #1645.

This adds much more convenience to the network types in `uefi-raw`, better integrating them with `core::net` types but also "typical" workflows. This "higher-level" logic is still low-level enough that I think it is perfectly fine to keep it. It will also not hinder Rust-based UEFI implementations.

## Steps to Undraft
- [x] merge and rebase onto #1747
- [x] merge and rebase onto #1748

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
