### PR TITLE
uefi: serial: add read_exact() and write_exact() + fix core::fmt::Write for Serial

### DIFF
--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use core::fmt::Write;
 use uefi::mem::memory_map::MemoryMap;
 use uefi::prelude::*;
 use uefi::proto::console::serial::Serial;
@@ -115,7 +116,8 @@ fn send_request_helper(serial: &mut Serial, request: HostRequest) -> Result {
     serial.set_attributes(&io_mode)?;
 
     // Send a screenshot request to the host.
-    serial.write(request.as_bytes()).discard_errdata()?;
+    // We transitively test Serial::write_exact() and Serial::write()
+    write!(serial, "{}", request).expect("should write all bytes");
 
     // Wait for the host's acknowledgement before moving forward.
     let mut reply = [0; 3];

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **Breaking:** Renamed `DevicePathNode::to_string()` to `DevicePathNode::to_string16()`
   to better differentiate with the new `to_string()` coming from the new
   `Display`.
+- Fixed potential partial writes in `fmt::Write` impl for `Serial` protocol
 
 # uefi - v0.36.1 (2025-11-05)
 

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -10,6 +10,7 @@ use crate::proto::unsafe_protocol;
 use crate::{Error, Result, ResultExt, Status, StatusExt, boot};
 use core::time::Duration;
 use core::{cmp, fmt};
+use log::error;
 use uefi_raw::protocol::console::serial::{
     SerialIoProtocol, SerialIoProtocol_1_1, SerialIoProtocolRevision,
 };
@@ -420,7 +421,16 @@ impl Serial {
 
 impl fmt::Write for Serial {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.write(s.as_bytes()).map(|_| ()).map_err(|_| fmt::Error)
+        // We retry on Status::TIMEOUT but propagate other errors
+        self.write_exact(s.as_bytes()).map_err(|e| {
+            let msg = "failed to write to serial device";
+            // Simple check to prevent endless recursion if a logger
+            // implementation uses the serial protocol
+            if !s.contains(msg) {
+                error!("{msg}: {e}");
+            }
+            fmt::Error
+        })
     }
 }
 


### PR DESCRIPTION

**Serial Protocol Improvements**

* Added `Serial::read_exact()` and `Serial::write_exact()` methods, which block until the entire buffer is read or written, automatically retrying on timeouts and stalling based on baud rate to avoid busy-waiting. These methods help prevent partial I/O and improve reliability when communicating over serial devices. 
* Fixed the `fmt::Write` implementation for `Serial` to use `write_exact()`

**Timing and Reliability Enhancements**

* Introduced helper functions (`duration_per_byte_estimate` and `duration_fifo_estimate`) to conservatively estimate the time needed for serial operations, taking into account baud rate, data bits, parity, and stop bits. These are used to determine appropriate stalling durations between retries.

**Testing and Documentation**

* Added unit tests for the timing estimation logic to ensure correct behavior under various serial configurations.
* **I tested this on real hardware - multiple times**