### PR TITLE
Improve docs of `OpenProtocolAttributes`

### DIFF
--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1719,9 +1719,17 @@ impl Drop for TplGuard {
 #[repr(u32)]
 #[derive(Debug)]
 pub enum OpenProtocolAttributes {
-    /// Used by drivers to get a protocol interface for a handle. The
-    /// driver will not be informed if the interface is uninstalled or
-    /// reinstalled.
+    /// Used by applications and drivers to open a protocol interface for a
+    /// handle.
+    ///
+    /// # Safety
+    ///
+    /// The interface is opened non-exclusively. The caller must ensure that
+    /// either the interface is immutable, or that no conflicting concurrent
+    /// access occurs.
+    ///
+    /// The caller must ensure that the interface is not uninstalled or
+    /// reinstalled while still in use.
     GetProtocol = 0x02,
 
     /// Used by bus drivers to show that a protocol is being used by one


### PR DESCRIPTION
* Clarify that `GetProtocol` can be used for applications too, not just drivers
* Add safety docs to `GetProtocol`
* Add warning docs to `Exclusive` and `ByDriverExclusive` to explain why `GetProtocol` is often a better choice
* Sort the variants in numerical order (this is visible in the generated docs)

https://github.com/rust-osdev/uefi-rs/issues/1733

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
