### PR TITLE
Use size_of/align_of from prelude

### DIFF
--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -304,13 +304,12 @@ impl DevicePathUtilitiesProtocol {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::mem;
 
     /// Test that ensures the struct is packed. Thus, we don't need to
     /// explicitly specify `packed`.
     #[test]
     fn abi() {
-        assert_eq!(mem::size_of::<DevicePathProtocol>(), 4);
-        assert_eq!(mem::align_of::<DevicePathProtocol>(), 1);
+        assert_eq!(size_of::<DevicePathProtocol>(), 4);
+        assert_eq!(align_of::<DevicePathProtocol>(), 1);
     }
 }

--- a/uefi-raw/src/table/system.rs
+++ b/uefi-raw/src/table/system.rs
@@ -6,7 +6,6 @@ use crate::table::boot::BootServices;
 use crate::table::configuration::ConfigurationTable;
 use crate::table::runtime::RuntimeServices;
 use crate::{Char16, Handle};
-use core::mem::size_of;
 use core::ptr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/uefi-test-runner/src/proto/pci/root_bridge.rs
+++ b/uefi-test-runner/src/proto/pci/root_bridge.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::mem;
 use uefi::Handle;
 use uefi::boot::{OpenProtocolAttributes, OpenProtocolParams, ScopedProtocol, image_handle};
 use uefi::proto::ProtocolPointer;
@@ -11,7 +10,7 @@ const RED_HAT_PCI_VENDOR_ID: u16 = 0x1AF4;
 const MASS_STORAGE_CTRL_CLASS_CODE: u8 = 0x1;
 const SATA_CTRL_SUBCLASS_CODE: u8 = 0x6;
 
