### PR TITLE
AtaPassThru: Add read_pio method for AtaRequestBuilder

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,6 +1,7 @@
 # uefi - [Unreleased]
 
 ## Added
+- Added `proto::ata::AtaRequestBuilder::read_pio()`.
 
 ## Changed
 


### PR DESCRIPTION
Every warning sign has a story behind it.
And boy ... do I have stories of actual server hardware doing **"things"**.

Let's call this time's offending vendor `Super M.`
Or better yet! Let's call it: `S. Micro`

---

On some mainboards, we have the problem that using UDMA to send the IDENTIFY command to the HDD just hangs indefinitely until the watchdog kills the app. Sending the same command using PIO works.

**Hangs:**
```rust
	let request = AtaRequestBuilder::read_udma(scsi_pt.io_align(), 0xEC)?
		.with_timeout(Duration::from_millis(500))
		.use_read_buffer(bfr)?
		.build();
      let response = device.execute_command(request)?;
```

**Works:**
```rust
	let request = AtaRequestBuilder::read_pio(scsi_pt.io_align(), 0xEC)?
		.with_timeout(Duration::from_millis(500))
		.with_device_head(0xA0)
		.with_sector_count(0)
		.use_read_buffer(bfr)?
		.build();
      let response = device.execute_command(request)?;
```
At first I thought it hangs because there were no drives connected to the port. But no ... turns out there actually are drives connected.

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/9b84acd5-0287-4bc5-92c1-a39e3d26f221" />

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
