### PR TITLE
uefi: find_handles() and locate_handle() can return empty collection + doc improvements

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -15,6 +15,8 @@
   returns `Option<Event>` instead of `&Event`.
 - `Http::get_mode_data` doesn't consume a parameter anymore and instead return
   an owned value of type `HttpConfigData`
+- **Breaking:** `boot::find_handles()` and `boot::locate_handle()` no longer
+  return `Err` on `Status::NOT_FOUND` but instead an empty collection.
 
 # uefi - v0.36.1 (2025-11-05)
 


### PR DESCRIPTION
`uefi` is supposed to provide convenient and idiomatic high-level
abstractions. Currently, `find_handles()` and `locate_handle()` can 
never return `&[]` respectively `Vec::new()` as an empty response 
from the underlying UEFI boot service is always treated as Error
originating from `Status::NOT_FOUND`. 

We should not expose that UEFI implementation details to users. It is
more convenient for users to just check if the resulting slice/vector
is empty or not.

Closes #1854 

Steps to Undraft
- [ ] do what nicholas suggested [here](https://github.com/rust-osdev/uefi-rs/issues/1854#issuecomment-3703928068) instead as it is clearly the better solution

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
