### PR TITLE
uefi: improve handling of Time

### DIFF
--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -9,6 +9,7 @@ use crate::time::helpers::{
 use bitflags::bitflags;
 use core::cmp::Ordering;
 use core::fmt::{self, Display, Formatter};
+use core::time::Duration;
 
 /// Generic non-EFI helpers to work with time.
 mod helpers {
@@ -384,6 +385,23 @@ impl Time {
         let total_seconds = seconds - tz_offset_seconds;
 
         Some(total_seconds * NANOS_PER_SECOND + self.nanosecond as i128)
+    }
+
+    /// Returns the elapsed [`Duration`] since `other`, assuming that `self`
+    /// happened later than `other`.
+    ///
+    /// Both dates need to be valid ([`Self::is_valid`]).
+    #[must_use]
+    pub fn elapsed_since(&self, other: &Self) -> Option<Duration> {
+        let lhs = self.to_utc_unix_timestamp_nanos()?;
+        let rhs = other.to_utc_unix_timestamp_nanos()?;
+
+        if lhs < rhs {
+            return None;
+        }
+
+        let delta = (lhs - rhs) as u128;
+        Some(Duration::from_nanos(delta as u64))
     }
 }
 

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -48,6 +48,33 @@ impl Time {
     /// Indicates the time should be interpreted as local time.
     pub const UNSPECIFIED_TIMEZONE: i16 = 0x07ff;
 
+    /// Creates a new UEFI [`Time`] from UTC components.
+    #[must_use]
+    pub const fn from_utc_time(
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+    ) -> Self {
+        // TODO validate() + return result
+        Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            pad1: 0,
+            nanosecond,
+            time_zone: 0, // UTC
+            daylight: Daylight::empty(),
+            pad2: 0,
+        }
+    }
+
     /// Create an invalid `Time` with all fields set to zero.
     #[must_use]
     pub const fn invalid() -> Self {

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -5,6 +5,70 @@
 use bitflags::bitflags;
 use core::fmt::{self, Display, Formatter};
 
+/// Generic non-EFI helpers to work with time.
+#[allow(unused)]
+mod helpers {
+    #[inline]
+    pub const fn is_leap_year(year: i32) -> bool {
+        (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // ---------------------------
+        // is_leap_year: basic cases
+
+        #[test]
+        fn leap_years_divisible_by_4() {
+            assert!(is_leap_year(1996));
+            assert!(is_leap_year(2024));
+            assert!(is_leap_year(0)); // year 0 is divisible by 400
+        }
+
+        #[test]
+        fn common_years_not_divisible_by_4() {
+            assert!(!is_leap_year(1999));
+            assert!(!is_leap_year(2023));
+            assert!(!is_leap_year(1));
+        }
+
+        #[test]
+        fn centuries_not_divisible_by_400_are_not_leap_years() {
+            assert!(!is_leap_year(1700));
+            assert!(!is_leap_year(1800));
+            assert!(!is_leap_year(1900));
+            assert!(!is_leap_year(2100));
+        }
+
+        #[test]
+        fn centuries_divisible_by_400_are_leap_years() {
+            assert!(is_leap_year(1600));
+            assert!(is_leap_year(2000));
+            assert!(is_leap_year(2400));
+        }
+
+        // ------------------------------------
+        // is_leap_year: negative / boundary
+
+        #[test]
+        fn negative_years_follow_same_divisibility_rules() {
+            assert!(is_leap_year(-4));
+            assert!(!is_leap_year(-1));
+            assert!(!is_leap_year(-100));
+            assert!(is_leap_year(-400));
+        }
+
+        #[test]
+        fn i32_boundaries_do_not_overflow() {
+            // These tests ensure no arithmetic overflow or panic occurs
+            assert!(!is_leap_year(i32::MAX));
+            assert!(is_leap_year(i32::MIN)); // i32::MIN % 400 == 0
+        }
+    }
+}
+
 /// Date and time representation.
 #[derive(Debug, Default, Copy, Clone, Eq)]
 #[repr(C)]

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -24,6 +24,21 @@ mod helpers {
         }
     }
 
+    /// Days since Unix epoch (1970-01-01), ignoring time-of-day.
+    pub fn days_since_unix_epoch(year: i32, month: u8, day: u8) -> i64 {
+        let mut days = 0i64;
+
+        for y in 1970..year {
+            days += if is_leap_year(y) { 366 } else { 365 };
+        }
+
+        for m in 1..month {
+            days += days_in_month(year, m) as i64;
+        }
+
+        days + (day as i64 - 1)
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -133,6 +148,48 @@ mod helpers {
         #[should_panic(expected = "invalid month")]
         fn max_u8_month_panics() {
             days_in_month(2024, u8::MAX);
+        }
+
+        // --------------------------------
+        // days_since_unix_epoch:
+
+        #[test]
+        fn test_epoch_start() {
+            // January 1, 1970 should be exactly 0 days
+            assert_eq!(days_since_unix_epoch(1970, 1, 1), 0);
+        }
+
+        #[test]
+        fn test_first_year_completion() {
+            // December 31, 1970 (365 days in a non-leap year, so 364 days since Jan 1)
+            assert_eq!(days_since_unix_epoch(1970, 12, 31), 364);
+        }
+
+        #[test]
+        fn test_one_full_year() {
+            // January 1, 1971 should be 365 days after the epoch
+            assert_eq!(days_since_unix_epoch(1971, 1, 1), 365);
+        }
+
+        #[test]
+        fn test_leap_year_handling() {
+            // 1972 was a leap year.
+            // Days: 1970 (365) + 1971 (365) = 730
+            assert_eq!(days_since_unix_epoch(1972, 1, 1), 730);
+
+            // After February 29, 1972
+            // Jan (31) + Feb (29) = 60. So March 1st is day 60 of that year.
+            // Total: 730 + 60 = 790
+            assert_eq!(days_since_unix_epoch(1972, 3, 1), 790);
+        }
+
+        #[test]
+        fn test_modern_date() {
+            // January 1, 2000 (Y2K)
+            // Between 1970 and 2000, there are 30 years.
+            // Leap years: 1972, 76, 80, 84, 88, 92, 96 (7 leap years)
+            // (23 non-leap * 365) + (7 leap * 366) = 10957
+            assert_eq!(days_since_unix_epoch(2000, 1, 1), 10957);
         }
     }
 }

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -131,6 +131,10 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct Daylight: u8 {
+        /// Daylight information available or not applicable to this time
+        /// zone.
+        const NONE = 0;
+
         /// Time is affected by daylight savings time.
         const ADJUST_DAYLIGHT = 0x01;
 

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -13,6 +13,17 @@ mod helpers {
         (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
     }
 
+    #[inline]
+    pub fn days_in_month(year: i32, month: u8) -> u8 {
+        match month {
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            4 | 6 | 9 | 11 => 30,
+            2 if is_leap_year(year) => 29,
+            2 => 28,
+            v => panic!("invalid month: {v}"),
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -65,6 +76,63 @@ mod helpers {
             // These tests ensure no arithmetic overflow or panic occurs
             assert!(!is_leap_year(i32::MAX));
             assert!(is_leap_year(i32::MIN)); // i32::MIN % 400 == 0
+        }
+
+        // ---------------------------
+        // days_in_month: fixed months
+
+        #[test]
+        fn months_with_31_days() {
+            let months = [1, 3, 5, 7, 8, 10, 12];
+            for &m in &months {
+                assert_eq!(days_in_month(2023, m), 31);
+                assert_eq!(days_in_month(2024, m), 31); // leap year should not matter
+            }
+        }
+
+        #[test]
+        fn months_with_30_days() {
+            let months = [4, 6, 9, 11];
+            for &m in &months {
+                assert_eq!(days_in_month(2023, m), 30);
+                assert_eq!(days_in_month(2024, m), 30);
+            }
+        }
+
+        // ---------------------------
+        // days_in_month: February
+
+        #[test]
+        fn february_in_common_year() {
+            assert_eq!(days_in_month(2023, 2), 28);
+            assert_eq!(days_in_month(1900, 2), 28); // century common year
+        }
+
+        #[test]
+        fn february_in_leap_year() {
+            assert_eq!(days_in_month(2024, 2), 29);
+            assert_eq!(days_in_month(2000, 2), 29); // century leap year
+        }
+
+        // --------------------------------
+        // days_in_month: invalid months
+
+        #[test]
+        #[should_panic(expected = "invalid month")]
+        fn month_zero_panics() {
+            days_in_month(2024, 0);
+        }
+
+        #[test]
+        #[should_panic(expected = "invalid month")]
+        fn month_above_12_panics() {
+            days_in_month(2024, 13);
+        }
+
+        #[test]
+        #[should_panic(expected = "invalid month")]
+        fn max_u8_month_panics() {
+            days_in_month(2024, u8::MAX);
         }
     }
 }

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Date and time types.
+//!
+//! See [`Time`].
 
 use crate::time::helpers::{
     NANOS_PER_SECOND, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, days_in_month,
@@ -205,6 +207,13 @@ mod helpers {
 }
 
 /// Date and time representation.
+///
+/// # Integration
+///
+/// The type can be integrated with higher-level time libraries by using the
+/// UTC UNIX timestamp in nanoseconds as exchange format. See:
+/// - [`Self::from_utc_unix_timestamp_nanos`]
+/// - [`Self::to_utc_unix_timestamp_nanos`]
 #[derive(Debug, Default, Copy, Clone, Eq)]
 #[repr(C)]
 pub struct Time {

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -6,6 +6,7 @@ use crate::time::helpers::{
     NANOS_PER_SECOND, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE, days_since_unix_epoch,
 };
 use bitflags::bitflags;
+use core::cmp::Ordering;
 use core::fmt::{self, Display, Formatter};
 
 /// Generic non-EFI helpers to work with time.
@@ -373,6 +374,14 @@ impl PartialEq for Time {
             && self.nanosecond == other.nanosecond
             && self.time_zone == other.time_zone
             && self.daylight == other.daylight
+    }
+}
+
+impl PartialOrd for Time {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let lhs = self.to_utc_unix_timestamp_nanos()?;
+        let rhs = other.to_utc_unix_timestamp_nanos()?;
+        lhs.partial_cmp(&rhs)
     }
 }
 


### PR DESCRIPTION
This is a larger PR improving the handling of `struct Time` from `uefi-raw`. On a very high level, we can convert a UEFI time to UNIX UTC Timestamps in nanoseconds and also create it from such a timestamp.

This allows:
- integration into time libraries on higher-levels
- PartialOrd
- `elapsed_since(&self, future: &Self) -> Option<Duration> {}`

## Hints for Reviewers

- It would make sense to only discuss the higher-level approach here and taking a coarse-grained look onto the commit history
- I will then split this into more reviewable commits

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
