### PR TITLE
ci: fix latest nightly issues

### DIFF
--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -22,7 +22,6 @@
     unused
 )]
 
-#[macro_use]
 mod enums;
 
 pub mod capsule;

--- a/uefi-raw/src/protocol/ata.rs
+++ b/uefi-raw/src/protocol/ata.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::device_path::DevicePathProtocol;
-use crate::{Event, Status};
+use crate::{Event, Status, newtype_enum};
 use core::ffi::c_void;
 use uguid::{Guid, guid};
 

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -2,7 +2,7 @@
 
 pub mod serial;
 
-use crate::{Boolean, Char16, Event, Guid, PhysicalAddress, Status, guid};
+use crate::{Boolean, Char16, Event, Guid, PhysicalAddress, Status, guid, newtype_enum};
 use bitflags::bitflags;
 use core::ptr;
 

--- a/uefi-raw/src/protocol/console/serial.rs
+++ b/uefi-raw/src/protocol/console/serial.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Guid, Status, guid};
+use crate::{Guid, Status, guid, newtype_enum};
 use bitflags::bitflags;
 
 bitflags! {

--- a/uefi-raw/src/protocol/device_path.rs
+++ b/uefi-raw/src/protocol/device_path.rs
@@ -42,7 +42,7 @@
 
 mod device_path_gen;
 
-use crate::{Boolean, Char16, Guid, guid};
+use crate::{Boolean, Char16, Guid, guid, newtype_enum};
 
 pub use device_path_gen::{acpi, bios_boot_spec, end, hardware, media, messaging};
 

--- a/uefi-raw/src/protocol/device_path/device_path_gen.rs
+++ b/uefi-raw/src/protocol/device_path/device_path_gen.rs
@@ -10,7 +10,7 @@
 #![allow(missing_debug_implementations)]
 use crate::protocol::device_path;
 use crate::table::boot::MemoryType;
-use crate::{Guid, IpAddress, guid};
+use crate::{Guid, IpAddress, guid, newtype_enum};
 use bitflags::bitflags;
 use device_path::DevicePathProtocol as DevicePathHeader;
 #[cfg(doc)]

--- a/uefi-raw/src/protocol/file_system.rs
+++ b/uefi-raw/src/protocol/file_system.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::time::Time;
-use crate::{Boolean, Char16, Event, Guid, Status, guid};
+use crate::{Boolean, Char16, Event, Guid, Status, guid, newtype_enum};
 use bitflags::bitflags;
 use core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/firmware_volume.rs
+++ b/uefi-raw/src/protocol/firmware_volume.rs
@@ -2,7 +2,7 @@
 
 use crate::firmware_storage::FirmwareVolumeAttributes;
 use crate::protocol::block::Lba;
-use crate::{Guid, Handle, PhysicalAddress, Status, guid};
+use crate::{Guid, Handle, PhysicalAddress, Status, guid, newtype_enum};
 use core::ffi::c_void;
 use core::ops::RangeInclusive;
 

--- a/uefi-raw/src/protocol/hii/config.rs
+++ b/uefi-raw/src/protocol/hii/config.rs
@@ -4,7 +4,7 @@
 
 use core::fmt::Debug;
 
-use crate::{Char16, Guid, Status, guid};
+use crate::{Char16, Guid, Status, guid, newtype_enum};
 
 /// EFI_CONFIG_KEYWORD_HANDLER_PROTOCOL
 #[derive(Debug)]

--- a/uefi-raw/src/protocol/hii/database.rs
+++ b/uefi-raw/src/protocol/hii/database.rs
@@ -3,7 +3,7 @@
 //! Bindings for HII Database Protocol
 
 use super::{HiiHandle, HiiPackageHeader, HiiPackageListHeader, KeyDescriptor};
-use crate::{Guid, Handle, Status, guid};
+use crate::{Guid, Handle, Status, guid, newtype_enum};
 
 /// EFI_HII_KEYBOARD_LAYOUT
 #[derive(Debug)]

--- a/uefi-raw/src/protocol/hii/mod.rs
+++ b/uefi-raw/src/protocol/hii/mod.rs
@@ -5,7 +5,7 @@
 pub mod config;
 pub mod database;
 
-use crate::{Char16, Guid};
+use crate::{Char16, Guid, newtype_enum};
 
 pub type HiiHandle = *mut core::ffi::c_void;
 

--- a/uefi-raw/src/protocol/network/dhcp4.rs
+++ b/uefi-raw/src/protocol/network/dhcp4.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Boolean, Char8, Event, Guid, Ipv4Address, MacAddress, Status, guid};
+use crate::{Boolean, Char8, Event, Guid, Ipv4Address, MacAddress, Status, guid, newtype_enum};
 use core::ffi::c_void;
 
 newtype_enum! {

--- a/uefi-raw/src/protocol/network/http.rs
+++ b/uefi-raw/src/protocol/network/http.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Boolean, Char8, Char16, Event, Guid, Ipv4Address, Ipv6Address, Status, guid};
+use crate::{
+    Boolean, Char8, Char16, Event, Guid, Ipv4Address, Ipv6Address, Status, guid, newtype_enum,
+};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};
 use core::ptr;

