### PR TITLE
workspace: switch to resolver v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "template",
     "uefi",


### PR DESCRIPTION
Default since Rust 2024 [0]. I am not sure if Cargo decided to use v2 instead of v3, but this way it is more correct in any way.

[0] https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
