### PR TITLE
uefi-raw: Add bindings for most HII protocols

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Added `Tcpv4Protocol`.
 - Added `StorageSecurityCommandProtocol`.
 - Added `FirmwareManagementProtocol`.
+- Added `HiiFontProtocol`, `HiiFontExProtocol`.
+- Added `HiiImageProtocol`, `HiiImageExProtocol`.
+- Added `HiiStringProtocol`.
+- Added `HiiPopupProtocol`.
+- Added `FormBrowser2Protocol`.
 
 ## Changed
 

--- a/uefi-raw/src/protocol/hii/config.rs
+++ b/uefi-raw/src/protocol/hii/config.rs
@@ -4,6 +4,8 @@
 
 use core::fmt::Debug;
 
+use super::form_browser::BrowserActionRequest;
+use super::{FormId, QuestionId, StringId};
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::{Boolean, Char16, Guid, Status, guid, newtype_enum};
 
@@ -69,34 +71,6 @@ newtype_enum! {
     }
 }
 
-newtype_enum! {
-    /// Represents actions requested by the Forms Browser in response to user interactions.
-    #[derive(Default)]
-    pub enum BrowserActionRequest: usize => {
-        /// No special behavior is taken by the Forms Browser.
-        NONE = 0,
-        /// The Forms Browser will exit and request the platform to reset.
-        RESET = 1,
-        /// The Forms Browser will save all modified question values to storage and exit.
-        SUBMIT = 2,
-        /// The Forms Browser will discard all modified question values and exit.
-        EXIT = 3,
-        /// The Forms Browser will write all modified question values on the selected form to storage and exit the form.
-        FORM_SUBMIT_EXIT = 4,
-        /// The Forms Browser will discard the modified question values on the selected form and exit the form.
-        FORM_DISCARD_EXIT = 5,
-        /// The Forms Browser will write all modified current question values on the selected form to storage.
-        FORM_APPLY = 6,
-        /// The Forms Browser will discard the current question values on the selected form and replace them with the original values.
-        FORM_DISCARD = 7,
-        /// The user performed a hardware or software configuration change, requiring controller reconnection.
-        /// The Forms Browser calls `DisconnectController()` followed by `ConnectController()`.
-        RECONNECT = 8,
-        /// The Forms Browser will write the current modified question value on the selected form to storage.
-        QUESTION_APPLY = 9,
-    }
-}
-
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HiiTime {
@@ -140,10 +114,6 @@ impl core::fmt::Debug for IfrTypeValue {
         f.debug_struct("EfiIfrTypeValue").finish()
     }
 }
-
-pub type QuestionId = u16;
-pub type FormId = u16;
-pub type StringId = u16;
 
 /// EFI_HII_CONFIG_ACCESS_PROTOCOL
 #[derive(Debug)]