-const REG_SIZE: u8 = mem::size_of::<u32>() as u8;
+const REG_SIZE: u8 = size_of::<u32>() as u8;
 
 pub fn test() {
     let pci_handles = uefi::boot::find_handles::<PciRootBridgeIo>().unwrap();

--- a/uefi-test-runner/src/proto/usb/io.rs
+++ b/uefi-test-runner/src/proto/usb/io.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::mem;
 use uefi::proto::usb::DeviceDescriptor;
 use uefi::proto::usb::io::{ControlTransfer, UsbIo};
 use uefi::{Status, boot};
@@ -61,14 +60,14 @@ pub fn test() {
             result.expect("failed to acquire string descriptor");
         }
 
-        let mut buffer = [0u8; mem::size_of::<DeviceDescriptor>()];
+        let mut buffer = [0u8; size_of::<DeviceDescriptor>()];
 
         io.control_transfer(
             DEVICE_TO_HOST | STANDARD_REQUEST | DEVICE_RECIPIENT,
             GET_DESCRIPTOR_REQUEST,
             u16::from(DEVICE_DESCRIPTOR) << 8,
             0,
-            ControlTransfer::DataIn(&mut buffer[..mem::size_of::<DeviceDescriptor>()]),
+            ControlTransfer::DataIn(&mut buffer[..size_of::<DeviceDescriptor>()]),
             0,
         )
         .expect("failed control transfer");

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -467,7 +467,7 @@ mod tests {
 
     fn mmap_raw<'a>(memory: &mut [MemoryDescriptor]) -> (&'a mut [u8], MemoryMapMeta) {
         let desc_size = size_of::<MemoryDescriptor>();
-        let len = core::mem::size_of_val(memory);
+        let len = size_of_val(memory);
         let ptr = memory.as_mut_ptr().cast::<u8>();
         let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
         let meta = MemoryMapMeta {

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -105,7 +105,6 @@ impl MemoryMapMeta {
 #[cfg(test)]
 mod tests_mmap_artificial {
     use super::*;
-    use core::mem::{size_of, size_of_val};
 
     fn buffer_to_map(buffer: &mut [MemoryDescriptor]) -> MemoryMapRefMut<'_> {
         let mmap_len = size_of_val(buffer);

--- a/uefi/src/mem/util.rs
+++ b/uefi/src/mem/util.rs
@@ -120,7 +120,6 @@ mod tests {
     use crate::{ResultExt, StatusExt};
     #[cfg(feature = "unstable")]
     use alloc::alloc::Global;
-    use core::mem::{align_of, size_of};
 
     /// Some simple dummy type to test [`make_boxed`].
     #[derive(Debug)]

--- a/uefi/src/proto/device_path/device_path_gen.rs
+++ b/uefi/src/proto/device_path/device_path_gen.rs
@@ -17,7 +17,6 @@ use crate::proto::device_path::{
 use crate::proto::network::IpAddress;
 use crate::{Guid, guid};
 use bitflags::bitflags;
-use core::mem::{size_of, size_of_val};
 use core::ptr::addr_of;
 use core::{fmt, slice};
 use ptr_meta::Pointee;
@@ -3650,7 +3649,7 @@ pub mod build {
     use crate::CStr16;
     use crate::proto::device_path::build::{BuildError, BuildNode};
     use crate::proto::device_path::{DeviceSubType, DeviceType};
-    use core::mem::{MaybeUninit, size_of_val};
+    use core::mem::MaybeUninit;
     /// Device path build nodes for [`DeviceType::END`].
     pub mod end {
         use super::*;

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -921,7 +921,6 @@ fn open_utility_protocol() -> Result<ScopedProtocol<DevicePathUtilities>, Device
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    use core::mem::{size_of, size_of_val};
 
     /// Create a node to `path` from raw data.
     fn add_node(path: &mut Vec<u8>, device_type: u8, sub_type: u8, node_data: &[u8]) {

--- a/uefi/src/proto/pci/mod.rs
+++ b/uefi/src/proto/pci/mod.rs
@@ -106,7 +106,7 @@ enum PciIoMode {
 }
 
 fn encode_io_mode_and_unit<U: PciIoUnit>(mode: PciIoMode) -> PciRootBridgeIoProtocolWidth {
-    match (mode, core::mem::size_of::<U>()) {
+    match (mode, size_of::<U>()) {
         (PciIoMode::Normal, 1) => PciRootBridgeIoProtocolWidth::UINT8,
         (PciIoMode::Normal, 2) => PciRootBridgeIoProtocolWidth::UINT16,
         (PciIoMode::Normal, 4) => PciRootBridgeIoProtocolWidth::UINT32,
@@ -129,11 +129,10 @@ fn encode_io_mode_and_unit<U: PciIoUnit>(mode: PciIoMode) -> PciRootBridgeIoProt
 #[cfg(test)]
 mod tests {
     use super::PciIoAddress;
-    use core::mem;
 
     #[test]
     fn test_pci_ioaddr_raw_conversion() {
-        assert_eq!(mem::size_of::<u64>(), mem::size_of::<PciIoAddress>());
+        assert_eq!(size_of::<u64>(), size_of::<PciIoAddress>());
         let srcaddr = PciIoAddress {
             reg: 0x11,
             fun: 0x33,

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -81,7 +81,6 @@ fn gen_uefi_code_as_string(groups: &[NodeGroup]) -> Result<String> {
         };
         use crate::proto::network::IpAddress;
         use crate::mem::memory_map::MemoryType;
-        use core::mem::{size_of, size_of_val};
         use core::ptr::addr_of;
         use core::{fmt, slice};
         use ptr_meta::Pointee;
@@ -94,7 +93,7 @@ fn gen_uefi_code_as_string(groups: &[NodeGroup]) -> Result<String> {
         pub mod build {
             use super::*;
 
-            use core::mem::{MaybeUninit, size_of_val};
+            use core::mem::MaybeUninit;
             use crate::CStr16;
             use crate::proto::device_path::build::{BuildError, BuildNode};
             use crate::proto::device_path::{DeviceSubType, DeviceType};


### PR DESCRIPTION
As of the 2024 edition, size_of/size_of_val/align_of/align_of_val are in the prelude, so no need to import or use a fully qualified path.
