### PR TITLE
Fix documentation for allocate_pages function

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -131,7 +131,7 @@ pub unsafe fn raise_tpl(tpl: Tpl) -> TplGuard {
 /// - `memory_type`: The [`MemoryType`] used to persist the allocation in the
 ///   UEFI memory map. Typically, UEFI OS loaders should allocate memory of
 ///   type [`MemoryType::LOADER_DATA`].
-///- `count`: Number of bytes to allocate.
+///- `count`: Number of pages to allocate.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
The documentation for allocate_pages here states that count is the number of bytes to allocate, but in the UEFI specification, it's the number of pages. It appears this function also uses it as count of pages.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
