### PR TITLE
uefi-raw: time feature with conversions to/from OffsetDateTime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +507,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -838,6 +859,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +976,7 @@ name = "uefi-raw"
 version = "0.13.0"
 dependencies = [
  "bitflags 2.10.0",
+ "time",
  "uguid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.88"
 bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
+time = { version = "0.3", default-features = false, features = [] }
 uguid = "2.2.1"
 
 [patch.crates-io]

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -16,6 +16,7 @@
   `OffsetDateTime` from the [time crate](https://crates.io/crates/time).
   - `Time::to_offset_date_time`
   - `Time::to_offset_date_time_with_default_timezone`
+  - implemented `TryFrom` from `OffsetDateTime` for `Time`
 
 ## Changed
 - Switched `*const Self` to `*mut Self` in `SerialIoProtocol::set_attributes()`

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Added new type `SerialIoProtocolRevision`
 - Added new type `SerialIoProtocol_1_1` as companion for `SerialIoProtocol`
   that includes the  `device_type_guid` parameter
+- Added the `time` feature which integrates `struct Time` closely with
+  `OffsetDateTime` from the [time crate](https://crates.io/crates/time).
+  - `Time::to_offset_date_time`
+  - `Time::to_offset_date_time_with_default_timezone`
 
 ## Changed
 - Switched `*const Self` to `*mut Self` in `SerialIoProtocol::set_attributes()`

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -20,7 +20,12 @@ rust-version = "1.85.1"
 
 [dependencies]
 bitflags.workspace = true
+time = { workspace = true, optional = true }
 uguid.workspace = true
+
+[features]
+default = ["time"]
+time = ["dep:time"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -131,6 +131,10 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct Daylight: u8 {
+        /// Daylight information not available or not applicable to the time
+        /// zone.
+        const NONE = 0;
+
         /// Time is affected by daylight savings time.
         const ADJUST_DAYLIGHT = 0x01;
 

--- a/uefi-raw/src/time.rs
+++ b/uefi-raw/src/time.rs
@@ -2,69 +2,11 @@
 
 //! Date and time types.
 
+#[cfg(feature = "time")]
+pub use time_crate_integration::*;
+
 use bitflags::bitflags;
-use core::error;
 use core::fmt::{self, Display, Formatter};
-#[cfg(feature = "time")]
-use time::{OffsetDateTime, UtcOffset};
-
-/// The time is invalid as it doesn't fulfill the requirements of
-/// [`Time::is_valid`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg(feature = "time")]
-pub struct InvalidTimeError(Time);
-
-#[cfg(feature = "time")]
-impl Display for InvalidTimeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Invalid EFI time (not valid): {}", self.0)
-    }
-}
-
-#[cfg(feature = "time")]
-impl error::Error for InvalidTimeError {}
-
-/// Errors that can happen when converting a [`Time`] to a [`OffsetDateTime`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg(feature = "time")]
-pub enum ToOffsetDateTimeError {
-    /// See [`InvalidTimeError`].
-    Invalid(InvalidTimeError),
-    /// The timezone is a valid EFI value but [`Time::UNSPECIFIED_TIMEZONE`]
-    /// means `local` which cannot be determined in a `no_std` context.
-    UnspecifiedTimezone,
-    /// The corresponding component has an invalid range (e.g. February 30th).
-    ComponentRange(time::error::ComponentRange),
-}
-
-#[cfg(feature = "time")]
-impl Display for ToOffsetDateTimeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Invalid(e) => {
-                write!(f, "Cannot convert to OffsetDateTime: {}", e)
-            }
-            Self::UnspecifiedTimezone => write!(
-                f,
-                "Cannot convert to OffsetDateTime: the timezone (local) can't be determined in a no_std context"
-            ),
-            Self::ComponentRange(e) => {
-                write!(f, "Cannot convert to OffsetDateTime: {}", e)
-            }
-        }
-    }
-}
-
-#[cfg(feature = "time")]
-impl error::Error for ToOffsetDateTimeError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::Invalid(e) => Some(e),
-            Self::UnspecifiedTimezone => None,
-            Self::ComponentRange(e) => Some(e),
-        }
-    }
-}
 
 /// Date and time representation.
 ///