--- a/uefi-raw/src/protocol/hii/font.rs
+++ b/uefi-raw/src/protocol/hii/font.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bindings for HII Font protocols and data types
+
+use super::image::ImageOutput;
+use super::{HiiHandle, StringId};
+use crate::protocol::console::GraphicsOutputBltPixel;
+use crate::{Char8, Char16, Guid, Status, guid};
+
+pub type FontHandle = *mut core::ffi::c_void;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiGlyphInfo {
+    pub width: u16,
+    pub height: u16,
+    pub offset_x: i16,
+    pub offset_y: i16,
+    pub advance_x: i16,
+}
+
+bitflags::bitflags! {
+    /// EFI_FONT_INFO_MASK
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct FontInfoMask: u32 {
+        const SYS_FONT = 1 << 0;
+        const SYS_SIZE = 1 << 1;
+        const SYS_STYLE = 1 << 2;
+        const SYS_FORE_COLOR = 1 << 4;
+        const SYS_BACK_COLOR = 1 << 5;
+        const RESIZE = 1 << 12;
+        const RESTYLE = 1 << 13;
+        const ANY_FONT = 1 << 16;
+        const ANY_SIZE = 1 << 17;
+        const ANY_STYLE = 1 << 18;
+    }
+}
+
+bitflags::bitflags! {
+    /// EFI_HII_FONT_STYLE
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct HiiFontStyle: u32 {
+        const BOLD = 1 << 0;
+        const ITALIC = 1 << 1;
+        const EMBOSS = 1 << 16;
+        const OUTLINE = 1 << 17;
+        const SHADOW = 1 << 18;
+        const UNDERLINE = 1 << 19;
+        const DBL_UNDER = 1 << 20;
+    }
+}
+
+impl HiiFontStyle {
+    pub const NORMAL: Self = Self::empty();
+}
+
+/// EFI_FONT_INFO
+#[derive(Debug)]
+#[repr(C)]
+pub struct FontInfo {
+    pub font_style: HiiFontStyle,
+    pub font_size: u16,
+    pub font_name: [Char16; 0],
+}
+
+/// EFI_FONT_DISPLAY_INFO
+#[derive(Debug)]
+#[repr(C)]
+pub struct FontDisplayInfo {
+    pub foreground_color: GraphicsOutputBltPixel,
+    pub background_color: GraphicsOutputBltPixel,
+    pub font_mask_info: FontInfoMask,
+    pub font_info: FontInfo,
+}
+
+bitflags::bitflags! {
+    /// EFI_HII_OUT_FLAGS
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct HiiOutFlags: u32 {
+        const CLIP = 1 << 0;
+        const WRAP = 1 << 1;
+        const CLIP_CLEAN_Y = 1 << 2;
+        const CLIP_CLEAN_X = 1 << 3;
+        const TRANSPARENT = 1 << 4;
+        const IGNORE_IF_NO_GLYPH = 1 << 5;
+        const IGNORE_LINE_BREAK = 1 << 6;
+        const DIRECT_TO_SCREEN = 1 << 7;
+    }
+}
+
+/// EFI_HII_ROW_INFO
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiRowInfo {
+    pub start_index: usize,
+    pub end_index: usize,
+    pub line_height: usize,
+    pub line_width: usize,
+    pub baseline_offset: usize,
+}
+
+/// EFI_HII_FONT_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiFontProtocol {
+    pub string_to_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiOutFlags,
+        string: *const Char16,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+        row_info_array: *mut *mut HiiRowInfo,
+        row_info_array_size: *mut usize,
+        column_info_array: *mut usize,
+    ) -> Status,
+    pub string_id_to_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiOutFlags,
+        package_list: HiiHandle,
+        string_id: StringId,
+        language: *const Char8,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+        row_info_array: *mut *mut HiiRowInfo,
+        row_info_array_size: *mut usize,
+        column_info_array: *mut usize,
+    ) -> Status,
+    pub get_glyph: unsafe extern "efiapi" fn(
+        this: *const Self,
+        char: Char16,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        baseline: *mut usize,
+    ) -> Status,
+    pub get_font_info: unsafe extern "efiapi" fn(
+        this: *const Self,
+        font_handle: *mut FontHandle,
+        string_info_in: *const FontDisplayInfo,
+        string_info_out: *mut *mut FontDisplayInfo,
+        string: *const Char16,
+    ) -> Status,
+}
+
+impl HiiFontProtocol {
+    pub const GUID: Guid = guid!("e9ca4775-8657-47fc-97e7-7ed65a084324");
+}
+
+// NOTE: This protocol is declared in the UEFI spec, but not defined in edk2.
+/// EFI_HII_FONT_EX_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiFontExProtocol {
+    pub string_to_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiOutFlags,
+        string: *const Char16,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+        row_info_array: *mut *mut HiiRowInfo,
+        row_info_array_size: *mut usize,
+        column_info_array: *mut usize,
+    ) -> Status,
+    pub string_id_to_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiOutFlags,
+        package_list: HiiHandle,
+        string_id: StringId,
+        language: *const Char8,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+        row_info_array: *mut *mut HiiRowInfo,
+        row_info_array_size: *mut usize,
+        column_info_array: *mut usize,
+    ) -> Status,
+    pub get_glyph_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        char: Char16,
+        string_info: *const FontDisplayInfo,
+        blt: *mut *mut ImageOutput,
+        baseline: *mut usize,
+    ) -> Status,
+    pub get_font_info_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        font_handle: *mut FontHandle,
+        string_info_in: *const FontDisplayInfo,
+        string_info_out: *mut *mut FontDisplayInfo,
+        string: *const Char16,
+    ) -> Status,
+    pub get_glyph_info: unsafe extern "efiapi" fn(
+        this: *const Self,
+        char: Char16,
+        font_display_info: *const FontDisplayInfo,
+        glyph_info: *mut HiiGlyphInfo,
+    ) -> Status,
+}
+
+impl HiiFontExProtocol {
+    pub const GUID: Guid = guid!("849e6875-db35-4df8-b41e-c8f33718073f");
+}

