### PR TITLE
uefi: Add integration with crates `jiff` and `time` for `struct Time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +547,21 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -976,6 +1013,7 @@ version = "0.37.0"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
+ "jiff",
  "log",
  "ptr_meta",
  "qemu-exit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +525,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -863,6 +884,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +979,7 @@ dependencies = [
  "log",
  "ptr_meta",
  "qemu-exit",
+ "time",
  "ucs2",
  "uefi-macros",
  "uefi-raw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.91"
 [workspace.dependencies]
 bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
+jiff = { version = "0.2", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
 qemu-exit = { version = "4.0.0" }
 time = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
 qemu-exit = { version = "4.0.0" }
+time = { version = "0.3", default-features = false }
 uguid = "2.2.1"
 
 [patch.crates-io]

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Added `Serial::read_exact()` and `Serial::write_exact()`
 - `CStr16::from_bytes_with_nul()`: This is especially useful to transform the
   retrieved value from a UEFI variable into a UCS2 (CStr16) string.
+- Integration of `Time` with `time` crate
+  - `TryFrom`: `time::PrimitiveDateTime <--> Time` (without timezone)
+  - `TryFrom`: `time::OffsetDateTime <--> Time` (with timezone)
 
 ## Changed
 - export all `text::{input, output}::*` types

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Integration of `Time` with `time` crate
   - `TryFrom`: `time::PrimitiveDateTime <--> Time` (without timezone)
   - `TryFrom`: `time::OffsetDateTime <--> Time` (with timezone)
+- Integration of `Time` with `jiff` crate
+  - `TryFrom`: `jiff::DateTime <--> Time` (without timezone)
+  - `TryFrom`: `jiff::Zoned <--> Time` (with timezone)
 
 ## Changed
 - export all `text::{input, output}::*` types

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -20,6 +20,8 @@ rust-version.workspace = true
 # KEEP this feature list in sync with doc in uefi/lib.rs!
 default = [ ]
 alloc = []
+# Integration with time crate `>= v0.3`
+time03 = ["dep:time"]
 
 # Generic gate to code that uses unstable features of Rust, needing a nightly
 # toolchain.
@@ -39,6 +41,7 @@ log-debugcon = []
 bitflags.workspace = true
 log.workspace = true
 ptr_meta.workspace = true
+time = { workspace = true, optional = true }
 qemu-exit = { workspace = true, optional = true }
 uguid.workspace = true
 cfg-if = "1.0.0"

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -20,6 +20,8 @@ rust-version.workspace = true
 # KEEP this feature list in sync with doc in uefi/lib.rs!
 default = [ ]
 alloc = []
+# Integration with jiff crate `>= v0.2`
+jiff02 = ["dep:jiff"]
 # Integration with time crate `>= v0.3`
 time03 = ["dep:time"]
 
@@ -41,6 +43,7 @@ log-debugcon = []
 bitflags.workspace = true
 log.workspace = true
 ptr_meta.workspace = true
+jiff = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
 qemu-exit = { workspace = true, optional = true }
 uguid.workspace = true

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -142,6 +142,9 @@
 //!   using this feature, or no allocator at all if you don't need to
 //!   dynamically allocate any memory. Note that even without that feature,
 //!   some code might use the internal UEFI allocator.
+//! - `jiff02`: Integration of [`runtime::Time`] with the `jiff` crate
+//!   (version 0.2 and possible above). Specifically, it integrates the time
+//!   struct with `DateTime` and `Zoned` via `TryFrom`.
 //! - `logger`: Logging implementation for the standard [`log`] crate
 //!   that prints output to the UEFI console. No buffering is done; this
 //!   is not a high-performance logger.

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -148,6 +148,9 @@
 //! - `log-debugcon`: Whether the logger set up by `logger` should also log
 //!   to the debugcon device (available in QEMU or Cloud Hypervisor on x86).
 //! - `panic_handler`: Add a default panic handler that logs to `stdout`.
+//! - `time03`: Integration of [`runtime::Time`] with the `time` crate
+//!   (version 0.3 and possible above). Specifically, it integrates the time
+//!   struct with `PrimitiveDateTime` and `OffsetDateTime` via `TryFrom`.
 //! - `unstable`: Enable functionality that depends on [unstable features] in
 //!   the Rust compiler (nightly version).
 //! - `qemu`: Enable some code paths to adapt their execution when executed

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -43,6 +43,9 @@ pub(super) enum ConversionErrorInner {
     /// Errors raised in the [`time`] crate.
     #[cfg(feature = "time03")]
     TimeCrateError(time::Error),
+    /// Errors raised in the [`jiff`] crate.
+    #[cfg(feature = "jiff02")]
+    JiffCrateError(jiff::Error),
 }
 
 impl Display for ConversionErrorInner {
@@ -53,6 +56,8 @@ impl Display for ConversionErrorInner {
             Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
             #[cfg(feature = "time03")]
             Self::TimeCrateError(e) => write!(f, "Time crate error: {}", e),
+            #[cfg(feature = "jiff02")]
+            Self::JiffCrateError(e) => write!(f, "Jiff crate error: {}", e),
         }
     }
 }
@@ -65,6 +70,9 @@ impl Error for ConversionErrorInner {
             Self::UnspecifiedTimezone => None,
             #[cfg(feature = "time03")]
             Self::TimeCrateError(e) => Some(e),
+            // None: Missing Error trait
+            #[cfg(feature = "jiff02")]
+            Self::JiffCrateError(_e) => None,
         }
     }
 }

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -78,7 +78,6 @@ impl Error for ConversionErrorInner {
 }
 
 #[cfg(test)]
-#[allow(unused)]
 pub(super) mod test_helpers {
     use super::*;
     use crate::runtime::TimeParams;

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -76,3 +76,107 @@ impl Error for ConversionErrorInner {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(unused)]
+pub(super) mod test_helpers {
+    use super::*;
+    use crate::runtime::TimeParams;
+    use uefi::runtime::Time;
+    use uefi_raw::time::Daylight;
+
+    pub fn sample_time(tz: i16) -> Time {
+        let params = TimeParams {
+            year: 2024,
+            month: 3,
+            day: 14,
+            hour: 12,
+            minute: 34,
+            second: 56,
+            nanosecond: 123_456_789,
+            time_zone: Some(tz),
+            daylight: Daylight::default(),
+        };
+        Time::new(params).unwrap()
+    }
+
+    fn invalid_date() -> Time {
+        let mut t = sample_time(0);
+        t.0.month = 2;
+        t.0.day = 31;
+        t
+    }
+
+    pub fn primitive_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError> + TryInto<Time, Error = ConversionError>,
+    {
+        let t = sample_time(Time::UNSPECIFIED_TIMEZONE);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.year, t.0.year);
+        assert_eq!(back.0.month, t.0.month);
+        assert_eq!(back.0.day, t.0.day);
+        assert_eq!(back.0.hour, t.0.hour);
+        assert_eq!(back.0.minute, t.0.minute);
+        assert_eq!(back.0.second, t.0.second);
+        assert_eq!(back.0.nanosecond, t.0.nanosecond);
+    }
+
+    pub fn zoned_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError> + TryInto<Time, Error = ConversionError>,
+    {
+        let t = sample_time(120);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 120);
+        assert_eq!(back.0.hour, t.0.hour);
+        assert_eq!(back.0.minute, t.0.minute);
+    }
+
+    pub fn negative_offset_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError> + TryInto<Time, Error = ConversionError>,
+    {
+        let t = sample_time(-330);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
+    }
+
+    pub fn preserves_nanoseconds<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError> + TryInto<Time, Error = ConversionError>,
+    {
+        let t = sample_time(60);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.nanosecond, 123_456_789);
+    }
+
+    pub fn unspecified_timezone_fails<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError>,
+    {
+        let t = sample_time(Time::UNSPECIFIED_TIMEZONE);
+        let result: Result<T, _> = t.try_into();
+        assert!(result.is_err());
+    }
+
+    pub fn invalid_calendar_date_fails<T>()
+    where
+        T: TryFrom<Time, Error = ConversionError>,
+    {
+        let result: Result<T, _> = invalid_date().try_into();
+        assert!(result.is_err());
+    }
+}

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -40,6 +40,9 @@ pub(super) enum ConversionErrorInner {
     ///
     /// [`Time::UNSPECIFIED_TIMEZONE`]: super::Time::UNSPECIFIED_TIMEZONE
     UnspecifiedTimezone,
+    /// Errors raised in the [`time`] crate.
+    #[cfg(feature = "time03")]
+    TimeCrateError(time::Error),
 }
 
 impl Display for ConversionErrorInner {
@@ -48,6 +51,8 @@ impl Display for ConversionErrorInner {
             Self::InvalidComponent => write!(f, "Invalid component"),
             Self::InvalidUefiTime(e) => write!(f, "Invalid UEFI time: {e}"),
             Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
+            #[cfg(feature = "time03")]
+            Self::TimeCrateError(e) => write!(f, "Time crate error: {}", e),
         }
     }
 }
@@ -58,6 +63,8 @@ impl Error for ConversionErrorInner {
             Self::InvalidComponent => None,
             Self::InvalidUefiTime(e) => Some(e),
             Self::UnspecifiedTimezone => None,
+            #[cfg(feature = "time03")]
+            Self::TimeCrateError(e) => Some(e),
         }
     }
 }

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Provides common helpers for the integration and conversion with
+//! different time crates from the ecosystem.
+
+use crate::runtime::TimeError;
+use core::error::Error;
+use core::fmt;
+use core::fmt::{Display, Formatter};
+
+/// An opaque error type indicating a UEFI [`Time`] could not be converted.
+///
+/// [`Time`]: super::Time
+#[derive(Debug)]
+pub struct ConversionError(pub(super) ConversionErrorInner);
+
+impl Display for ConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Time conversion error: {}", self.0)
+    }
+}
+
+impl Error for ConversionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        // Don't expose the inner error, it is not useful to the user.
+        None
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum ConversionErrorInner {
+    /// Invalid component.
+    InvalidComponent,
+    /// Invalid UEFI time: [`Time::is_valid`] reported an error.
+    ///
+    /// [`Time::is_valid`]: super::Time::is_valid
+    InvalidUefiTime(TimeError),
+    /// A timezone was required for the conversion, but the UEFI time indicates
+    /// [`Time::UNSPECIFIED_TIMEZONE`].
+    ///
+    /// [`Time::UNSPECIFIED_TIMEZONE`]: super::Time::UNSPECIFIED_TIMEZONE
+    UnspecifiedTimezone,
+}
+
+impl Display for ConversionErrorInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidComponent => write!(f, "Invalid component"),
+            Self::InvalidUefiTime(e) => write!(f, "Invalid UEFI time: {e}"),
+            Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
+        }
+    }
+}
+
+impl Error for ConversionErrorInner {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidComponent => None,
+            Self::InvalidUefiTime(e) => Some(e),
+            Self::UnspecifiedTimezone => None,
+        }
+    }
+}

--- a/uefi/src/runtime/time/integration_jiff_crate.rs
+++ b/uefi/src/runtime/time/integration_jiff_crate.rs
@@ -118,3 +118,60 @@ impl TryFrom<Zoned> for Time {
         Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::integration_common::test_helpers;
+    use super::*;
+
+    #[test]
+    fn primitive_roundtrip_basic() {
+        test_helpers::primitive_roundtrip::<DateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_positive_offset() {
+        test_helpers::zoned_roundtrip::<Zoned>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_negative_offset() {
+        test_helpers::negative_offset_roundtrip::<Zoned>();
+    }
+
+    #[test]
+    fn nanoseconds_preserved() {
+        test_helpers::preserves_nanoseconds::<Zoned>();
+    }
+
+    #[test]
+    fn unspecified_timezone_is_rejected() {
+        test_helpers::unspecified_timezone_fails::<Zoned>();
+    }
+
+    #[test]
+    fn invalid_date_is_rejected() {
+        test_helpers::invalid_calendar_date_fails::<DateTime>();
+    }
+
+    // jiff-specific edge case: offset minute precision
+    #[test]
+    fn half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(90); // +01:30
+
+        let z: Zoned = t.try_into().unwrap();
+        let back: Time = z.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 90);
+    }
+
+    #[test]
+    fn negative_half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(-330); // -05:30
+
+        let z: Zoned = t.try_into().unwrap();
+        let back: Time = z.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
+    }
+}

--- a/uefi/src/runtime/time/integration_jiff_crate.rs
+++ b/uefi/src/runtime/time/integration_jiff_crate.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration of the UEFI [`Time`] type with the [`jiff`] crate.
+
+use super::Time;
+use super::integration_common::{ConversionError, ConversionErrorInner};
+use jiff::Zoned;
+use jiff::civil::DateTime;
+use jiff::tz::{Offset, TimeZone};
+use uefi::runtime::TimeParams;
+
+// Timezone unaware
+impl TryFrom<Time> for DateTime {
+    type Error = ConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(ConversionError(ConversionErrorInner::InvalidUefiTime(e)));
+        }
+
+        let datetime = Self::new(
+            // Cannot fail as the value is valid and in range (we checked that).
+            i16::try_from(value.0.year).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.month).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.day).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.hour).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.minute).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.second).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i32::try_from(value.0.nanosecond).unwrap(),
+        )
+        .map_err(|e| ConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+
+        Ok(datetime)
+    }
+}
+
+// Timezone aware
+impl TryFrom<Time> for Zoned {
+    type Error = ConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(ConversionError(ConversionErrorInner::InvalidUefiTime(e)));
+        }
+
+        if value.0.time_zone == Time::UNSPECIFIED_TIMEZONE {
+            return Err(ConversionError(ConversionErrorInner::UnspecifiedTimezone));
+        }
+
+        let datetime = DateTime::try_from(value)?;
+        let seconds = value.0.time_zone as i32 * 60 /* seconds per minute */;
+        let offset = Offset::from_seconds(seconds)
+            .map_err(|e| ConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+        let timezone = TimeZone::fixed(offset);
+        let zoned = datetime
+            .to_zoned(timezone)
+            .map_err(|e| ConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+        Ok(zoned)
+    }
+}
+
+impl TryFrom<DateTime> for Time {
+    type Error = ConversionError;
+
+    fn try_from(value: DateTime) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::try_from(value.month())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            day: u8::try_from(value.day())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            hour: u8::try_from(value.hour())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            minute: u8::try_from(value.minute())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            second: u8::try_from(value.second())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            nanosecond: u32::try_from(value.subsec_nanosecond())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            time_zone: None,
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+impl TryFrom<Zoned> for Time {
+    type Error = ConversionError;
+    fn try_from(value: Zoned) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::try_from(value.month())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            day: u8::try_from(value.day())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            hour: u8::try_from(value.hour())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            minute: u8::try_from(value.minute())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            second: u8::try_from(value.second())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            nanosecond: u32::try_from(value.subsec_nanosecond())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            time_zone: Some(
+                i16::try_from(value.offset().seconds() / 60 /* seconds per minute */)
+                    .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            ),
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}

--- a/uefi/src/runtime/time/integration_time_crate.rs
+++ b/uefi/src/runtime/time/integration_time_crate.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration of the UEFI [`Time`] type with the [`time`] crate.
+
+use super::Time;
+use super::integration_common::{ConversionError, ConversionErrorInner};
+use crate::runtime::TimeParams;
+use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
+
+impl TryFrom<Time> for PrimitiveDateTime {
+    type Error = ConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(ConversionError(ConversionErrorInner::InvalidUefiTime(e)));
+        }
+
+        // Emulated try {} block to keep the `?` error propagation scoped
+        // (we have a different error type here)
+        let datetime: Result<Self, time::error::ComponentRange> = (|| {
+            let month = time::Month::try_from(value.0.month)?;
+            let date = time::Date::from_calendar_date(value.0.year as i32, month, value.0.day)?;
+            let time = time::Time::from_hms_nano(
+                value.0.hour,
+                value.0.minute,
+                value.0.second,
+                value.0.nanosecond,
+            )?;
+            Ok(Self::new(date, time))
+        })();
+
+        datetime
+            .map_err(time::Error::ComponentRange)
+            .map_err(|e| ConversionError(ConversionErrorInner::TimeCrateError(e)))
+    }
+}
+
+impl TryFrom<Time> for OffsetDateTime {
+    type Error = ConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(ConversionError(ConversionErrorInner::InvalidUefiTime(e)));
+        }
+
+        let primitive_date_time: PrimitiveDateTime = value.try_into()?;
+
+        if value.0.time_zone == Time::UNSPECIFIED_TIMEZONE {
+            return Err(ConversionError(ConversionErrorInner::UnspecifiedTimezone));
+        }
+
+        let h = (value.0.time_zone / 60) as i8;
+        let m = (value.0.time_zone.abs() % 60) as i8;
+
+        let offset = UtcOffset::from_hms(h, m, 0)
+            .map_err(time::Error::ComponentRange)
+            .map_err(|e| ConversionError(ConversionErrorInner::TimeCrateError(e)))?;
+        Ok(primitive_date_time.assume_offset(offset))
+    }
+}
+
+impl TryFrom<PrimitiveDateTime> for Time {
+    type Error = ConversionError;
+
+    fn try_from(value: PrimitiveDateTime) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::from(value.month()),
+            day: value.day(),
+            hour: value.hour(),
+            minute: value.minute(),
+            second: value.second(),
+            nanosecond: value.nanosecond(),
+            time_zone: None,
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+impl TryFrom<OffsetDateTime> for Time {
+    type Error = ConversionError;
+
+    fn try_from(value: OffsetDateTime) -> Result<Self, Self::Error> {
+        let timezone_offset_minutes = value.offset().whole_seconds() / 60;
+        if value.offset().whole_seconds() % 60 != 0 {
+            return Err(ConversionError(ConversionErrorInner::InvalidComponent));
+        }
+
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::from(value.month()),
+            day: value.day(),
+            hour: value.hour(),
+            minute: value.minute(),
+            second: value.second(),
+            nanosecond: value.nanosecond(),
+            time_zone: Some(
+                i16::try_from(timezone_offset_minutes)
+                    .map_err(|_e| ConversionError(ConversionErrorInner::InvalidComponent))?,
+            ),
+            daylight: Default::default(),
+        };
+
+        Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}

--- a/uefi/src/runtime/time/integration_time_crate.rs
+++ b/uefi/src/runtime/time/integration_time_crate.rs
@@ -50,7 +50,7 @@ impl TryFrom<Time> for OffsetDateTime {
         }
 
         let h = (value.0.time_zone / 60) as i8;
-        let m = (value.0.time_zone.abs() % 60) as i8;
+        let m = (value.0.time_zone % 60) as i8;
 
         let offset = UtcOffset::from_hms(h, m, 0)
             .map_err(time::Error::ComponentRange)
@@ -105,5 +105,63 @@ impl TryFrom<OffsetDateTime> for Time {
         };
 
         Self::new(params).map_err(|e| ConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::integration_common::test_helpers;
+    use super::*;
+    use time::{OffsetDateTime, PrimitiveDateTime};
+
+    #[test]
+    fn primitive_roundtrip_basic() {
+        test_helpers::primitive_roundtrip::<PrimitiveDateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_positive_offset() {
+        test_helpers::zoned_roundtrip::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_negative_offset() {
+        test_helpers::negative_offset_roundtrip::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn nanoseconds_preserved() {
+        test_helpers::preserves_nanoseconds::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn unspecified_timezone_is_rejected() {
+        test_helpers::unspecified_timezone_fails::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn invalid_date_is_rejected() {
+        test_helpers::invalid_calendar_date_fails::<PrimitiveDateTime>();
+    }
+
+    // important real-world offset edge case
+    #[test]
+    fn half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(90); // +01:30
+
+        let dt: OffsetDateTime = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 90);
+    }
+
+    #[test]
+    fn negative_half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(-330); // -05:30
+
+        let dt: OffsetDateTime = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
     }
 }

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -7,8 +7,10 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
-#[cfg(feature = "time03")]
+#[cfg(any(feature = "jiff02", feature = "time03"))]
 mod integration_common;
+#[cfg(feature = "jiff02")]
+mod integration_jiff_crate;
 #[cfg(feature = "time03")]
 mod integration_time_crate;
 
@@ -25,7 +27,13 @@ mod integration_time_crate;
 /// - [`TryFrom`]: `PrimitiveDateTime` <--> [`Time`] (without timezone)
 /// - [`TryFrom`]: `OffsetDateTime` <--> [`Time`] (with timezone)
 ///
+/// ## Integration with [`jiff`][jiff crate] crate
+///
+/// - [`TryFrom`]: `DateTime` <--> [`Time`] (without timezone)
+/// - [`TryFrom`]: `Zoned` <--> [`Time`] (with timezone)
+///
 /// [time crate]: https://crates.io/crates/time
+/// [jiff crate]: https://crates.io/crates/jiff
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Time(uefi_raw::time::Time);

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -7,6 +7,9 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
+#[allow(unused)]
+mod integration_common;
+
 /// Date and time representation.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -7,10 +7,25 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
-#[allow(unused)]
+#[cfg(feature = "time03")]
 mod integration_common;
+#[cfg(feature = "time03")]
+mod integration_time_crate;
 
 /// Date and time representation.
+///
+/// # Integration with Time-related Crates of the Ecosystem
+///
+/// Handling time is complicated. Therefore, we do not reinvent the wheel and
+/// forward all complexity of time to well-known crates of the ecosystem. For
+/// that, we provide integrations with various crates:
+///
+/// ## Integration with [`time`][time crate] crate
+///
+/// - [`TryFrom`]: `PrimitiveDateTime` <--> [`Time`] (without timezone)
+/// - [`TryFrom`]: `OffsetDateTime` <--> [`Time`] (with timezone)
+///
+/// [time crate]: https://crates.io/crates/time
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Time(uefi_raw::time::Time);

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -56,6 +56,7 @@ pub enum Feature {
     Unstable,
     PanicHandler,
     Qemu,
+    Time03,
 
     // `uefi-test-runner` features.
     DebugSupport,
@@ -76,6 +77,7 @@ impl Feature {
             Self::Unstable => "unstable",
             Self::PanicHandler => "panic_handler",
             Self::Qemu => "qemu",
+            Self::Time03 => "time03",
 
             Self::DebugSupport => "uefi-test-runner/debug_support",
             Self::MultiProcessor => "uefi-test-runner/multi_processor",
@@ -117,7 +119,7 @@ impl Feature {
     /// - `include_unstable` - add all functionality behind the `unstable` feature
     /// - `runtime_features` - add all functionality that effect the runtime of Rust
     pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
-        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger];
+        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger, Self::Time03];
         if include_unstable {
             base_features.extend([Self::Unstable])
         }
@@ -387,19 +389,19 @@ mod tests {
     fn test_comma_separated_features() {
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, false)),
-            "alloc,log-debugcon,logger"
+            "alloc,log-debugcon,logger,time03"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, true)),
-            "alloc,log-debugcon,logger,global_allocator"
+            "alloc,log-debugcon,logger,time03,global_allocator"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, false)),
-            "alloc,log-debugcon,logger,unstable"
+            "alloc,log-debugcon,logger,time03,unstable"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, true)),
-            "alloc,log-debugcon,logger,unstable,global_allocator"
+            "alloc,log-debugcon,logger,time03,unstable,global_allocator"
         );
     }
 

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -56,6 +56,7 @@ pub enum Feature {
     Unstable,
     PanicHandler,
     Qemu,
+    Jiff02,
     Time03,
 
     // `uefi-test-runner` features.
@@ -77,6 +78,7 @@ impl Feature {
             Self::Unstable => "unstable",
             Self::PanicHandler => "panic_handler",
             Self::Qemu => "qemu",
+            Self::Jiff02 => "jiff02",
             Self::Time03 => "time03",
 
             Self::DebugSupport => "uefi-test-runner/debug_support",
@@ -119,7 +121,13 @@ impl Feature {
     /// - `include_unstable` - add all functionality behind the `unstable` feature
     /// - `runtime_features` - add all functionality that effect the runtime of Rust
     pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
-        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger, Self::Time03];
+        let mut base_features = vec![
+            Self::Alloc,
+            Self::Jiff02,
+            Self::LogDebugcon,
+            Self::Logger,
+            Self::Time03,
+        ];
         if include_unstable {
             base_features.extend([Self::Unstable])
         }
@@ -389,19 +397,19 @@ mod tests {
     fn test_comma_separated_features() {
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, false)),
-            "alloc,log-debugcon,logger,time03"
+            "alloc,jiff02,log-debugcon,logger,time03"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, true)),
-            "alloc,log-debugcon,logger,time03,global_allocator"
+            "alloc,jiff02,log-debugcon,logger,time03,global_allocator"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, false)),
-            "alloc,log-debugcon,logger,time03,unstable"
+            "alloc,jiff02,log-debugcon,logger,time03,unstable"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, true)),
-            "alloc,log-debugcon,logger,time03,unstable,global_allocator"
+            "alloc,jiff02,log-debugcon,logger,time03,unstable,global_allocator"
         );
     }
 


### PR DESCRIPTION
This is my third design, superseding the outdated approaches #1896 and #1899.

# Motivation

My high-level goal is to make `struct Time` more useable, e.g., compare dates (before, after, ...).

# Design

This PR integrates `struct Time` of the `uefi` crate with https://crates.io/crates/time and https://crates.io/crates/jiff. I decided for the following design:

- `TryFrom` and no specific constructors
- Use the "datetime without timezone" and "datetime with timezone" types of the time libraries

## Error

There is a single opaque `ConversionError` shared by all `TryFrom` impls.

# Implementation

- `time` crate
  - `struct Time <--> PrimitiveDateTime` (without timezone)
  - `struct Time <--> OffsetDateTime` (with timezone)

- `jiff` crate
  - `struct Time <--> DateTime` (without timezone)
  - `struct Time <--> Zoned` (with timezone)