### PR TITLE
uefi/test-runner: Remove `crate::` and `uefi::` prefix from Status

### DIFF
--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -316,7 +316,7 @@ fn test_raw_disk_io2(handle: Handle) {
             let mut task = DiskIoTask {
                 token: DiskIo2Token {
                     event: Some(event.unsafe_clone()),
-                    transaction_status: uefi::Status::NOT_READY,
+                    transaction_status: Status::NOT_READY,
                 },
                 buffer: [0; 512],
             };
@@ -337,7 +337,7 @@ fn test_raw_disk_io2(handle: Handle) {
                 .expect("Failed to wait on completion event");
 
             // Verify that the disk's MBR signature is correct
-            assert_eq!(task.token.transaction_status, uefi::Status::SUCCESS);
+            assert_eq!(task.token.transaction_status, Status::SUCCESS);
             assert_eq!(task.buffer[510], 0x55);
             assert_eq!(task.buffer[511], 0xaa);
 

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -29,7 +29,7 @@ impl BlockIO {
     ///   exhaustive verification operation of the device during reset.
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`  The block device is not functioning
+    /// * `Status::DEVICE_ERROR`  The block device is not functioning
     ///   correctly and could not be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
@@ -43,13 +43,13 @@ impl BlockIO {
     /// * `buffer` - The target buffer of the read operation
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`       The device reported an error while attempting to perform the read
+    /// * `Status::DEVICE_ERROR`       The device reported an error while attempting to perform the read
     ///   operation.
-    /// * `uefi::Status::NO_MEDIA`           There is no media in the device.
-    /// * `uefi::Status::MEDIA_CHANGED`      The `media_id` is not for the current media.
-    /// * `uefi::Status::BAD_BUFFER_SIZE`    The buffer size parameter is not a multiple of the intrinsic block size of
+    /// * `Status::NO_MEDIA`           There is no media in the device.
+    /// * `Status::MEDIA_CHANGED`      The `media_id` is not for the current media.
+    /// * `Status::BAD_BUFFER_SIZE`    The buffer size parameter is not a multiple of the intrinsic block size of
     ///   the device.
-    /// * `uefi::Status::INVALID_PARAMETER`  The read request contains LBAs that are not valid, or the buffer is not on
+    /// * `Status::INVALID_PARAMETER`  The read request contains LBAs that are not valid, or the buffer is not on
     ///   proper alignment.
     pub fn read_blocks(&self, media_id: u32, lba: Lba, buffer: &mut [u8]) -> Result {
         let buffer_size = buffer.len();
@@ -73,14 +73,14 @@ impl BlockIO {
     /// * `buffer`      Buffer to be written
     ///
     /// # Errors
-    /// * `uefi::Status::WRITE_PROTECTED`       The device cannot be written to.
-    /// * `uefi::Status::NO_MEDIA`              There is no media in the device.
-    /// * `uefi::Status::MEDIA_CHANGED`         The `media_id` is not for the current media.
-    /// * `uefi::Status::DEVICE_ERROR`          The device reported an error while attempting to perform the write
+    /// * `Status::WRITE_PROTECTED`       The device cannot be written to.
+    /// * `Status::NO_MEDIA`              There is no media in the device.
+    /// * `Status::MEDIA_CHANGED`         The `media_id` is not for the current media.
+    /// * `Status::DEVICE_ERROR`          The device reported an error while attempting to perform the write
     ///   operation.
-    /// * `uefi::Status::BAD_BUFFER_SIZE`       The buffer size parameter is not a multiple of the intrinsic block size
+    /// * `Status::BAD_BUFFER_SIZE`       The buffer size parameter is not a multiple of the intrinsic block size
     ///   of the device.
-    /// * `uefi::Status::INVALID_PARAMETER`     The write request contains LBAs that are not valid, or the buffer is not
+    /// * `Status::INVALID_PARAMETER`     The write request contains LBAs that are not valid, or the buffer is not
     ///   on proper alignment.
     pub fn write_blocks(&mut self, media_id: u32, lba: Lba, buffer: &[u8]) -> Result {
         let buffer_size = buffer.len();
@@ -99,8 +99,8 @@ impl BlockIO {
     /// Flushes all modified data to a physical block device.
     ///
     /// # Errors
-    /// * `uefi::Status::DEVICE_ERROR`          The device reported an error while attempting to write data.
-    /// * `uefi::Status::NO_MEDIA`              There is no media in the device.
+    /// * `Status::DEVICE_ERROR`          The device reported an error while attempting to write data.
+    /// * `Status::NO_MEDIA`              There is no media in the device.
     pub fn flush_blocks(&mut self) -> Result {
         unsafe { (self.0.flush_blocks)(&mut self.0) }.to_result()
     }

--- a/uefi/src/proto/media/disk_info.rs
+++ b/uefi/src/proto/media/disk_info.rs
@@ -6,6 +6,9 @@ use crate::StatusExt;
 use uefi_macros::unsafe_protocol;
 use uefi_raw::protocol::disk::DiskInfoProtocol;
 
+#[cfg(doc)]
+use crate::Status;
+
 /// Enum representing the interface type of the disk.
 ///
 /// This protocol abstracts various disk interfaces, including IDE, USB, AHCI, NVME, and more.
@@ -60,7 +63,7 @@ pub struct DeviceLocationInfo {
 ///
 /// Not all operations are supported by all interface types!
 /// Either use [`DiskInfo::interface`] to determine what should be possible, or simply
-/// try and handle the [`crate::Status::UNSUPPORTED`] error return value.
+/// try and handle the [`Status::UNSUPPORTED`] error return value.
 ///
 /// # UEFI Spec Description
 /// Provides the basic interfaces to abstract platform information regarding an IDE controller.
@@ -99,10 +102,10 @@ impl DiskInfo {
     /// Length of the response (amount of bytes that were written to the given buffer).
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the InquiryData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided InquiryDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] The command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] The device does not support this data class.
+    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the InquiryData from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] The provided InquiryDataSize buffer is not large enough to store the required data.
     pub fn inquiry(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         unsafe {
@@ -120,10 +123,10 @@ impl DiskInfo {
     /// Length of the response (amount of bytes that were written to the given buffer).
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the IdentifyData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided IdentifyDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] The command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] The device does not support this data class.
+    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the IdentifyData from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] The provided IdentifyDataSize buffer is not large enough to store the required data.
     pub fn identify(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         unsafe {
@@ -141,10 +144,10 @@ impl DiskInfo {
     /// [`SenseDataInfo`] struct containing the number of bytes of sense data and the number of sense data structures.
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`crate::Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`crate::Status::DEVICE_ERROR`] An error occurred while reading the SenseData from the device.
-    /// - [`crate::Status::BUFFER_TOO_SMALL`] The provided SenseDataSize buffer is not large enough to store the required data.
+    /// - [`Status::SUCCESS`] The command was accepted without any errors.
+    /// - [`Status::NOT_FOUND`] The device does not support this data class.
+    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the SenseData from the device.
+    /// - [`Status::BUFFER_TOO_SMALL`] The provided SenseDataSize buffer is not large enough to store the required data.
     pub fn sense_data(&self, bfr: &mut [u8]) -> crate::Result<SenseDataInfo> {
         let mut len: u32 = bfr.len() as u32;
         let mut number: u8 = 0;
@@ -166,8 +169,8 @@ impl DiskInfo {
     /// [`DeviceLocationInfo`] struct containing the channel and device numbers.
     ///
     /// # Errors
-    /// - [`crate::Status::SUCCESS`] The `IdeChannel` and `IdeDevice` values are valid.
-    /// - [`crate::Status::UNSUPPORTED`] Not supported by this disk's interface type.
+    /// - [`Status::SUCCESS`] The `IdeChannel` and `IdeDevice` values are valid.
+    /// - [`Status::UNSUPPORTED`] Not supported by this disk's interface type.
     pub fn bus_location(&self) -> crate::Result<DeviceLocationInfo> {
         let mut ide_channel: u32 = 0; // called ide, but also useful for other interfaces
         let mut ide_device: u32 = 0;

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -55,18 +55,18 @@ pub trait File: Sized {
     /// errors returned by this function, but some implementations (such as EDK2) perform
     /// additional validation and may return that status for invalid inputs.
     ///
-    /// [`INVALID_PARAMETER`]: uefi::Status::INVALID_PARAMETER
+    /// [`INVALID_PARAMETER`]: Status::INVALID_PARAMETER
     ///
-    /// * [`uefi::Status::INVALID_PARAMETER`]
-    /// * [`uefi::Status::NOT_FOUND`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::MEDIA_CHANGED`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::OUT_OF_RESOURCES`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::INVALID_PARAMETER`]
+    /// * [`Status::NOT_FOUND`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::MEDIA_CHANGED`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::OUT_OF_RESOURCES`]
+    /// * [`Status::VOLUME_FULL`]
     fn open(
         &mut self,
         filename: &CStr16,
@@ -96,7 +96,7 @@ pub trait File: Sized {
     ///
     /// See section `EFI_FILE_PROTOCOL.Delete()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::WARN_DELETE_FAILURE`]
+    /// * [`Status::WARN_DELETE_FAILURE`]
     fn delete(mut self) -> Result {
         let result = unsafe { (self.imp().delete)(self.imp()) }.to_result();
         mem::forget(self);
@@ -117,11 +117,11 @@ pub trait File: Sized {
     ///
     /// See section `EFI_FILE_PROTOCOL.GetInfo()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::BUFFER_TOO_SMALL`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::BUFFER_TOO_SMALL`]
     fn get_info<'buf, Info: FileProtocolInfo + ?Sized>(
         &mut self,
         buffer: &'buf mut [u8],
@@ -162,14 +162,14 @@ pub trait File: Sized {
     ///
     /// See section `EFI_FILE_PROTOCOL.SetInfo()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
-    /// * [`uefi::Status::BAD_BUFFER_SIZE`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
+    /// * [`Status::BAD_BUFFER_SIZE`]
     fn set_info<Info: FileProtocolInfo + ?Sized>(&mut self, info: &Info) -> Result {
         let info_ptr = ptr::from_ref(info).cast::<c_void>();
         let info_size = size_of_val(info);
@@ -182,12 +182,12 @@ pub trait File: Sized {
     ///
     /// See section `EFI_FILE_PROTOCOL.Flush()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
     fn flush(&mut self) -> Result {
         unsafe { (self.imp().flush)(self.imp()) }.to_result()
     }

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -37,9 +37,9 @@ impl RegularFile {
     ///
     /// See section `EFI_FILE_PROTOCOL.Read()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
     ///
     /// # Quirks
     ///
@@ -91,12 +91,12 @@ impl RegularFile {
     ///
     /// See section `EFI_FILE_PROTOCOL.Write()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::WRITE_PROTECTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::VOLUME_FULL`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::WRITE_PROTECTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::VOLUME_FULL`]
     pub fn write(&mut self, buffer: &[u8]) -> Result<(), usize> {
         let mut buffer_size = buffer.len();
         unsafe { (self.imp().write)(self.imp(), &mut buffer_size, buffer.as_ptr().cast()) }
@@ -109,7 +109,7 @@ impl RegularFile {
     ///
     /// See section `EFI_FILE_PROTOCOL.GetPosition()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::DEVICE_ERROR`]
+    /// * [`Status::DEVICE_ERROR`]
     pub fn get_position(&mut self) -> Result<u64> {
         let mut pos = 0u64;
         unsafe { (self.imp().get_position)(self.imp(), &mut pos) }.to_result_with_val(|| pos)
@@ -129,7 +129,7 @@ impl RegularFile {
     ///
     /// See section `EFI_FILE_PROTOCOL.SetPosition()` in the UEFI Specification for more details.
     ///
-    /// * [`uefi::Status::DEVICE_ERROR`]
+    /// * [`Status::DEVICE_ERROR`]
     pub fn set_position(&mut self, position: u64) -> Result {
         unsafe { (self.imp().set_position)(self.imp(), position) }.to_result()
     }

--- a/uefi/src/proto/media/fs.rs
+++ b/uefi/src/proto/media/fs.rs
@@ -8,6 +8,9 @@ use crate::{Result, StatusExt};
 use core::ptr;
 use uefi_raw::protocol::file_system::SimpleFileSystemProtocol;
 
+#[cfg(doc)]
+use crate::Status;
+
 /// Simple File System [`Protocol`]. Allows access to a FAT-12/16/32 file
 /// system.
 ///
@@ -41,13 +44,13 @@ impl SimpleFileSystem {
     /// `EFI_SIMPLE_FILE SYSTEM_PROTOCOL.OpenVolume()` (this has a space in between FILE and
     /// SYSTEM; it could be a typo in the UEFI spec).
     ///
-    /// * [`uefi::Status::UNSUPPORTED`]
-    /// * [`uefi::Status::NO_MEDIA`]
-    /// * [`uefi::Status::DEVICE_ERROR`]
-    /// * [`uefi::Status::VOLUME_CORRUPTED`]
-    /// * [`uefi::Status::ACCESS_DENIED`]
-    /// * [`uefi::Status::OUT_OF_RESOURCES`]
-    /// * [`uefi::Status::MEDIA_CHANGED`]
+    /// * [`Status::UNSUPPORTED`]
+    /// * [`Status::NO_MEDIA`]
+    /// * [`Status::DEVICE_ERROR`]
+    /// * [`Status::VOLUME_CORRUPTED`]
+    /// * [`Status::ACCESS_DENIED`]
+    /// * [`Status::OUT_OF_RESOURCES`]
+    /// * [`Status::MEDIA_CHANGED`]
     pub fn open_volume(&mut self) -> Result<Directory> {
         let mut ptr = ptr::null_mut();
         unsafe { (self.0.open_volume)(&mut self.0, &mut ptr) }

--- a/uefi/src/proto/pci/root_bridge.rs
+++ b/uefi/src/proto/pci/root_bridge.rs
@@ -9,6 +9,9 @@ use crate::StatusExt;
 use uefi_macros::unsafe_protocol;
 use uefi_raw::protocol::pci::root_bridge::{PciRootBridgeIoAccess, PciRootBridgeIoProtocol};
 
+#[cfg(doc)]
+use crate::Status;
+
 /// Protocol that provides access to the PCI Root Bridge I/O protocol.
 ///
 /// # UEFI Spec Description
@@ -37,7 +40,7 @@ impl PciRootBridgeIo {
     /// Flush all PCI posted write transactions from a PCI host bridge to system memory.
     ///
     /// # Errors
-    /// - [`crate::Status::DEVICE_ERROR`] The PCI posted write transactions were not flushed from the PCI host bridge
+    /// - [`Status::DEVICE_ERROR`] The PCI posted write transactions were not flushed from the PCI host bridge
     ///   due to a hardware error.
     pub fn flush(&mut self) -> crate::Result<()> {
         unsafe { (self.0.flush)(&mut self.0).to_result() }
@@ -69,8 +72,8 @@ impl PciIoAccessPci<'_> {
     /// - The read value of type `U`.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The read request could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The read request could not be completed due to a lack of resources.
     pub fn read_one<U: PciIoUnit>(&self, addr: PciIoAddress) -> crate::Result<U> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         let mut result = U::default();
@@ -93,8 +96,8 @@ impl PciIoAccessPci<'_> {
     /// - `data` - The value to write.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The write request could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The write request could not be completed due to a lack of resources.
     pub fn write_one<U: PciIoUnit>(&self, addr: PciIoAddress, data: U) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         unsafe {
@@ -116,8 +119,8 @@ impl PciIoAccessPci<'_> {
     /// - `data` - A mutable slice to store the read values.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
     pub fn read<U: PciIoUnit>(&self, addr: PciIoAddress, data: &mut [U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         unsafe {
@@ -139,8 +142,8 @@ impl PciIoAccessPci<'_> {
     /// - `data` - A slice containing the values to write.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
     pub fn write<U: PciIoUnit>(&self, addr: PciIoAddress, data: &[U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         unsafe {
@@ -163,8 +166,8 @@ impl PciIoAccessPci<'_> {
     /// - `data` - The value to fill the address range with.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The operation could not be completed due to a lack of resources.
     pub fn fill_write<U: PciIoUnit>(
         &self,
         addr: PciIoAddress,
@@ -195,8 +198,8 @@ impl PciIoAccessPci<'_> {
     /// The resulting `data` buffer will contain the elements returned by reading the same address multiple times sequentially.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
     pub fn fifo_read<U: PciIoUnit>(&self, addr: PciIoAddress, data: &mut [U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Fifo);
         unsafe {
@@ -222,8 +225,8 @@ impl PciIoAccessPci<'_> {
     /// (starting at `addr` and ending at `addr + size_of::<U>()`) sequentially.
     ///
     /// # Errors
-    /// - [`crate::Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`crate::Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
+    /// - [`Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
     pub fn fifo_write<U: PciIoUnit>(&self, addr: PciIoAddress, data: &[U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Fifo);
         unsafe {

--- a/uefi/src/proto/scsi/mod.rs
+++ b/uefi/src/proto/scsi/mod.rs
@@ -11,6 +11,9 @@ use uefi_raw::protocol::scsi::{
     ScsiIoDataDirection, ScsiIoHostAdapterStatus, ScsiIoScsiRequestPacket, ScsiIoTargetStatus,
 };
 
+#[cfg(doc)]
+use crate::Status;
+
 pub mod pass_thru;
 
 /// Represents the data direction for a SCSI request.
@@ -124,7 +127,7 @@ impl<'a> ScsiRequestBuilder<'a> {
     /// # Description
     /// By default (without calling this method, or by calling with [`Duration::ZERO`]),
     /// SCSI requests have no timeout.
-    /// Setting a timeout here will cause SCSI commands to potentially fail with [`crate::Status::TIMEOUT`].
+    /// Setting a timeout here will cause SCSI commands to potentially fail with [`Status::TIMEOUT`].
     #[must_use]
     pub const fn with_timeout(mut self, timeout: Duration) -> Self {
         self.req.packet.timeout = (timeout.as_nanos() / 100) as u64;

--- a/uefi/src/proto/security/memory_protection.rs
+++ b/uefi/src/proto/security/memory_protection.rs
@@ -7,6 +7,9 @@ use crate::{Result, StatusExt};
 use core::ops::Range;
 use uefi_raw::protocol::memory_protection::MemoryAttributeProtocol;
 
+#[cfg(doc)]
+use crate::Status;
+
 /// Memory Attribute [`Protocol`] for Memory Protection.
 ///
 /// Protocol for getting and setting memory protection attributes.
@@ -34,7 +37,6 @@ impl MemoryProtection {
     /// [`READ_PROTECT`]: MemoryAttribute::READ_PROTECT
     /// [`EXECUTE_PROTECT`]: MemoryAttribute::EXECUTE_PROTECT
     /// [`READ_ONLY`]: MemoryAttribute::READ_ONLY
-    /// [`Status::NO_MAPPING`]: crate::Status::NO_MAPPING
     /// [UEFI page size]: uefi::boot::PAGE_SIZE
     pub fn get_memory_attributes(
         &self,


### PR DESCRIPTION
In many places, especially doc comments, `Status` was referred to as `uefi::Status` or `crate::Status`. Consistently use `Status` instead, adding imports as needed. Note that in cases where `Status` is only used in docstrings, the `use` is gated by `#[cfg(doc)]`. (This avoids needing a bunch of manual `Status::*` links in docstrings.)

This is mostly a mechanical find-replace change, except for adding imports where needed.

Parts of this change are also present in https://github.com/rust-osdev/uefi-rs/pull/1603 and https://github.com/rust-osdev/uefi-rs/pull/1705.

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
