### PR TITLE
uefi-raw/uefi: Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -11,7 +11,7 @@
 //! [`uefi`]: https://crates.io/crates/uefi
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -227,7 +227,7 @@
 //! [uefi-std-tr-issue]: https://github.com/rust-lang/rust/issues/100499
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #![deny(
     clippy::all,


### PR DESCRIPTION
Our latest release failed to build on docs.rs [1] because the `doc_auto_cfg` feature has been subsumed by `doc_cfg`:
https://github.com/rust-lang/rust/pull/138907

[1]: https://docs.rs/crate/uefi/0.36.0/builds/2603179

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