--- a/uefi-raw/src/protocol/hii/form_browser.rs
+++ b/uefi-raw/src/protocol/hii/form_browser.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Form Browser protocol
+
+use super::{FormId, HiiHandle};
+use crate::{Boolean, Char16, Guid, Status, guid, newtype_enum};
+
+/// EFI_SCREEN_DESCRIPTOR
+#[derive(Debug)]
+#[repr(C)]
+pub struct ScreenDescriptor {
+    pub left_column: usize,
+    pub right_column: usize,
+    pub top_row: usize,
+    pub bottom_row: usize,
+}
+
+newtype_enum! {
+    /// Represents actions requested by the Forms Browser in response to user interactions.
+    #[derive(Default)]
+    pub enum BrowserActionRequest: usize => {
+        /// No special behavior is taken by the Forms Browser.
+        NONE = 0,
+        /// The Forms Browser will exit and request the platform to reset.
+        RESET = 1,
+        /// The Forms Browser will save all modified question values to storage and exit.
+        SUBMIT = 2,
+        /// The Forms Browser will discard all modified question values and exit.
+        EXIT = 3,
+        /// The Forms Browser will write all modified question values on the selected form to storage and exit the form.
+        FORM_SUBMIT_EXIT = 4,
+        /// The Forms Browser will discard the modified question values on the selected form and exit the form.
+        FORM_DISCARD_EXIT = 5,
+        /// The Forms Browser will write all modified current question values on the selected form to storage.
+        FORM_APPLY = 6,
+        /// The Forms Browser will discard the current question values on the selected form and replace them with the original values.
+        FORM_DISCARD = 7,
+        /// The user performed a hardware or software configuration change, requiring controller reconnection.
+        /// The Forms Browser calls `DisconnectController()` followed by `ConnectController()`.
+        RECONNECT = 8,
+        /// The Forms Browser will write the current modified question value on the selected form to storage.
+        QUESTION_APPLY = 9,
+    }
+}
+
+/// EFI_FORM_BROWSER2_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct FormBrowser2Protocol {
+    pub send_form: unsafe extern "efiapi" fn(
+        this: *const Self,
+        handles: *const HiiHandle,
+        handle_count: usize,
+        formset_guid: *const Guid,
+        form_id: FormId,
+        screen_dimensions: *const ScreenDescriptor,
+        action_request: *mut BrowserActionRequest,
+    ) -> Status,
+    pub browser_callback: unsafe extern "efiapi" fn(
+        this: *const Self,
+        results_data_size: *mut usize,
+        results_data: *mut Char16,
+        retrieve_data: Boolean,
+        variable_guid: *const Guid,
+        variable_name: *const Char16,
+    ) -> Status,
+}
+
+impl FormBrowser2Protocol {
+    pub const GUID: Guid = guid!("b9d4c360-bcfb-4f9b-9298-53c136982258");
+}