@@ -119,150 +61,6 @@ pub struct Time {
 impl Time {
     /// Indicates the time should be interpreted as local time.
     pub const UNSPECIFIED_TIMEZONE: i16 = 0x07ff;
-
-    #[cfg(feature = "time")]
-    fn _to_offset_date_time(
-        &self,
-        local_timezone: Option<UtcOffset>,
-    ) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
-        if !self.is_valid() {
-            return Err(ToOffsetDateTimeError::Invalid(InvalidTimeError(*self)));
-        }
-
-        // Special handling for `UNSPECIFIED_TIMEZONE` (local):
-        // - specific time zone => all good
-        // - `UNSPECIFIED_TIMEZONE` and no default time zone => return Err
-        // - else: use the default time zone
-        let offset_hms: (i8, i8, i8) = {
-            if self.time_zone == Self::UNSPECIFIED_TIMEZONE {
-                if let Some(local_timezone) = local_timezone {
-                    local_timezone.as_hms()
-                } else {
-                    return Err(ToOffsetDateTimeError::UnspecifiedTimezone);
-                }
-            } else {
-                let h = self.time_zone / 60;
-                let m = self.time_zone % 60;
-
-                (h as i8, m as i8, 0)
-            }
-        };
-
-        // Emulated try {} block to keep the `?` error propagation scoped
-        // (we have a different error type here)
-        let datetime: Result<OffsetDateTime, time::error::ComponentRange> = (|| {
-            let month = time::Month::try_from(self.month)?;
-            let date = time::Date::from_calendar_date(self.year as i32, month, self.day)?;
-            let time =
-                time::Time::from_hms_nano(self.hour, self.minute, self.second, self.nanosecond)?;
-            let offset = UtcOffset::from_hms(offset_hms.0, offset_hms.1, offset_hms.2)?;
-            Ok(OffsetDateTime::new_in_offset(date, time, offset))
-        })();
-
-        datetime.map_err(ToOffsetDateTimeError::ComponentRange)
-    }
-
-    /// Converts this [`Time`] to a [`OffsetDateTime`] using the UTC offset
-    /// stored in `self.time_zone`.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(OffsetDateTime)` if the time is valid and the timezone is fully
-    ///   specified (not `UNSPECIFIED_TIMEZONE`).
-    /// - `Err(ToOffsetDateTimeError::Invalid(_))` if any of the time fields are
-    ///   out of valid EFI ranges (e.g., year < 1900, month > 12).
-    /// - `Err(ToOffsetDateTimeError::UnspecifiedTimezone)` if the timezone is
-    ///   `UNSPECIFIED_TIMEZONE`, since no default local timezone was provided.
-    /// - `Err(ToOffsetDateTimeError::ComponentRange(_))` if the combination of
-    ///   fields results in an invalid calendar date (e.g., February 30th).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use uefi_raw::time::{Time, ToOffsetDateTimeError};
-    /// # use time::OffsetDateTime;
-    /// let t = Time {
-    ///     year: 2024,
-    ///     month: 3,
-    ///     day: 15,
-    ///     hour: 12,
-    ///     minute: 0,
-    ///     second: 0,
-    ///     pad1: 0,
-    ///     nanosecond: 0,
-    ///     time_zone: 0, // UTC
-    ///     daylight: Default::default(),
-    ///     pad2: 0,
-    /// };
-    ///
-    /// let odt: OffsetDateTime = t.to_offset_date_time().unwrap();
-    /// assert_eq!(odt.offset().whole_seconds(), 0);
-    /// ```
-    #[cfg(feature = "time")]
-    pub fn to_offset_date_time(&self) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
-        self._to_offset_date_time(None)
-    }
-
-    /// Converts this [`Time`] to a [`OffsetDateTime`] using a provided default
-    /// timezone when `self.time_zone` is [`Self::UNSPECIFIED_TIMEZONE`].
-    ///
-    /// If the stored `time_zone` field is `UNSPECIFIED_TIMEZONE`, this method
-    /// uses the provided `local` [`UtcOffset`] as the offset. Otherwise, the
-    /// stored `time_zone` in minutes is used.
-    ///
-    /// # Arguments
-    ///
-    /// - `local`: The default [`UtcOffset`] to use if `time_zone` is
-    ///   [`Self::UNSPECIFIED_TIMEZONE`].
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(OffsetDateTime)` if the time is valid and the offset can be
-    ///   applied successfully.
-    /// - `Err(ToOffsetDateTimeError::Invalid(_))` if any of the time fields are
-    ///   out of valid EFI ranges.
-    /// - `Err(ToOffsetDateTimeError::ComponentRange(_))` if the combination of
-    ///   fields results in an invalid calendar date.
-    ///
-    /// # Panics
-    ///
-    /// This function does **not panic** under normal usage. It is impossible
-    /// for `UnspecifiedTimezone` to be returned because the caller provides
-    /// a valid default offset.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use uefi_raw::time::{Time, ToOffsetDateTimeError};
-    /// # use time::{OffsetDateTime, UtcOffset};
-    /// let mut t = Time {
-    ///     year: 2024,
-    ///     month: 3,
-    ///     day: 15,
-    ///     hour: 12,
-    ///     minute: 0,
-    ///     second: 0,
-    ///     pad1: 0,
-    ///     nanosecond: 0,
-    ///     time_zone: Time::UNSPECIFIED_TIMEZONE,
-    ///     daylight: Default::default(),
-    ///     pad2: 0,
-    /// };
-    ///
-    /// let default_offset = UtcOffset::from_hms(1, 30, 0).unwrap();
-    /// let odt: OffsetDateTime = t.to_offset_date_time_with_default_timezone(default_offset).unwrap();
-    /// assert_eq!(odt.offset(), default_offset);
-    /// ```
-    #[cfg(feature = "time")]
-    pub fn to_offset_date_time_with_default_timezone(
-        &self,
-        local: UtcOffset,
-    ) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
-        match self._to_offset_date_time(Some(local)) {
-            Err(ToOffsetDateTimeError::UnspecifiedTimezone) => unreachable!(),
-            other => other,
-        }
-    }
 
     /// Create an invalid `Time` with all fields set to zero.
     #[must_use]
