### PR TITLE
uefi-raw: add Storage Security Command protocol type definitions

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Added `Tcpv4Protocol`.
+- Added `StorageSecurityCommandProtocol`.
 
 ## Changed
 

--- a/uefi-raw/src/protocol/media.rs
+++ b/uefi-raw/src/protocol/media.rs
@@ -35,3 +35,32 @@ pub struct LoadFile2Protocol {
 impl LoadFile2Protocol {
     pub const GUID: Guid = guid!("4006c0c1-fcb3-403e-996d-4a6c8724e06d");
 }
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct StorageSecurityCommandProtocol {
+    pub receive_data: unsafe extern "efiapi" fn(
+        this: *mut Self,
+        media_id: u32,
+        timeout: u64,
+        security_protocol: u8,
+        security_protocol_specific_data: u16,
+        buffer_size: usize,
+        buffer: *mut c_void,
+        transfer_size: *mut usize,
+    ) -> Status,
+
+    pub send_data: unsafe extern "efiapi" fn(
+        this: *mut Self,
+        media_id: u32,
+        timeout: u64,
+        security_protocol: u8,
+        security_protocol_specific_data: u16,
+        buffer_size: usize,
+        buffer: *const c_void,
+    ) -> Status,
+}
+
+impl StorageSecurityCommandProtocol {
+    pub const GUID: Guid = guid!("c88b0b6d-0dfc-49a7-9cb4-49074b4c3a78");
+}


### PR DESCRIPTION
This adds the raw definition of the `StorageSecurityCommandProtocol` from section 13.14 of the UEFI spec.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
