### PR TITLE
ci: fix broken uefi-macros test

### DIFF
--- a/uefi-macros/tests/ui/fail/entry_bad_return_type.stderr
+++ b/uefi-macros/tests/ui/fail/entry_bad_return_type.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
  --> tests/ui/fail/entry_bad_return_type.rs:6:1
   |
 6 | fn main() -> bool {
-  | ^^^^^^^^^^^^^^^^^ expected `Status`, found `bool`
+  | --^^^^^^^^^^^^^^^
+  | |
+  | expected `Status`, found `bool`
+  | expected because of the type of the constant
   |
   = note: expected fn pointer `extern "efiapi" fn(Handle, *const c_void) -> Status`
              found fn pointer `extern "efiapi" fn(Handle, *const c_void) -> bool`


### PR DESCRIPTION
A recent rust update caused a changed diagnosis format. Likely the update to Rust 1.96.