@@ -360,79 +158,281 @@ bitflags! {
 }
 
 #[cfg(feature = "time")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FromOffsetDateTimeError {
-    /// The year is not representable as `u16`.
-    InvalidYear(i32),
-    /// Time zone offsets with seconds are not representable.
-    OffsetWithSeconds(i8),
-    InvalidTime(InvalidTimeError),
-}
+mod time_crate_integration {
+    use super::*;
+    use core::error;
+    use time::{OffsetDateTime, UtcOffset};
 
-#[cfg(feature = "time")]
-impl Display for FromOffsetDateTimeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidYear(y) => {
-                write!(
-                    f,
-                    "Cannot to convert OffsetDateTime to EFI Time: invalid year {y}"
-                )
-            }
-            Self::OffsetWithSeconds(s) => {
-                write!(
-                    f,
-                    "Cannot to convert OffsetDateTime to EFI Time: time zone offset has seconds ({s}) which is unsupported"
-                )
-            }
-            Self::InvalidTime(t) => {
-                write!(f, "The time is invalid: {t}")
-            }
+    /// The time is invalid as it doesn't fulfill the requirements of
+    /// [`Time::is_valid`].
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub struct InvalidTimeError(Time);
+
+    impl Display for InvalidTimeError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write!(f, "Invalid EFI time (not valid): {}", self.0)
         }
     }
-}
 
-#[cfg(feature = "time")]
-impl error::Error for FromOffsetDateTimeError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::InvalidYear(_) => None,
-            Self::OffsetWithSeconds(_) => None,
-            Self::InvalidTime(e) => Some(e),
-        }
+    impl error::Error for InvalidTimeError {}
+
+    /// Errors that can happen when converting a [`Time`] to a [`OffsetDateTime`].
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum ToOffsetDateTimeError {
+        /// See [`InvalidTimeError`].
+        Invalid(InvalidTimeError),
+        /// The timezone is a valid EFI value but [`Time::UNSPECIFIED_TIMEZONE`]
+        /// means `local` which cannot be determined in a `no_std` context.
+        UnspecifiedTimezone,
+        /// The corresponding component has an invalid range (e.g. February 30th).
+        ComponentRange(time::error::ComponentRange),
     }
