### PR TITLE
uefi: Refactor PciRootBridgeIo::enumerate() with tree-topology information

### DIFF
--- a/uefi-test-runner/src/proto/scsi/pass_thru.rs
+++ b/uefi-test-runner/src/proto/scsi/pass_thru.rs
@@ -16,9 +16,9 @@ fn test_allocating_api() {
     // by default respectively. We manually configure an additional SCSI controller.
     // Thus, we should see two controllers with support for EXT_SCSI_PASS_THRU on this platform
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    assert_eq!(scsi_ctrl_handles.len(), 2);
+    assert_eq!(scsi_ctrl_handles.len(), 4);
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    assert_eq!(scsi_ctrl_handles.len(), 1);
+    assert_eq!(scsi_ctrl_handles.len(), 3);
 
     let mut found_drive = false;
     for handle in scsi_ctrl_handles {

--- a/uefi/src/proto/pci/enumeration.rs
+++ b/uefi/src/proto/pci/enumeration.rs
@@ -4,10 +4,11 @@
 
 use core::mem;
 
-use alloc::collections::btree_set::BTreeSet;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::btree_set::{self, BTreeSet};
 
+use super::PciIoAddress;
 use super::root_bridge::PciRootBridgeIo;
-use super::{FullPciIoAddress, PciIoAddress};
 
 #[allow(unused)]
 #[derive(Clone, Copy, Debug)]
@@ -56,6 +57,93 @@ fn read_device_register_u32<T: Sized + Copy>(
 }
 
 // ##########################################################################################
+
+/// Struct representing the tree structure of PCI devices.
+///
+/// This allows iterating over all valid PCI device addresses in a tree, as well as querying
+/// the tree topology.
+#[derive(Debug)]
+pub struct PciTree {
+    segment: u32,
+    devices: BTreeSet<PciIoAddress>,
+    bus_anchors: BTreeMap<u8 /* bus */, PciIoAddress>,
+}
+impl PciTree {
+    pub(crate) const fn new(segment: u32) -> Self {
+        Self {
+            segment,
+            devices: BTreeSet::new(),
+            bus_anchors: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn should_visit_bus(&self, bus: u8) -> bool {
+        !self.bus_anchors.contains_key(&bus)
+    }
+
+    pub(crate) fn push_device(&mut self, addr: PciIoAddress) {
+        self.devices.insert(addr);
+    }
+
+    /// Pushes a new bridge into the topology.
+    ///
+    /// Returns `false` if the bus is already in the topology and `true`
+    /// if the bridge was added to the topology.
+    pub(crate) fn push_bridge(&mut self, addr: PciIoAddress, child_bus: u8) -> bool {
+        match self.bus_anchors.contains_key(&child_bus) {
+            true => false,
+            false => {
+                self.bus_anchors.insert(child_bus, addr);
+                true
+            }
+        }
+    }
+
+    /// Iterate over all valid PCI device addresses in this tree structure.
+    pub fn iter(&self) -> btree_set::Iter<'_, PciIoAddress> {
+        self.devices.iter()
+    }
+
+    /// Get the segment number of this PCI tree.
+    #[must_use]
+    pub const fn segment_nr(&self) -> u32 {
+        self.segment
+    }
+
+    /// Query the address of the parent PCI bridge this `addr`'s bus is subordinate to.
+    #[must_use]
+    pub fn parent_for(&self, addr: PciIoAddress) -> Option<PciIoAddress> {
+        self.bus_anchors.get(&addr.bus).cloned()
+    }
+
+    /// Iterate over all subsequent busses below the given `addr`.
+    /// This yields 0 results if `addr` doesn't point to a PCI bridge.
+    pub fn child_bus_of_iter(&self, addr: PciIoAddress) -> impl Iterator<Item = u8> {
+        self.bus_anchors
+            .iter()
+            .filter(move |&(_, parent)| *parent == addr)
+            .map(|(bus, _)| bus)
+            .cloned()
+    }
+}
+impl IntoIterator for PciTree {
+    type Item = PciIoAddress;
+    type IntoIter = btree_set::IntoIter<PciIoAddress>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.devices.into_iter()
+    }
+}
+impl<'a> IntoIterator for &'a PciTree {
+    type Item = &'a PciIoAddress;
+    type IntoIter = btree_set::Iter<'a, PciIoAddress>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.devices.iter()
+    }
+}
+
+// ##########################################################################################
 // # Query Helpers (read from a device's configuration registers)
 
 fn get_vendor_id(proto: &mut PciRootBridgeIo, addr: PciIoAddress) -> uefi::Result<u16> {
@@ -86,12 +174,12 @@ fn get_secondary_bus_range(
 fn visit_function(
     proto: &mut PciRootBridgeIo,
     addr: PciIoAddress,
-    queue: &mut BTreeSet<FullPciIoAddress>,
+    tree: &mut PciTree,
 ) -> uefi::Result<()> {
     if get_vendor_id(proto, addr)? == 0xFFFF {
         return Ok(()); // function doesn't exist - bail instantly
     }
-    queue.insert(FullPciIoAddress::new(proto.segment_nr(), addr));
+    tree.push_device(addr);
     let (base_class, sub_class) = get_classes(proto, addr)?;
     let header_type = get_header_type(proto, addr)? & 0b01111111;
     if base_class == 0x6 && sub_class == 0x4 && header_type == 0x01 {
@@ -106,8 +194,11 @@ fn visit_function(
             return Ok(());
         }
         for bus in secondary_bus_nr..=subordinate_bus_nr {
-            // Recurse into the bus namespaces on the other side of the bridge
-            visit_bus(proto, PciIoAddress::new(bus, 0, 0), queue)?;
+            // Recurse into the bus namespaces on the other side of the bridge, if we haven't visited
+            // the subordinate bus through a more direct path already
+            if tree.push_bridge(addr, bus) {
+                visit_bus(proto, PciIoAddress::new(bus, 0, 0), tree)?;
+            }
         }
     }
     Ok(())
@@ -116,17 +207,17 @@ fn visit_function(
 fn visit_device(
     proto: &mut PciRootBridgeIo,
     addr: PciIoAddress,
-    queue: &mut BTreeSet<FullPciIoAddress>,
+    tree: &mut PciTree,
 ) -> uefi::Result<()> {
     if get_vendor_id(proto, addr)? == 0xFFFF {
         return Ok(()); // device doesn't exist
     }
-    visit_function(proto, addr.with_function(0), queue)?;
+    visit_function(proto, addr.with_function(0), tree)?;
     if get_header_type(proto, addr.with_function(0))? & 0x80 != 0 {
         // This is a multi-function device - also try the remaining functions [1;7]
         // These remaining functions can be sparsely populated - as long as function 0 exists.
         for fun in 1..=7 {
-            visit_function(proto, addr.with_function(fun), queue)?;
+            visit_function(proto, addr.with_function(fun), tree)?;
         }
     }
 
@@ -136,11 +227,11 @@ fn visit_device(
 pub(crate) fn visit_bus(
     proto: &mut PciRootBridgeIo,
     addr: PciIoAddress,
-    queue: &mut BTreeSet<FullPciIoAddress>,
+    tree: &mut PciTree,
 ) -> uefi::Result<()> {
     // Given a valid bus entry point - simply try all possible devices addresses
     for dev in 0..32 {
-        visit_device(proto, addr.with_device(dev), queue)?;
+        visit_device(proto, addr.with_device(dev), tree)?;
     }
     Ok(())
 }

--- a/uefi/src/proto/pci/mod.rs
+++ b/uefi/src/proto/pci/mod.rs
@@ -8,7 +8,7 @@ use uefi_raw::protocol::pci::root_bridge::PciRootBridgeIoProtocolWidth;
 
 pub mod configuration;
 #[cfg(feature = "alloc")]
-mod enumeration;
+pub mod enumeration;
 pub mod root_bridge;
 
 /// IO Address for PCI/register IO operations
@@ -121,36 +121,6 @@ impl Ord for PciIoAddress {
             .then(fun.cmp(&o_fun))
             .then(reg.cmp(&o_reg))
             .then(ext_reg.cmp(&o_ext_reg))
-    }
-}
-
-// --------------------------------------------------------------------------------------------
-
-/// Fully qualified pci address. This address is valid across root bridges.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct FullPciIoAddress {
-    /// PCI segment number
-    segment: u32,
-    /// Subsequent PCI address
-    addr: PciIoAddress,
-}
-impl FullPciIoAddress {
-    /// Construct a new fully qualified pci address.
-    #[must_use]
-    pub const fn new(segment: u32, addr: PciIoAddress) -> Self {
-        Self { segment, addr }
-    }
-
-    /// Get the segment number this address belongs to.
-    #[must_use]
-    pub const fn segment(&self) -> u32 {
-        self.segment
-    }
-
-    /// Get the internal RootBridge-specific portion of the address.
-    #[must_use]
-    pub const fn addr(&self) -> PciIoAddress {
-        self.addr
     }
 }
 


### PR DESCRIPTION
- Refactored return type from standard `BTreeSet<PciIoAddress>` to custom `PciTree` struct with tree topology information
- Removed special FullPciIoAddress type, since segment number is fixed per PciRoot
- During enumeration, skip branches we have already seen
- During enumeration, collect tree topology information (which child bus linked from where)
- Add complicated pci structure in integration test vm
- Print child busses for every device entry in integration test

Previously, we iterated over the bus range from the ACPI descriptor. I changed this in my last MR to only visit the first in the range. I changed this back to iterate over all of the entries, but skip the ones we have seen previously - now that that's easily possible. I decided that better safe than sorry is the best way. The iteration over all child busses already saved our ass once - let's not willingly take this safety net away. Sorry for the back and forth here.

The plan for device paths is now to add something like:   `PciTree::device_path(&self, addr: PciIoAddress) -> PoolDevicePath`.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
