### PR TITLE
release: uefi-raw-0.12.0, uefi-macros-0.19.0, uefi-0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags 2.9.4",
  "uguid",

--- a/book/src/tutorial/app.md
+++ b/book/src/tutorial/app.md
@@ -23,8 +23,9 @@ cargo add uefi --features logger,panic_handler
 to your `Cargo.toml`. The resulting `Cargo.toml` should look like that:
 ```toml
 [dependencies]
-log = "0.4.21"
-uefi = { version = "0.35.0", features = [ "panic_handler", "logger" ] }
+log = "0.4"
+# Check crates.io for the latest version.
+uefi = { version = "<latest, e.g. 0.36>", features = [ "panic_handler", "logger" ] }
 ```
 
 Replace the contents of `src/main.rs` with this:

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uefi = { version = "0.35", features = ["panic_handler"] }
+uefi = { version = "0.36", features = ["panic_handler"] }

--- a/uefi-macros/CHANGELOG.md
+++ b/uefi-macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # uefi-macros - [Unreleased]
 
+## Added
+
+## Changed
+
+
+# uefi-macros - v0.19 (2025-10-21)
+
 ## Changed
 
 - **Breaking:** The MSRV is now 1.85.1 and the crate uses the Rust 2024 edition.

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-macros"
-version = "0.18.1"
+version = "0.19.0"
 readme = "README.md"
 description = "Procedural macros for the `uefi` crate."
 

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,6 +1,13 @@
 # uefi-raw - [Unreleased]
 
 ## Added
+
+## Changed
+
+
+# uefi-raw - v0.12 (2025-10-21)
+
+## Added
 - Added `AllocateType`.
 - Added `PciRootBridgeIoProtocol`.
 - Added `ConfigKeywordHandlerProtocol`.

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.11.0"
+version = "0.12.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,6 +1,13 @@
 # uefi - [Unreleased]
 
 ## Added
+
+## Changed
+
+
+# uefi - v0.36 (2025-10-21)
+
+## Added
 - Added `ConfigTableEntry::MEMORY_ATTRIBUTES_GUID` and `ConfigTableEntry::IMAGE_SECURITY_DATABASE_GUID`.
 - Added `proto::usb::io::UsbIo`.
 - Added `proto::pci::PciRootBridgeIo`.

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.35.0"
+version = "0.36.0"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,
@@ -42,8 +42,8 @@ ptr_meta.workspace = true
 uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
-uefi-macros = "0.18.1"
-uefi-raw = "0.11.0"
+uefi-macros = "0.19.0"
+uefi-raw = "0.12.0"
 qemu-exit = { version = "3.0.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
There are no more blockers and we should release new versions of `uefi-raw` and `uefi`. We have major highlights and changes since the last release and we should ship them to downstream users.

Closes #1655.

## Selected Highlights
- Rust edition 2024
- Refactored net code: Public API now uses `core::net` types
- Improved documentation
- Removed `allocator_api` feature
- Added multiple new protocols
- Bugfixes

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