-}
 
-#[cfg(feature = "time")]
-impl TryFrom<OffsetDateTime> for Time {
-    type Error = FromOffsetDateTimeError;
-
-    fn try_from(value: OffsetDateTime) -> Result<Self, Self::Error> {
-        let this = Self {
-            year: u16::try_from(value.date().year())
-                .map_err(|_| Self::Error::InvalidYear(value.date().year()))?,
-            // No checks needed: underlying type has repr `u8`
-            month: value.date().month() as u8,
-            day: value.date().day(),
-            hour: value.time().hour(),
-            minute: value.time().minute(),
-            second: value.time().second(),
-            pad1: 0,
-            nanosecond: value.time().nanosecond(),
-            time_zone: {
-                let (h, m, s) = value.offset().as_hms();
-                if s != 0 {
-                    return Err(Self::Error::OffsetWithSeconds(s));
+    impl Display for ToOffsetDateTimeError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Invalid(e) => {
+                    write!(f, "Cannot convert to OffsetDateTime: {}", e)
                 }
-                (h as i16 * 60) + (m as i16)
-            },
-            daylight: Daylight::NONE,
-            pad2: 0,
-        };
-        if this.is_valid() {
-            Ok(this)
-        } else {
-            Err(Self::Error::InvalidTime(InvalidTimeError(this)))
+                Self::UnspecifiedTimezone => write!(
+                    f,
+                    "Cannot convert to OffsetDateTime: the timezone (local) can't be determined in a no_std context"
+                ),
+                Self::ComponentRange(e) => {
+                    write!(f, "Cannot convert to OffsetDateTime: {}", e)
+                }
+            }
+        }
+    }
+
+    impl error::Error for ToOffsetDateTimeError {
+        fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+            match self {
+                Self::Invalid(e) => Some(e),
+                Self::UnspecifiedTimezone => None,
+                Self::ComponentRange(e) => Some(e),
+            }
+        }
+    }
+
+    impl Time {
+        fn _to_offset_date_time(
+            &self,
+            local_timezone: Option<UtcOffset>,
+        ) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
+            if !self.is_valid() {
+                return Err(ToOffsetDateTimeError::Invalid(InvalidTimeError(*self)));
+            }
+
+            // Special handling for `UNSPECIFIED_TIMEZONE` (local):
+            // - specific time zone => all good
+            // - `UNSPECIFIED_TIMEZONE` and no default time zone => return Err
+            // - else: use the default time zone
+            let offset_hms: (i8, i8, i8) = {
+                if self.time_zone == Self::UNSPECIFIED_TIMEZONE {
+                    if let Some(local_timezone) = local_timezone {
+                        local_timezone.as_hms()
+                    } else {
+                        return Err(ToOffsetDateTimeError::UnspecifiedTimezone);
+                    }
+                } else {
+                    let h = self.time_zone / 60;
+                    let m = self.time_zone % 60;
+
+                    (h as i8, m as i8, 0)
+                }
+            };
+
+            // Emulated try {} block to keep the `?` error propagation scoped
+            // (we have a different error type here)
+            let datetime: Result<OffsetDateTime, time::error::ComponentRange> = (|| {
+                let month = time::Month::try_from(self.month)?;
+                let date = time::Date::from_calendar_date(self.year as i32, month, self.day)?;
+                let time = time::Time::from_hms_nano(
+                    self.hour,
+                    self.minute,
+                    self.second,
+                    self.nanosecond,
+                )?;
+                let offset = UtcOffset::from_hms(offset_hms.0, offset_hms.1, offset_hms.2)?;
+                Ok(OffsetDateTime::new_in_offset(date, time, offset))
+            })();
+
+            datetime.map_err(ToOffsetDateTimeError::ComponentRange)
+        }
+
+        /// Converts this [`Time`] to a [`OffsetDateTime`] using the UTC offset
+        /// stored in `self.time_zone`.
+        ///
+        /// # Returns
+        ///
+        /// - `Ok(OffsetDateTime)` if the time is valid and the timezone is fully
+        ///   specified (not `UNSPECIFIED_TIMEZONE`).
+        /// - `Err(ToOffsetDateTimeError::Invalid(_))` if any of the time fields are
+        ///   out of valid EFI ranges (e.g., year < 1900, month > 12).
+        /// - `Err(ToOffsetDateTimeError::UnspecifiedTimezone)` if the timezone is
+        ///   `UNSPECIFIED_TIMEZONE`, since no default local timezone was provided.
+        /// - `Err(ToOffsetDateTimeError::ComponentRange(_))` if the combination of
+        ///   fields results in an invalid calendar date (e.g., February 30th).
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use uefi_raw::time::{Time, ToOffsetDateTimeError};
+        /// # use time::OffsetDateTime;
+        /// let t = Time {
+        ///     year: 2024,
+        ///     month: 3,
+        ///     day: 15,
+        ///     hour: 12,
+        ///     minute: 0,
+        ///     second: 0,
+        ///     pad1: 0,
+        ///     nanosecond: 0,
+        ///     time_zone: 0, // UTC
+        ///     daylight: Default::default(),
+        ///     pad2: 0,
+        /// };
+        ///
+        /// let odt: OffsetDateTime = t.to_offset_date_time().unwrap();
+        /// assert_eq!(odt.offset().whole_seconds(), 0);
+        /// ```
+        pub fn to_offset_date_time(&self) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
+            self._to_offset_date_time(None)
+        }
+
+        /// Converts this [`Time`] to a [`OffsetDateTime`] using a provided default
+        /// timezone when `self.time_zone` is [`Self::UNSPECIFIED_TIMEZONE`].
+        ///
+        /// If the stored `time_zone` field is `UNSPECIFIED_TIMEZONE`, this method
+        /// uses the provided `local` [`UtcOffset`] as the offset. Otherwise, the
+        /// stored `time_zone` in minutes is used.
+        ///
+        /// # Arguments
+        ///
+        /// - `local`: The default [`UtcOffset`] to use if `time_zone` is
+        ///   [`Self::UNSPECIFIED_TIMEZONE`].
+        ///
+        /// # Returns
+        ///
+        /// - `Ok(OffsetDateTime)` if the time is valid and the offset can be
+        ///   applied successfully.
+        /// - `Err(ToOffsetDateTimeError::Invalid(_))` if any of the time fields are
+        ///   out of valid EFI ranges.
+        /// - `Err(ToOffsetDateTimeError::ComponentRange(_))` if the combination of
+        ///   fields results in an invalid calendar date.
+        ///
+        /// # Panics
+        ///
+        /// This function does **not panic** under normal usage. It is impossible
+        /// for `UnspecifiedTimezone` to be returned because the caller provides
+        /// a valid default offset.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use uefi_raw::time::{Time, ToOffsetDateTimeError};
+        /// # use time::{OffsetDateTime, UtcOffset};
+        /// let mut t = Time {
+        ///     year: 2024,
+        ///     month: 3,
+        ///     day: 15,
+        ///     hour: 12,
+        ///     minute: 0,
+        ///     second: 0,
+        ///     pad1: 0,
+        ///     nanosecond: 0,
+        ///     time_zone: Time::UNSPECIFIED_TIMEZONE,
+        ///     daylight: Default::default(),
+        ///     pad2: 0,
+        /// };
+        ///
+        /// let default_offset = UtcOffset::from_hms(1, 30, 0).unwrap();
+        /// let odt: OffsetDateTime = t.to_offset_date_time_with_default_timezone(default_offset).unwrap();
+        /// assert_eq!(odt.offset(), default_offset);
+        /// ```
+        pub fn to_offset_date_time_with_default_timezone(
+            &self,
+            local: UtcOffset,
+        ) -> Result<OffsetDateTime, ToOffsetDateTimeError> {
+            match self._to_offset_date_time(Some(local)) {
+                Err(ToOffsetDateTimeError::UnspecifiedTimezone) => unreachable!(),
+                other => other,
+            }
+        }
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum FromOffsetDateTimeError {
+        /// The year is not representable as `u16`.
+        InvalidYear(i32),
+        /// Time zone offsets with seconds are not representable.
+        OffsetWithSeconds(i8),
+        InvalidTime(InvalidTimeError),
+    }
+
+    impl Display for FromOffsetDateTimeError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::InvalidYear(y) => {
+                    write!(
+                        f,
+                        "Cannot to convert OffsetDateTime to EFI Time: invalid year {y}"
+                    )
+                }
+                Self::OffsetWithSeconds(s) => {
+                    write!(
+                        f,
+                        "Cannot to convert OffsetDateTime to EFI Time: time zone offset has seconds ({s}) which is unsupported"
+                    )
+                }
+                Self::InvalidTime(t) => {
+                    write!(f, "The time is invalid: {t}")
+                }
+            }
+        }
+    }
+
+    impl error::Error for FromOffsetDateTimeError {
+        fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+            match self {
+                Self::InvalidYear(_) => None,
+                Self::OffsetWithSeconds(_) => None,
+                Self::InvalidTime(e) => Some(e),
+            }
+        }
+    }
+
+    impl TryFrom<OffsetDateTime> for Time {
+        type Error = FromOffsetDateTimeError;
+
+        fn try_from(value: OffsetDateTime) -> Result<Self, Self::Error> {
+            let this = Self {
+                year: u16::try_from(value.date().year())
+                    .map_err(|_| Self::Error::InvalidYear(value.date().year()))?,
+                // No checks needed: underlying type has repr `u8`
+                month: value.date().month() as u8,
+                day: value.date().day(),
+                hour: value.time().hour(),
+                minute: value.time().minute(),
+                second: value.time().second(),
+                pad1: 0,
+                nanosecond: value.time().nanosecond(),
+                time_zone: {
+                    let (h, m, s) = value.offset().as_hms();
+                    if s != 0 {
+                        return Err(Self::Error::OffsetWithSeconds(s));
+                    }
+                    (h as i16 * 60) + (m as i16)
+                },
+                daylight: Daylight::NONE,
+                pad2: 0,
+            };
+            if this.is_valid() {
+                Ok(this)
+            } else {
+                Err(Self::Error::InvalidTime(InvalidTimeError(this)))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `time` feature that enables interoperability between our EFI `Time` struct and the `time` crate's `OffsetDateTime` type. The goal is to make it easier to work with standard Rust time types while maintaining the safety and validation guarantees of the `Time` struct.

The PR only focuses on uefi-raw, `uefi` follows in a next step.

This replaces #1896 as it is clearly a better strategy to move as much of the time handling as possible into a bulletproof crate. I decided to go with `time` as it is the defacto standard of the ecosystem.

## Highlights

1. **New conversions**  
   - `Time::to_offset_date_time()` -> converts a valid `Time` into an `OffsetDateTime` in UTC or using a provided default local timezone.  
   - `Time::to_offset_date_time_with_default_timezone(local: UtcOffset)` -> handles `UNSPECIFIED_TIMEZONE` safely with an optional local offset.  
   - `TryFrom<OffsetDateTime>` for `Time` -> allows converting standard Rust times into EFI `Time`, with proper error handling for unrepresentable years or offsets with non-zero seconds.

2. **Error handling**  
   - Introduced `ToOffsetDateTimeError` and `FromOffsetDateTimeError` for detailed conversion errors.  
   - Covers invalid years, invalid components, unspecified timezone in no_std, and offsets with seconds.

3. **Comprehensive unit tests**  
   - Tests for all public methods, including boundary cases (nanoseconds, offsets, years).  
   - Conversion round-trips validated where possible.  
   - I used an LLM (ChatGPT) as sparring partner - very helpful!

## Benefits

- Makes `Time` more ergonomic to use with standard Rust time APIs.  
- More bulletproof than #1896 

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
