### PR TITLE
book: Rephrase target installation

### DIFF
--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -2,9 +2,10 @@
 
 ## Toolchain
 
-In order to compile for UEFI, an appropriate target must be installed. The
-easiest way to set this up is using a [rustup toolchain file]. In the root of
-your repository, add `rust-toolchain.toml`:
+In order to compile for UEFI, an appropriate target must be installed. Unless
+your operating system provides packages for the Rust UEFI targets, the easiest
+way to set this up is using a [rustup toolchain file]. In the root of your
+repository, add `rust-toolchain.toml`:
 
 ```toml
 [toolchain]


### PR DESCRIPTION
Minor rephrasing to make the modified section read true. This is helpful as it reminds some users of that there might be a more appropriate approach to installation, while being subtle enough to not disturb anyone.

Also, this makes it less problematic for operating system porters and distributors to add links to this book without opening up themselves to unnecessary support cases and bug reports.

The main rust installation instructions earlier in the book link to rust-lang.org:s installation instructions which do not have this problem, since they do mention other methods than rustup.

## Checklist
- [✓] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [✗] Update the changelog (if necessary)
