### PR TITLE
doc: fix broken links

### DIFF
--- a/uefi-raw/src/protocol/tcg/v2.rs
+++ b/uefi-raw/src/protocol/tcg/v2.rs
@@ -111,7 +111,7 @@ pub struct Tcg2BootServiceCapability {
 }
 
 bitflags! {
-    /// Flags for the [`Tcg::hash_log_extend_event`] function.
+    /// Flags for the [`Tcg2Protocol::hash_log_extend_event`] function.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(transparent)]
     pub struct Tcg2HashLogExtendEventFlags: u64 {

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -216,11 +216,11 @@
 //! [Zulip]: https://rust-osdev.zulipchat.com
 //! [`GlobalAlloc`]: alloc::alloc::GlobalAlloc
 //! [`cstr16!`]: crate::cstr16
-//! [`entry-macro`]: uefi_macros::entry
 //! [`r-efi`]: https://crates.io/crates/r-efi
 //! [`unsafe_protocol`]: proto::unsafe_protocol
 //! [apache]: https://github.com/rust-osdev/uefi-rs/blob/main/uefi/LICENSE-APACHE
 //! [contributing]: https://github.com/rust-osdev/uefi-rs/blob/main/CONTRIBUTING.md
+//! [entry-macro]: uefi_macros::entry
 //! [issue tracker]: https://github.com/rust-osdev/uefi-rs/issues
 //! [mit]: https://github.com/rust-osdev/uefi-rs/blob/main/uefi/LICENSE-MIT
 //! [rustc-uefi-std]: https://doc.rust-lang.org/nightly/rustc/platform-support/unknown-uefi.html

--- a/uefi/src/proto/scsi/pass_thru.rs
+++ b/uefi/src/proto/scsi/pass_thru.rs
@@ -106,7 +106,7 @@ impl ExtScsiPassThru {
     /// This operation resets all the SCSI devices connected to the SCSI channel.
     ///
     /// # Returns
-    /// [`Result<()>`] indicating the success or failure of the operation.
+    /// [`Result`] indicating the success or failure of the operation.
     ///
     /// # Errors
     /// - [`Status::UNSUPPORTED`] The SCSI channel does not support a channel reset operation.
@@ -174,7 +174,7 @@ impl ScsiDevice<'_> {
     /// to perform target resets.
     ///
     /// # Returns
-    /// [`Result<()>`] indicating the success or failure of the operation.
+    /// [`Result`] indicating the success or failure of the operation.
     ///
     /// # Errors
     /// - [`Status::UNSUPPORTED`] The SCSI channel does not support a target reset operation.

--- a/uefi/src/proto/string/unicode_collation.rs
+++ b/uefi/src/proto/string/unicode_collation.rs
@@ -39,13 +39,13 @@ impl UnicodeCollation {
     ///
     /// The following syntax can be used to build the string `pattern`:
     ///
-    /// |Pattern Character            |Meaning                                           |
-    /// |-----------------------------|--------------------------------------------------|
-    /// |*                            | Match 0 or more characters                       |
-    /// |?                            | Match any one character                          |
-    /// |[`char1` `char2`...`charN`]| Match any character in the set                   |
-    /// |[`char1`-`char2`]          | Match any character between `char1` and `char2`|
-    /// |`char`                      | Match the character `char`                      |
+    /// |Pattern Character              |Meaning                                           |
+    /// |-------------------------------|--------------------------------------------------|
+    /// |*                              | Match 0 or more characters                       |
+    /// |?                              | Match any one character                          |
+    /// |``[`char1` `char2`...`charN`]``| Match any character in the set                   |
+    /// |``[`char1`-`char2`]``          | Match any character between `char1` and `char2`|
+    /// |`char`                         | Match the character `char`                      |
     ///
     /// For example, the pattern "*.Fw" will match all strings that end
     /// in ".FW", ".fw", ".Fw" or ".fW". The pattern "[a-z]" will match any


### PR DESCRIPTION
Some of those were found using:

cargo deadlinks --check-intra-doc-links -- --features alloc

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