--- a/uefi-raw/src/protocol/hii/image.rs
+++ b/uefi-raw/src/protocol/hii/image.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bindings for HII Image protocols and data types
+
+use super::{HiiHandle, ImageId};
+use crate::protocol::console::{GraphicsOutputBltPixel, GraphicsOutputProtocol};
+use crate::{Guid, Status, guid};
+use core::fmt;
+
+bitflags::bitflags! {
+    /// EFI_HII_DRAW_FLAGS
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct HiiDrawFlags: u32 {
+        const CLIP = 1 << 0;
+        const FORCE_TRANS = 1 << 4;
+        const FORCE_OPAQUE = 1 << 5;
+        const TRANSPARENT = Self::FORCE_TRANS.bits() | Self::FORCE_OPAQUE.bits();
+        const DIRECT_TO_SCREEN = 1 << 7;
+    }
+}
+
+impl HiiDrawFlags {
+    pub const DEFAULT: Self = Self::empty();
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[repr(transparent)]
+    pub struct ImageInputFlags: u32 {
+        const TRANSPARENT = 1 << 0;
+    }
+}
+
+/// EFI_IMAGE_INPUT
+#[derive(Debug)]
+#[repr(C)]
+pub struct ImageInput {
+    pub flags: ImageInputFlags,
+    pub width: u16,
+    pub height: u16,
+    pub bitmap: *const GraphicsOutputBltPixel,
+}
+
+#[repr(C)]
+pub union ImageOutputDest {
+    pub bitmap: *mut GraphicsOutputBltPixel,
+    pub screen: *mut GraphicsOutputProtocol,
+}
+
+impl fmt::Debug for ImageOutputDest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // All union fields are pointers.
+        f.debug_struct("ImageOutputDest")
+            .field("bitmap", unsafe { &self.bitmap })
+            .field("screen", unsafe { &self.screen })
+            .finish()
+    }
+}
+
+impl Default for ImageOutputDest {
+    fn default() -> Self {
+        Self {
+            bitmap: core::ptr::null_mut(),
+        }
+    }
+}
+
+/// EFI_IMAGE_OUTPUT
+#[derive(Debug)]
+#[repr(C)]
+pub struct ImageOutput {
+    pub width: u16,
+    pub height: u16,
+    pub image: ImageOutputDest,
+}
+
+/// EFI_HII_IMAGE_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiImageProtocol {
+    pub new_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: *mut ImageId,
+        image: *const ImageInput,
+    ) -> Status,
+    pub get_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        image: *mut ImageInput,
+    ) -> Status,
+    pub set_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        image: *const ImageInput,
+    ) -> Status,
+    pub draw_image: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiDrawFlags,
+        image: *const ImageInput,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+    ) -> Status,
+    pub draw_image_id: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiDrawFlags,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+    ) -> Status,
+}
+
+impl HiiImageProtocol {
+    pub const GUID: Guid = guid!("31a6406a-6bdf-4e46-b2a2-ebaa89c40920");
+}
+
+/// EFI_HII_IMAGE_EX_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiImageExProtocol {
+    // NOTE: UEFI 2.11 declares `image` as an inout value; edk2 declares it as
+    // an input-only value, matching the non-extended protocol version.
+    pub new_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: *mut ImageId,
+        image: *const ImageInput,
+    ) -> Status,
+    pub get_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        image: *mut ImageInput,
+    ) -> Status,
+    pub set_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        image: *const ImageInput,
+    ) -> Status,
+    pub draw_image_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiDrawFlags,
+        image: *const ImageInput,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+    ) -> Status,
+    pub draw_image_id_ex: unsafe extern "efiapi" fn(
+        this: *const Self,
+        flags: HiiDrawFlags,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        blt: *mut *mut ImageOutput,
+        blt_x: usize,
+        blt_y: usize,
+    ) -> Status,
+    pub get_image_info: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        image_id: ImageId,
+        image: *mut ImageOutput,
+    ) -> Status,
+}
+
+impl HiiImageExProtocol {
+    pub const GUID: Guid = guid!("1a1241e6-8f19-41a9-bc0e-e8ef39e06546");
+}

--- a/uefi-raw/src/protocol/hii/mod.rs
+++ b/uefi-raw/src/protocol/hii/mod.rs
@@ -4,10 +4,22 @@
 
 pub mod config;
 pub mod database;
+pub mod font;
+pub mod form_browser;
+pub mod image;
+pub mod popup;
+pub mod string;
 
 use crate::{Char16, Guid, newtype_enum};
 
 pub type HiiHandle = *mut core::ffi::c_void;
+
+pub type QuestionId = u16;
+pub type ImageId = u16;
+pub type StringId = u16;
+pub type FormId = u16;
+pub type VarstoreId = u16;
+pub type AnimationId = u16;
 
 /// EFI_HII_PACKAGE_HEADER
 #[derive(Debug)]

