### PR TITLE
Revert "ci/fix: upgrade QEMU on windows"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Install QEMU
-        run: choco install qemu --version 2025.12.24
+        run: choco install qemu --version 2023.4.24
       - name: Checkout sources
         uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -312,37 +312,19 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
         UefiArch::AArch64 => "qemu-system-aarch64",
         UefiArch::IA32 | UefiArch::X86_64 => "qemu-system-x86_64",
     };
+    let mut cmd = Command::new(qemu_exe);
 
-    // The QEMU installer for Windows does not automatically add the
-    // directory containing the QEMU executables to the PATH. Add
-    // the default directory to the PATH to make it more likely that
-    // QEMU will be found on Windows. (The directory is appended, so
-    // if a different directory on the PATH already has the QEMU
-    // binary this change won't affect anything.)
-    let fn_append_win_path = |cmd: &mut Command| {
+    if platform::is_windows() {
+        // The QEMU installer for Windows does not automatically add the
+        // directory containing the QEMU executables to the PATH. Add
+        // the default directory to the PATH to make it more likely that
+        // QEMU will be found on Windows. (The directory is appended, so
+        // if a different directory on the PATH already has the QEMU
+        // binary this change won't affect anything.)
         let mut path = env::var_os("PATH").unwrap_or_default();
         path.push(r";C:\Program Files\qemu");
         cmd.env("PATH", path);
-    };
-
-    // Print the QEMU version
-    {
-        let mut cmd = Command::new(qemu_exe);
-        if platform::is_windows() {
-            fn_append_win_path(&mut cmd)
-        };
-        cmd.arg("--version");
-        let output = cmd.output()?;
-        eprintln!("QEMU:");
-        eprintln!("  binary : {qemu_exe}");
-        eprintln!("  version: {}", String::from_utf8(output.stdout)?);
     }
-
-    // Construct the actual QEMU argument
-    let mut cmd = Command::new(qemu_exe);
-    if platform::is_windows() {
-        fn_append_win_path(&mut cmd)
-    };
 
     // Disable default devices.
     // QEMU by defaults enables a ton of devices which slow down boot.


### PR DESCRIPTION
Reverts rust-osdev/uefi-rs#1876

Since merging the update we're seeing a lot of CI failures that look like this:
```
Error: failed to open file `\\.\pipe\qemu-monitor`: The system cannot find the file specified. (os error 2)
```

It's not consistent, but it's happened enough times that I think something is going wrong with the new QEMU version. See for example:
* https://github.com/rust-osdev/uefi-rs/actions/runs/21346029768/job/61433835168
* https://github.com/rust-osdev/uefi-rs/actions/runs/21345927033/job/61433558978
* https://github.com/rust-osdev/uefi-rs/actions/runs/21342913699/job/61425203437
* https://github.com/rust-osdev/uefi-rs/actions/runs/21342850142/job/61425037981