### PR TITLE
cargo xtask improvements

### DIFF
--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -280,7 +280,12 @@ fn check_fields(fields: &Punctuated<Field, Comma>, src: &Path) -> Result<(), Err
 }
 
 /// List with allowed combinations of representations (see [`Repr`]).
-const ALLOWED_REPRS: &[&[Repr]] = &[&[Repr::C], &[Repr::C, Repr::Packed], &[Repr::Transparent]];
+const ALLOWED_REPRS: &[&[Repr]] = &[
+    &[Repr::C],
+    &[Repr::C, Repr::Packed],
+    &[Repr::Transparent],
+    &[Repr::Align(4), Repr::C],
+];
 
 fn check_type_attrs(attrs: &[Attribute], spanned: &dyn Spanned, src: &Path) -> Result<(), Error> {
     let attrs = parse_attrs(attrs, src)?;
@@ -482,7 +487,7 @@ mod tests {
                     }
                 }
             },
-            ErrorKind::ForbiddenRepr,
+            ErrorKind::ForbiddenRepr(vec![Repr::C]),
         );
     }
 
@@ -614,7 +619,7 @@ mod tests {
                     pub f: u32,
                 }
             },
-            ErrorKind::ForbiddenRepr,
+            ErrorKind::ForbiddenRepr(vec![Repr::Rust]),
         );
 
         // Forbidden attr.


### PR DESCRIPTION
Prerequisite for #1699 where I want to use

```rust
#[repr(C, align(4))]
pub struct IpAddress(pub [u8; 16]);
```

in uefi-raw.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