--- a/uefi-raw/src/protocol/hii/popup.rs
+++ b/uefi-raw/src/protocol/hii/popup.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Popup protocol
+
+use super::{HiiHandle, StringId};
+use crate::{Guid, Status, guid, newtype_enum};
+
+newtype_enum! {
+    /// EFI_HII_POPUP_STYLE
+    pub enum HiiPopupStyle: u32 => {
+        INFO = 0,
+        WARNING = 1,
+        ERROR = 2,
+    }
+}
+
+newtype_enum! {
+    /// EFI_HII_POPUP_TYPE
+    pub enum HiiPopupType: u32 => {
+        OK = 0,
+        OK_CANCEL = 1,
+        YES_NO = 2,
+        YES_NO_CANCEL = 3,
+    }
+}
+
+newtype_enum! {
+    /// EFI_HII_POPUP_SELECTION
+    pub enum HiiPopupSelection: u32 => {
+        OK = 0,
+        CANCEL = 1,
+        YES = 2,
+        NO = 3,
+    }
+}
+
+/// EFI_HII_POPUP_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiPopupProtocol {
+    pub revision: u64,
+    pub create_popup: unsafe extern "efiapi" fn(
+        this: *const Self,
+        popup_style: HiiPopupStyle,
+        popup_type: HiiPopupType,
+        hii_handle: HiiHandle,
+        message: StringId,
+        user_selection: *mut HiiPopupSelection,
+    ) -> Status,
+}
+
+impl HiiPopupProtocol {
+    pub const GUID: Guid = guid!("4311edc0-6054-46d4-9e40-893ea952fccc");
+    pub const REVISION: u64 = 1;
+}

--- a/uefi-raw/src/protocol/hii/string.rs
+++ b/uefi-raw/src/protocol/hii/string.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bindings for HII String protocols and data types
+
+use super::font::FontInfo;
+use super::{HiiHandle, StringId};
+use crate::{Char8, Char16, Guid, Status, guid};
+
+/// EFI_HII_STRING_PROTOCOL
+#[derive(Debug)]
+#[repr(C)]
+pub struct HiiStringProtocol {
+    pub new_string: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        string_id: *mut StringId,
+        language: *const Char8,
+        language_name: *const Char16,
+        string: *const Char16,
+        string_font_info: *const FontInfo,
+    ) -> Status,
+    pub get_string: unsafe extern "efiapi" fn(
+        this: *const Self,
+        language: *const Char8,
+        package_list: HiiHandle,
+        string_id: StringId,
+        string: *mut *mut Char16,
+        string_size: *mut usize,
+        string_font_info: *mut *mut FontInfo,
+    ) -> Status,
+    pub set_string: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        string_id: StringId,
+        language: *const Char8,
+        string: *const Char16,
+        string_font_info: *const FontInfo,
+    ) -> Status,
+    pub get_languages: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        languages: *mut Char8,
+        languages_size: *mut usize,
+    ) -> Status,
+    pub get_secondary_languages: unsafe extern "efiapi" fn(
+        this: *const Self,
+        package_list: HiiHandle,
+        primary_language: *const Char8,
+        secondary_languages: *mut Char8,
+        secondary_languages_size: *mut usize,
+    ) -> Status,
+}
+
+impl HiiStringProtocol {
+    pub const GUID: Guid = guid!("0fd96974-23aa-4cdc-b9cb-98d17750322a");
+}


### PR DESCRIPTION
Add bindings for the following protocols:

- HiiFont (`EFI_HII_FONT_PROTOCOL`)
- HiiFontEx (`EFI_HII_FONT_EX_PROTOCOL`)
- HiiString (`EFI_HII_STRING_PROTOCOL`)
- HiiImage (`EFI_HII_IMAGE_PROTOCOL`)
- HiiImageEx (`EFI_HII_IMAGE_EX_PROTOCOL`)
- HiiPopup (`EFI_HII_POPUP_PROTOCOL`)
- FormBrowser2 (`EFI_FORM_BROWSER2_PROTOCOL`)

Ref: UEFI 2.11: 34 HII Protocols
Ref: UEFI 2.11: 35 HII Configuration Processing and Browser Protocol

### TODO

- [x] Determine correct implementation and use of anonymous union in `ImageOutput`
- [x] Add glyph-related data types to complete `HiiFontExProtocol.get_glyph_info`
- [x] ~Add HII package definitions for database integration (Section 33.3)~?
  - Will add IFR related stuff in a follow up, since it looks like a lot.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
