### PR TITLE
uefi: memory safety fixes (UB!)

### DIFF
--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -161,6 +161,8 @@ pub struct GraphicsOutputProtocol {
     pub set_mode: unsafe extern "efiapi" fn(*mut Self, mode_number: u32) -> Status,
     pub blt: unsafe extern "efiapi" fn(
         *mut Self,
+        // Depending on `blt_operation`, this is an IN parameter (readable)
+        // or an OUT parameter (writeable).
         blt_buffer: *mut GraphicsOutputBltPixel,
         blt_operation: GraphicsOutputBltOperation,
         source_x: usize,

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -23,6 +23,8 @@
   image in QEMU or Cloud Hypervisor, when the debugcon/debug-console device is
   available.
 - The documentation for UEFI protocols has been streamlined and improved.
+- Fixed memory safety bug in `SimpleNetwork::read_nv_data`. The `buffer`
+  parameter is now mutable.
 
 # uefi - 0.35.0 (2025-05-04)
 

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -59,8 +59,8 @@ use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull};
 use uefi_raw::protocol::console::{
-    GraphicsOutputBltOperation, GraphicsOutputModeInformation, GraphicsOutputProtocol,
-    GraphicsOutputProtocolMode,
+    GraphicsOutputBltOperation, GraphicsOutputBltPixel, GraphicsOutputModeInformation,
+    GraphicsOutputProtocol, GraphicsOutputProtocolMode,
 };
 
 pub use uefi_raw::protocol::console::PixelBitmask;
@@ -201,7 +201,8 @@ impl GraphicsOutput {
                     match src_region {
                         BltRegion::Full => (self.0.blt)(
                             &mut self.0,
-                            buffer.as_ptr() as *mut _,
+                            // SAFETY: The buffer is only used for reading.
+                            buffer.as_ptr().cast::<GraphicsOutputBltPixel>().cast_mut(),
                             GraphicsOutputBltOperation::BLT_BUFFER_TO_VIDEO,
                             0,
                             0,
@@ -217,7 +218,8 @@ impl GraphicsOutput {
                             px_stride,
                         } => (self.0.blt)(
                             &mut self.0,
-                            buffer.as_ptr() as *mut _,
+                            // SAFETY: The buffer is only used for reading.
+                            buffer.as_ptr().cast::<GraphicsOutputBltPixel>().cast_mut(),
                             GraphicsOutputBltOperation::BLT_BUFFER_TO_VIDEO,
                             src_x,
                             src_y,

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -142,30 +142,32 @@ impl SimpleNetwork {
         status.to_result_with_val(|| mac_address)
     }
 
-    /// Perform read operations on the NVRAM device attached to
-    /// a network interface.
-    pub fn read_nv_data(&self, offset: usize, buffer: &[u8]) -> Result {
+    /// Reads data from the NVRAM device attached to the network interface into
+    /// the provided `dst_buffer`.
+    pub fn read_nv_data(&self, offset: usize, dst_buffer: &mut [u8]) -> Result {
         unsafe {
             (self.0.non_volatile_data)(
                 &self.0,
                 Boolean::from(true),
                 offset,
-                buffer.len(),
-                buffer.as_ptr() as *mut c_void,
+                dst_buffer.len(),
+                dst_buffer.as_mut_ptr().cast(),
             )
         }
         .to_result()
     }
 
-    /// Perform write operations on the NVRAM device attached to a network interface.
-    pub fn write_nv_data(&self, offset: usize, buffer: &mut [u8]) -> Result {
+    /// Writes data into the NVRAM device attached to the network interface from
+    /// the provided `src_buffer`.
+    pub fn write_nv_data(&self, offset: usize, src_buffer: &[u8]) -> Result {
         unsafe {
             (self.0.non_volatile_data)(
                 &self.0,
                 Boolean::from(false),
                 offset,
-                buffer.len(),
-                buffer.as_mut_ptr().cast(),
+                src_buffer.len(),
+                // SAFETY: The buffer is only used for reading.
+                src_buffer.as_ptr().cast::<c_void>().cast_mut(),
             )
         }
         .to_result()


### PR DESCRIPTION
Fix some memory safety issues.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
