### PR TITLE
Change SimpleNetwork::wait_for_packet to return `Option<Event>`

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Changed
 - Changed ordering of `proto::pci::PciIoAddress` to (bus -> dev -> fun -> reg -> ext_reg).
 - Return request with status as error data object for `proto::ata::pass_thru::AtaDevice`.
+- **Breaking:** `proto::network::snp::SimpleNetwork::wait_for_packet` now
+  returns `Option<Event>` instead of `&Event`.
 
 # uefi - v0.36.1 (2025-11-05)
 

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -270,8 +270,8 @@ impl SimpleNetwork {
     /// On QEMU, this event seems to never fire; it is suggested to verify that your implementation
     /// of UEFI properly implements this event before using it.
     #[must_use]
-    pub const fn wait_for_packet(&self) -> &Event {
-        unsafe { &*(ptr::from_ref(&self.0.wait_for_packet).cast::<Event>()) }
+    pub fn wait_for_packet(&self) -> Option<Event> {
+        unsafe { Event::from_ptr(self.0.wait_for_packet) }
     }
 
     /// Returns a reference to the Simple Network mode.


### PR DESCRIPTION
A reference to an `Event` is useless since every api takes an `&mut Event`, now we return the `Event` by value.

~~I also changed the name from `wait_for_packet` to `wait_for_packet_event` to match `Input::wait_for_key_event` and `Pointer::wait_for_input_event`.~~

Both of these are breaking changes but it's necessary since it's not usable as it is now.
