### PR TITLE
release: uefi-raw-0.13.0, uefi-0.36.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bitflags 2.9.4",
  "uguid",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uefi = { version = "0.36", features = ["panic_handler"] }
+uefi = { version = "0.36.1", features = ["panic_handler"] }

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## Added
 
 ## Changed
+
+
+# uefi-raw - v0.13.0 (2025-11-05)
+
+## Changed
 - **Breaking:** Various uses of `bool` have been replaced with `Boolean`.
+- Fixing build on <https://docs.rs/uefi>
 
 
 # uefi-raw - v0.12 (2025-10-21)
@@ -33,6 +39,7 @@
 ## Changed
 - **Breaking:** The MSRV is now 1.85.1 and the crate uses the Rust 2024 edition.
 - The documentation for UEFI protocols has been streamlined and improved.
+
 
 # uefi-raw - 0.11.0 (2025-05-04)
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.12.0"
+version = "0.13.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## Changed
 
 
+# uefi - v0.36.1 (2025-11-05)
+
+- Fixing build on <https://docs.rs/uefi>
+
+
 # uefi - v0.36 (2025-10-21)
 
 ## Added

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.36.0"
+version = "0.36.1"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,
@@ -43,7 +43,7 @@ uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
 uefi-macros = "0.19.0"
-uefi-raw = "0.12.0"
+uefi-raw = "0.13.0"
 qemu-exit = { version = "3.0.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The fix from https://github.com/rust-osdev/uefi-rs/pull/1796 will help to fix the build on docs.rs

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