--- a/uefi-raw/src/protocol/network/ip4_config2.rs
+++ b/uefi-raw/src/protocol/network/ip4_config2.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::protocol::network::ip4::Ip4RouteTable;
-use crate::{Char16, Event, Guid, Ipv4Address, MacAddress, Status, guid};
+use crate::{Char16, Event, Guid, Ipv4Address, MacAddress, Status, guid, newtype_enum};
 use core::ffi::c_void;
 
 newtype_enum! {

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Boolean, Char8, Guid, IpAddress, MacAddress, Status, guid};
+use crate::{Boolean, Char8, Guid, IpAddress, MacAddress, Status, guid, newtype_enum};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Formatter};

--- a/uefi-raw/src/protocol/network/snp.rs
+++ b/uefi-raw/src/protocol/network/snp.rs
@@ -4,7 +4,7 @@ use core::ffi;
 
 use bitflags::bitflags;
 
-use crate::{Boolean, Event, Guid, IpAddress, MacAddress, Status, guid};
+use crate::{Boolean, Event, Guid, IpAddress, MacAddress, Status, guid, newtype_enum};
 
 #[derive(Debug)]
 #[repr(C)]

--- a/uefi-raw/src/protocol/network/tls.rs
+++ b/uefi-raw/src/protocol/network/tls.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{Guid, Status, guid};
+use crate::{Guid, Status, guid, newtype_enum};
 use core::ffi::c_void;
 
 newtype_enum! {

--- a/uefi-raw/src/protocol/nvme.rs
+++ b/uefi-raw/src/protocol/nvme.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::device_path::DevicePathProtocol;
-use crate::Status;
+use crate::{Status, newtype_enum};
 use core::ffi::c_void;
 use uguid::{Guid, guid};
 

--- a/uefi-raw/src/protocol/pci/root_bridge.rs
+++ b/uefi-raw/src/protocol/pci/root_bridge.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::table::boot::{AllocateType, MemoryType};
-use crate::{Handle, PhysicalAddress, Status};
+use crate::{Handle, PhysicalAddress, Status, newtype_enum};
 use core::ffi::c_void;
 use uguid::{Guid, guid};
 

--- a/uefi-raw/src/protocol/rng.rs
+++ b/uefi-raw/src/protocol/rng.rs
@@ -2,7 +2,7 @@
 
 //! `Rng` protocol.
 
-use crate::{Guid, Status, guid};
+use crate::{Guid, Status, guid, newtype_enum};
 
 newtype_enum! {
     /// The algorithms listed are optional, not meant to be exhaustive

--- a/uefi-raw/src/protocol/scsi.rs
+++ b/uefi-raw/src/protocol/scsi.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::device_path::DevicePathProtocol;
-use crate::{Event, Guid, Status, guid};
+use crate::{Event, Guid, Status, guid, newtype_enum};
 use core::ffi::c_void;
 
 pub const SCSI_TARGET_MAX_BYTES: usize = 0x10;

--- a/uefi-raw/src/protocol/tcg/enums.rs
+++ b/uefi-raw/src/protocol/tcg/enums.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::newtype_enum;
+
 newtype_enum! {
     /// Algorithm identifiers.
     ///

--- a/uefi-raw/src/protocol/usb/host_controller.rs
+++ b/uefi-raw/src/protocol/usb/host_controller.rs
@@ -4,7 +4,7 @@ use core::ffi;
 
 use bitflags::bitflags;
 
-use crate::{Boolean, Guid, Status, guid};
+use crate::{Boolean, Guid, Status, guid, newtype_enum};
 
 use super::{AsyncUsbTransferCallback, DataDirection, DeviceRequest, UsbTransferStatus};
 

--- a/uefi-raw/src/protocol/usb/mod.rs
+++ b/uefi-raw/src/protocol/usb/mod.rs
@@ -4,7 +4,7 @@ use core::ffi;
 
 use bitflags::bitflags;
 
-use crate::Status;
+use crate::{Status, newtype_enum};
 
 pub mod host_controller;
 pub mod io;

--- a/uefi-raw/src/status.rs
+++ b/uefi-raw/src/status.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::newtype_enum;
 use core::fmt::Debug;
 
 newtype_enum! {
@@ -46,7 +47,7 @@ pub enum Status: usize => {
     WRITE_PROTECTED         = Self::ERROR_BIT |  8,
     /// A resource has run out.
     OUT_OF_RESOURCES        = Self::ERROR_BIT |  9,
-    /// An inconstency was detected on the file system.
+    /// An inconsistency was detected on the file system.
     VOLUME_CORRUPTED        = Self::ERROR_BIT | 10,
     /// There is no more space on the file system.
     VOLUME_FULL             = Self::ERROR_BIT | 11,

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -4,7 +4,9 @@
 
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::table::Header;
-use crate::{Boolean, Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress};
+use crate::{
+    Boolean, Char16, Event, Guid, Handle, PhysicalAddress, Status, VirtualAddress, newtype_enum,
+};
 use bitflags::bitflags;
 use core::ffi::c_void;
 use core::ops::RangeInclusive;

--- a/uefi-raw/src/table/runtime.rs
+++ b/uefi-raw/src/table/runtime.rs
@@ -6,7 +6,7 @@ use crate::capsule::CapsuleHeader;
 use crate::table::Header;
 use crate::table::boot::MemoryDescriptor;
 use crate::time::Time;
-use crate::{Boolean, Char16, Guid, PhysicalAddress, Status, guid};
+use crate::{Boolean, Char16, Guid, PhysicalAddress, Status, guid, newtype_enum};
 use bitflags::bitflags;
 use core::ffi::c_void;
 

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -117,7 +117,7 @@ pub trait Align {
     /// this will return 7. Returns 0 if `val == 0`.
     #[must_use]
     fn offset_up_to_alignment(val: usize) -> usize {
-        assert!(Self::alignment() != 0);
+        assert_ne!(Self::alignment(), 0);
         let r = val % Self::alignment();
         if r == 0 { 0 } else { Self::alignment() - r }
     }
@@ -169,7 +169,9 @@ pub use strs::{
     UnalignedCStr16Error,
 };
 
-/// These functions are used in the implementation of the [`cstr8`] macro.
+/// These functions are used in the implementation of the [`cstr8!`] macro.
+///
+/// [`cstr8!`]: crate::cstr8
 #[doc(hidden)]
 pub use strs::{str_num_latin1_chars, str_to_latin1};
 

--- a/xtask/src/device_path/mod.rs
+++ b/xtask/src/device_path/mod.rs
@@ -54,7 +54,7 @@ fn gen_uefi_raw_code_as_string(groups: &[NodeGroup]) -> Result<String> {
         use bitflags::bitflags;
         use crate::protocol::device_path;
         use crate::table::boot::MemoryType;
-        use crate::{Guid, IpAddress, guid};
+        use crate::{Guid, IpAddress, guid, newtype_enum};
         use device_path::DevicePathProtocol as DevicePathHeader;
         #[cfg(doc)]
         use device_path::DeviceType;


### PR DESCRIPTION
We were inconsistent with the use of the newtype_enum! macro.
Sometimes we imported it directly, sometimes we used it from
the global scope (#[macro_use]). We now prefer an explicit 
dependency for every usage.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
