### PR TITLE
uefi: Add integration with `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +525,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -863,6 +884,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +979,7 @@ dependencies = [
  "log",
  "ptr_meta",
  "qemu-exit",
+ "time",
  "ucs2",
  "uefi-macros",
  "uefi-raw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
 qemu-exit = { version = "4.0.0" }
+time = { version = "0.3", default-features = false }
 uguid = "2.2.1"
 
 [patch.crates-io]

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Added `Serial::read_exact()` and `Serial::write_exact()`
 - `CStr16::from_bytes_with_nul()`: This is especially useful to transform the
   retrieved value from a UEFI variable into a UCS2 (CStr16) string.
+- Integration of `Time` with `time` crate
+  - `TryFrom`: `time::PrimitiveDateTime <--> Time` (without timezone)
+  - `TryFrom`: `time::OffsetDateTime <--> Time` (with timezone)
 
 ## Changed
 - export all `text::{input, output}::*` types

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -20,6 +20,8 @@ rust-version.workspace = true
 # KEEP this feature list in sync with doc in uefi/lib.rs!
 default = [ ]
 alloc = []
+# Integration with time crate `v0.3`
+time03 = ["dep:time"]
 
 # Generic gate to code that uses unstable features of Rust, needing a nightly
 # toolchain.
@@ -39,6 +41,7 @@ log-debugcon = []
 bitflags.workspace = true
 log.workspace = true
 ptr_meta.workspace = true
+time = { workspace = true, optional = true }
 qemu-exit = { workspace = true, optional = true }
 uguid.workspace = true
 cfg-if = "1.0.0"

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -148,6 +148,9 @@
 //! - `log-debugcon`: Whether the logger set up by `logger` should also log
 //!   to the debugcon device (available in QEMU or Cloud Hypervisor on x86).
 //! - `panic_handler`: Add a default panic handler that logs to `stdout`.
+//! - `time03`: Integration of [`Time`][time-struct] with the `time` crate
+//!   (version 0.3). Specifically, the covers [`TryFrom`] integration with
+//!   `PrimitiveDateTime` and `OffsetDateTime` of the `time` crate.
 //! - `unstable`: Enable functionality that depends on [unstable features] in
 //!   the Rust compiler (nightly version).
 //! - `qemu`: Enable some code paths to adapt their execution when executed
@@ -251,6 +254,7 @@
 //! [rustc-uefi-std]: https://doc.rust-lang.org/nightly/rustc/platform-support/unknown-uefi.html
 //! [spec]: https://uefi.org/specifications
 //! [template]: https://github.com/rust-osdev/uefi-rs/tree/main/template
+//! [time-struct]: crate::runtime::Time
 //! [uefi-std-tr-issue]: https://github.com/rust-lang/rust/issues/100499
 //! [unstable features]: https://doc.rust-lang.org/unstable-book/
 

--- a/uefi/src/runtime/mod.rs
+++ b/uefi/src/runtime/mod.rs
@@ -9,7 +9,7 @@
 
 mod time;
 
-pub use time::{Time, TimeByteConversionError, TimeError, TimeParams};
+pub use time::*;
 
 use crate::data_types::PhysicalAddress;
 use crate::table::{self, Revision};

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -8,19 +8,19 @@ use core::error::Error;
 use core::fmt;
 use core::fmt::{Display, Formatter};
 
-/// An opaque error type indicating a UEFI [`Time`] could not be converted.
+/// Opaque error type indicating a UEFI [`Time`] could not be converted.
 ///
 /// [`Time`]: super::Time
 #[derive(Debug)]
-pub struct ConversionError(pub(super) ConversionErrorInner);
+pub struct TimeConversionError(pub(super) ConversionErrorInner);
 
-impl Display for ConversionError {
+impl Display for TimeConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Time conversion error: {}", self.0)
     }
 }
 
-impl Error for ConversionError {}
+impl Error for TimeConversionError {}
 
 #[derive(Debug)]
 pub(super) enum ConversionErrorInner {
@@ -35,6 +35,9 @@ pub(super) enum ConversionErrorInner {
     ///
     /// [`Time::UNSPECIFIED_TIMEZONE`]: super::Time::UNSPECIFIED_TIMEZONE
     UnspecifiedTimezone,
+    /// Errors raised in the [`time`] crate.
+    #[cfg(feature = "time03")]
+    TimeCrateError(time::Error),
 }
 
 impl Display for ConversionErrorInner {
@@ -43,6 +46,8 @@ impl Display for ConversionErrorInner {
             Self::InvalidComponent => write!(f, "Invalid component"),
             Self::InvalidUefiTime(e) => write!(f, "Invalid UEFI time: {e}"),
             Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
+            #[cfg(feature = "time03")]
+            Self::TimeCrateError(e) => write!(f, "Time crate error: {}", e),
         }
     }
 }
@@ -53,6 +58,8 @@ impl Error for ConversionErrorInner {
             Self::InvalidComponent => None,
             Self::InvalidUefiTime(e) => Some(e),
             Self::UnspecifiedTimezone => None,
+            #[cfg(feature = "time03")]
+            Self::TimeCrateError(e) => Some(e),
         }
     }
 }

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Provides common helpers for the integration and conversion with
+//! different time crates from the ecosystem.
+
+use crate::runtime::TimeError;
+use core::error::Error;
+use core::fmt;
+use core::fmt::{Display, Formatter};
+
+/// An opaque error type indicating a UEFI [`Time`] could not be converted.
+///
+/// [`Time`]: super::Time
+#[derive(Debug)]
+pub struct ConversionError(pub(super) ConversionErrorInner);
+
+impl Display for ConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Time conversion error: {}", self.0)
+    }
+}
+
+impl Error for ConversionError {}
+
+#[derive(Debug)]
+pub(super) enum ConversionErrorInner {
+    /// Invalid component.
+    InvalidComponent,
+    /// Invalid UEFI time: [`Time::is_valid`] reported an error.
+    ///
+    /// [`Time::is_valid`]: super::Time::is_valid
+    InvalidUefiTime(TimeError),
+    /// A timezone was required for the conversion, but the UEFI time indicates
+    /// [`Time::UNSPECIFIED_TIMEZONE`].
+    ///
+    /// [`Time::UNSPECIFIED_TIMEZONE`]: super::Time::UNSPECIFIED_TIMEZONE
+    UnspecifiedTimezone,
+}
+
+impl Display for ConversionErrorInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidComponent => write!(f, "Invalid component"),
+            Self::InvalidUefiTime(e) => write!(f, "Invalid UEFI time: {e}"),
+            Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
+        }
+    }
+}
+
+impl Error for ConversionErrorInner {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidComponent => None,
+            Self::InvalidUefiTime(e) => Some(e),
+            Self::UnspecifiedTimezone => None,
+        }
+    }
+}

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -63,3 +63,107 @@ impl Error for ConversionErrorInner {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(unused)]
+pub(super) mod test_helpers {
+    use super::*;
+    use crate::runtime::TimeParams;
+    use uefi::runtime::Time;
+    use uefi_raw::time::Daylight;
+
+    pub fn sample_time(tz: i16) -> Time {
+        let params = TimeParams {
+            year: 2024,
+            month: 3,
+            day: 14,
+            hour: 12,
+            minute: 34,
+            second: 56,
+            nanosecond: 123_456_789,
+            time_zone: Some(tz),
+            daylight: Daylight::default(),
+        };
+        Time::new(params).unwrap()
+    }
+
+    fn invalid_date() -> Time {
+        let mut t = sample_time(0);
+        t.0.month = 2;
+        t.0.day = 31;
+        t
+    }
+
+    pub fn primitive_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError> + TryInto<Time, Error = TimeConversionError>,
+    {
+        let t = sample_time(Time::UNSPECIFIED_TIMEZONE);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.year, t.0.year);
+        assert_eq!(back.0.month, t.0.month);
+        assert_eq!(back.0.day, t.0.day);
+        assert_eq!(back.0.hour, t.0.hour);
+        assert_eq!(back.0.minute, t.0.minute);
+        assert_eq!(back.0.second, t.0.second);
+        assert_eq!(back.0.nanosecond, t.0.nanosecond);
+    }
+
+    pub fn zoned_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError> + TryInto<Time, Error = TimeConversionError>,
+    {
+        let t = sample_time(120);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 120);
+        assert_eq!(back.0.hour, t.0.hour);
+        assert_eq!(back.0.minute, t.0.minute);
+    }
+
+    pub fn negative_offset_roundtrip<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError> + TryInto<Time, Error = TimeConversionError>,
+    {
+        let t = sample_time(-330);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
+    }
+
+    pub fn preserves_nanoseconds<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError> + TryInto<Time, Error = TimeConversionError>,
+    {
+        let t = sample_time(60);
+
+        let dt: T = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.nanosecond, 123_456_789);
+    }
+
+    pub fn unspecified_timezone_fails<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError>,
+    {
+        let t = sample_time(Time::UNSPECIFIED_TIMEZONE);
+        let result: Result<T, _> = t.try_into();
+        assert!(result.is_err());
+    }
+
+    pub fn invalid_calendar_date_fails<T>()
+    where
+        T: TryFrom<Time, Error = TimeConversionError>,
+    {
+        let result: Result<T, _> = invalid_date().try_into();
+        assert!(result.is_err());
+    }
+}

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -65,7 +65,6 @@ impl Error for ConversionErrorInner {
 }
 
 #[cfg(test)]
-#[allow(unused)]
 pub(super) mod test_helpers {
     use super::*;
     use crate::runtime::TimeParams;

--- a/uefi/src/runtime/time/integration_time_crate.rs
+++ b/uefi/src/runtime/time/integration_time_crate.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration of the UEFI [`Time`] type with the [`time`] crate.
+
+use super::Time;
+use super::integration_common::{ConversionErrorInner, TimeConversionError};
+use crate::runtime::TimeParams;
+use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
+
+impl TryFrom<Time> for PrimitiveDateTime {
+    type Error = TimeConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(TimeConversionError(ConversionErrorInner::InvalidUefiTime(
+                e,
+            )));
+        }
+
+        // Emulated try {} block to keep the `?` error propagation scoped
+        // (we have a different error type here)
+        let datetime: Result<Self, time::error::ComponentRange> = (|| {
+            let month = time::Month::try_from(value.0.month)?;
+            let date = time::Date::from_calendar_date(value.0.year as i32, month, value.0.day)?;
+            let time = time::Time::from_hms_nano(
+                value.0.hour,
+                value.0.minute,
+                value.0.second,
+                value.0.nanosecond,
+            )?;
+            Ok(Self::new(date, time))
+        })();
+
+        datetime
+            .map_err(time::Error::ComponentRange)
+            .map_err(|e| TimeConversionError(ConversionErrorInner::TimeCrateError(e)))
+    }
+}
+
+impl TryFrom<Time> for OffsetDateTime {
+    type Error = TimeConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(TimeConversionError(ConversionErrorInner::InvalidUefiTime(
+                e,
+            )));
+        }
+
+        let primitive_date_time: PrimitiveDateTime = value.try_into()?;
+
+        if value.0.time_zone == Time::UNSPECIFIED_TIMEZONE {
+            return Err(TimeConversionError(
+                ConversionErrorInner::UnspecifiedTimezone,
+            ));
+        }
+
+        let h = (value.0.time_zone / 60) as i8;
+        let m = (value.0.time_zone.abs() % 60) as i8;
+
+        let offset = UtcOffset::from_hms(h, m, 0)
+            .map_err(time::Error::ComponentRange)
+            .map_err(|e| TimeConversionError(ConversionErrorInner::TimeCrateError(e)))?;
+        Ok(primitive_date_time.assume_offset(offset))
+    }
+}
+
+impl TryFrom<PrimitiveDateTime> for Time {
+    type Error = TimeConversionError;
+
+    fn try_from(value: PrimitiveDateTime) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::from(value.month()),
+            day: value.day(),
+            hour: value.hour(),
+            minute: value.minute(),
+            second: value.second(),
+            nanosecond: value.nanosecond(),
+            time_zone: None,
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+impl TryFrom<OffsetDateTime> for Time {
+    type Error = TimeConversionError;
+
+    fn try_from(value: OffsetDateTime) -> Result<Self, Self::Error> {
+        let timezone_offset_minutes = value.offset().whole_seconds() / 60;
+        if value.offset().whole_seconds() % 60 != 0 {
+            return Err(TimeConversionError(ConversionErrorInner::InvalidComponent));
+        }
+
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::from(value.month()),
+            day: value.day(),
+            hour: value.hour(),
+            minute: value.minute(),
+            second: value.second(),
+            nanosecond: value.nanosecond(),
+            time_zone: Some(
+                i16::try_from(timezone_offset_minutes)
+                    .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            ),
+            daylight: Default::default(),
+        };
+
+        Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}

--- a/uefi/src/runtime/time/integration_time_crate.rs
+++ b/uefi/src/runtime/time/integration_time_crate.rs
@@ -56,7 +56,7 @@ impl TryFrom<Time> for OffsetDateTime {
         }
 
         let h = (value.0.time_zone / 60) as i8;
-        let m = (value.0.time_zone.abs() % 60) as i8;
+        let m = (value.0.time_zone % 60) as i8;
 
         let offset = UtcOffset::from_hms(h, m, 0)
             .map_err(time::Error::ComponentRange)
@@ -111,5 +111,63 @@ impl TryFrom<OffsetDateTime> for Time {
         };
 
         Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::integration_common::test_helpers;
+    use super::*;
+    use time::{OffsetDateTime, PrimitiveDateTime};
+
+    #[test]
+    fn primitive_roundtrip_basic() {
+        test_helpers::primitive_roundtrip::<PrimitiveDateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_positive_offset() {
+        test_helpers::zoned_roundtrip::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_negative_offset() {
+        test_helpers::negative_offset_roundtrip::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn nanoseconds_preserved() {
+        test_helpers::preserves_nanoseconds::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn unspecified_timezone_is_rejected() {
+        test_helpers::unspecified_timezone_fails::<OffsetDateTime>();
+    }
+
+    #[test]
+    fn invalid_date_is_rejected() {
+        test_helpers::invalid_calendar_date_fails::<PrimitiveDateTime>();
+    }
+
+    // important real-world offset edge case
+    #[test]
+    fn half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(90); // +01:30
+
+        let dt: OffsetDateTime = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 90);
+    }
+
+    #[test]
+    fn negative_half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(-330); // -05:30
+
+        let dt: OffsetDateTime = t.try_into().unwrap();
+        let back: Time = dt.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
     }
 }

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -7,6 +7,9 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
+#[allow(unused)]
+mod integration_common;
+
 /// Date and time representation.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -3,14 +3,32 @@
 //! Module for UEFI time-related types and definitions and convenience and
 //! abstractions build around these.
 
+#[cfg(feature = "time03")]
+pub use integration_common::TimeConversionError;
+
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
-#[allow(unused)]
+#[cfg(feature = "time03")]
 mod integration_common;
+#[cfg(feature = "time03")]
+mod integration_time_crate;
 
 /// Date and time representation.
+///
+/// # Integration with Time-related Crates of the Ecosystem
+///
+/// Handling time is complicated. Therefore, we do not reinvent the wheel and
+/// forward all complexity of time to well-known crates of the ecosystem. For
+/// that, we provide integrations with various crates:
+///
+/// ## Integration with [`time`][time crate] crate
+///
+/// - [`TryFrom`]: `PrimitiveDateTime` <--> [`Time`] (without timezone)
+/// - [`TryFrom`]: `OffsetDateTime` <--> [`Time`] (with timezone)
+///
+/// [time crate]: https://crates.io/crates/time
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Time(uefi_raw::time::Time);

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -56,6 +56,7 @@ pub enum Feature {
     Unstable,
     PanicHandler,
     Qemu,
+    Time03,
 
     // `uefi-test-runner` features.
     DebugSupport,
@@ -76,6 +77,7 @@ impl Feature {
             Self::Unstable => "unstable",
             Self::PanicHandler => "panic_handler",
             Self::Qemu => "qemu",
+            Self::Time03 => "time03",
 
             Self::DebugSupport => "uefi-test-runner/debug_support",
             Self::MultiProcessor => "uefi-test-runner/multi_processor",
@@ -117,7 +119,7 @@ impl Feature {
     /// - `include_unstable` - add all functionality behind the `unstable` feature
     /// - `runtime_features` - add all functionality that effect the runtime of Rust
     pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
-        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger];
+        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger, Self::Time03];
         if include_unstable {
             base_features.extend([Self::Unstable])
         }
@@ -387,19 +389,19 @@ mod tests {
     fn test_comma_separated_features() {
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, false)),
-            "alloc,log-debugcon,logger"
+            "alloc,log-debugcon,logger,time03"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, true)),
-            "alloc,log-debugcon,logger,global_allocator"
+            "alloc,log-debugcon,logger,time03,global_allocator"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, false)),
-            "alloc,log-debugcon,logger,unstable"
+            "alloc,log-debugcon,logger,time03,unstable"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, true)),
-            "alloc,log-debugcon,logger,unstable,global_allocator"
+            "alloc,log-debugcon,logger,time03,unstable,global_allocator"
         );
     }
 


### PR DESCRIPTION
Split out from #1911 - this PR adds integration with the `time` crate whereas `jiff` comes in a follow-up (#1956).