### PR TITLE
Fix connect_controller to take a list for `driver_image`.

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Added `SimpleTextInputExProtocol`.
 
 ## Changed
+- Corrected the type of the `driver_image` parameter in
+  `BootServices::connect_controller` from `Handle` to `*const Handle`.
 
 
 # uefi-raw - v0.14.0 (2026-03-22)

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -152,7 +152,7 @@ pub struct BootServices {
     // Driver support services
     pub connect_controller: unsafe extern "efiapi" fn(
         controller: Handle,
-        driver_image: Handle,
+        driver_image: *const Handle,
         remaining_device_path: *const DevicePathProtocol,
         recursive: Boolean,
     ) -> Status,

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -152,7 +152,7 @@ fn reconnect_serial_to_console(serial_handle: Handle) {
         .finalize()
         .unwrap();
 
-    uefi::boot::connect_controller(serial_handle, None, Some(terminal_device_path), true)
+    uefi::boot::connect_controller(serial_handle, &[], Some(terminal_device_path), true)
         .expect("failed to reconnect serial to console");
 }
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## Changed
 - **Breaking:** The variants of `TimerTrigger` now hold a `Duration`
+- **Breaking:** The `driver_image` parameter of `boot::connect_controller` is
+  now a `None`-terminated slice. Callers that previously passed `None` for this
+  argument should pass in `&[]` instead.
 
 # uefi - v0.37.0 (2026-03-22)
 

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -661,6 +661,11 @@ pub fn wait_for_event(events: &mut [Event]) -> Result<usize, Option<usize>> {
 /// to make them rescan some state that changed, e.g. reconnecting
 /// a block handle after your app modified disk partitions.
 ///
+/// The `driver_image` argument is usually an empty slice. Otherwise, it
+/// contains an ordered list of candidates for the driver binding protocols that
+/// will manage the `controller`. If non-empty, the slice must be terminated
+/// with `None`.
+///
 /// # Errors
 ///
 /// * [`Status::NOT_FOUND`]: there are no driver-binding protocol instances
@@ -669,17 +674,27 @@ pub fn wait_for_event(events: &mut [Event]) -> Result<usize, Option<usize>> {
 ///   start drivers associated with `controller`.
 pub fn connect_controller(
     controller: Handle,
-    driver_image: Option<Handle>,
+    driver_image: &[Option<Handle>],
     remaining_device_path: Option<&DevicePath>,
     recursive: bool,
 ) -> Result {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
 
+    let driver_image: *const uefi_raw::Handle = if let Some(last) = driver_image.last() {
+        assert!(
+            last.is_none(),
+            "driver_image parameter must be terminated with None"
+        );
+        driver_image.as_ptr().cast()
+    } else {
+        ptr::null()
+    };
+
     unsafe {
         (bt.connect_controller)(
             controller.as_ptr(),
-            Handle::opt_to_ptr(driver_image),
+            driver_image,
             remaining_device_path
                 .map(|dp| dp.as_ffi_ptr())
                 .unwrap_or(ptr::null())


### PR DESCRIPTION
The parameter in `uefi-raw` was wrong. This parameter is supposed to be a null-terminated array of handles. Changed it to `*const Handle` accordingly.

This makes the `uefi` wrapper a little ugly, since the safe equivalent is `&[Option<Handle>]`, and the user must ensure that the last element of the slice is `None`. Fortunately this parameter is usually unused, and the user can just pass in `&[]`, so the API ugliness should be OK.

Fixes https://github.com/rust-osdev/uefi-rs/issues/1938