### PR TITLE
uefi: Add integration with `jiff` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +559,21 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -988,6 +1025,7 @@ version = "0.37.0"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
+ "jiff",
  "log",
  "ptr_meta",
  "qemu-exit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.91"
 [workspace.dependencies]
 bitflags = "2.0.0"
 log = { version = "0.4.5", default-features = false }
+jiff = { version = "0.2", default-features = false }
 ptr_meta = { version = "0.3.0", default-features = false, features = ["derive"] }
 qemu-exit = { version = "4.0.0" }
 time = { version = "0.3", default-features = false }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -47,6 +47,9 @@
 - Integration of `Time` with `time` crate
   - `TryFrom`: `time::PrimitiveDateTime <--> Time` (without timezone)
   - `TryFrom`: `time::OffsetDateTime <--> Time` (with timezone)
+- Integration of `Time` with `jiff` crate
+  - `TryFrom`: `jiff::DateTime <--> Time` (without timezone)
+  - `TryFrom`: `jiff::Zoned <--> Time` (with timezone)
 
 ## Changed
 - export all `text::{input, output}::*` types

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -20,6 +20,8 @@ rust-version.workspace = true
 # KEEP this feature list in sync with doc in uefi/lib.rs!
 default = [ ]
 alloc = []
+# Integration with jiff crate `v0.2`
+jiff02 = ["dep:jiff"]
 # Integration with time crate `v0.3`
 time03 = ["dep:time"]
 
@@ -41,6 +43,7 @@ log-debugcon = []
 bitflags.workspace = true
 log.workspace = true
 ptr_meta.workspace = true
+jiff = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
 qemu-exit = { workspace = true, optional = true }
 uguid.workspace = true

--- a/uefi/src/lib.rs
+++ b/uefi/src/lib.rs
@@ -142,6 +142,9 @@
 //!   using this feature, or no allocator at all if you don't need to
 //!   dynamically allocate any memory. Note that even without that feature,
 //!   some code might use the internal UEFI allocator.
+//! - `jiff02`: Integration of [`runtime::Time`] with the `jiff` crate
+//!   (version 0.2 and possible above). Specifically, it integrates the time
+//!   struct with `DateTime` and `Zoned` via `TryFrom`.
 //! - `logger`: Logging implementation for the standard [`log`] crate
 //!   that prints output to the UEFI console. No buffering is done; this
 //!   is not a high-performance logger.

--- a/uefi/src/runtime/time/integration_common.rs
+++ b/uefi/src/runtime/time/integration_common.rs
@@ -38,6 +38,9 @@ pub(super) enum ConversionErrorInner {
     /// Errors raised in the [`time`] crate.
     #[cfg(feature = "time03")]
     TimeCrateError(time::Error),
+    /// Errors raised in the [`jiff`] crate.
+    #[cfg(feature = "jiff02")]
+    JiffCrateError(jiff::Error),
 }
 
 impl Display for ConversionErrorInner {
@@ -48,6 +51,8 @@ impl Display for ConversionErrorInner {
             Self::UnspecifiedTimezone => write!(f, "Unspecified timezone"),
             #[cfg(feature = "time03")]
             Self::TimeCrateError(e) => write!(f, "Time crate error: {}", e),
+            #[cfg(feature = "jiff02")]
+            Self::JiffCrateError(e) => write!(f, "Jiff crate error: {}", e),
         }
     }
 }
@@ -60,6 +65,9 @@ impl Error for ConversionErrorInner {
             Self::UnspecifiedTimezone => None,
             #[cfg(feature = "time03")]
             Self::TimeCrateError(e) => Some(e),
+            // None: Missing Error trait
+            #[cfg(feature = "jiff02")]
+            Self::JiffCrateError(_e) => None,
         }
     }
 }

--- a/uefi/src/runtime/time/integration_jiff_crate.rs
+++ b/uefi/src/runtime/time/integration_jiff_crate.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration of the UEFI [`Time`] type with the [`jiff`] crate.
+
+use super::Time;
+use super::integration_common::{ConversionErrorInner, TimeConversionError};
+use jiff::Zoned;
+use jiff::civil::DateTime;
+use jiff::tz::{Offset, TimeZone};
+use uefi::runtime::TimeParams;
+
+// Timezone unaware
+impl TryFrom<Time> for DateTime {
+    type Error = TimeConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(TimeConversionError(ConversionErrorInner::InvalidUefiTime(
+                e,
+            )));
+        }
+
+        let datetime = Self::new(
+            // Cannot fail as the value is valid and in range (we checked that).
+            i16::try_from(value.0.year).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.month).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.day).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.hour).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.minute).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i8::try_from(value.0.second).unwrap(),
+            // Cannot fail as the value is valid and in range (we checked that).
+            i32::try_from(value.0.nanosecond).unwrap(),
+        )
+        .map_err(|e| TimeConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+
+        Ok(datetime)
+    }
+}
+
+// Timezone aware
+impl TryFrom<Time> for Zoned {
+    type Error = TimeConversionError;
+
+    fn try_from(value: Time) -> Result<Self, Self::Error> {
+        if let Err(e) = value.is_valid() {
+            return Err(TimeConversionError(ConversionErrorInner::InvalidUefiTime(
+                e,
+            )));
+        }
+
+        if value.0.time_zone == Time::UNSPECIFIED_TIMEZONE {
+            return Err(TimeConversionError(
+                ConversionErrorInner::UnspecifiedTimezone,
+            ));
+        }
+
+        let datetime = DateTime::try_from(value)?;
+        let seconds = value.0.time_zone as i32 * 60 /* seconds per minute */;
+        let offset = Offset::from_seconds(seconds)
+            .map_err(|e| TimeConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+        let timezone = TimeZone::fixed(offset);
+        let zoned = datetime
+            .to_zoned(timezone)
+            .map_err(|e| TimeConversionError(ConversionErrorInner::JiffCrateError(e)))?;
+        Ok(zoned)
+    }
+}
+
+impl TryFrom<DateTime> for Time {
+    type Error = TimeConversionError;
+
+    fn try_from(value: DateTime) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::try_from(value.month())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            day: u8::try_from(value.day())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            hour: u8::try_from(value.hour())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            minute: u8::try_from(value.minute())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            second: u8::try_from(value.second())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            nanosecond: u32::try_from(value.subsec_nanosecond())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            time_zone: None,
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}
+
+impl TryFrom<Zoned> for Time {
+    type Error = TimeConversionError;
+    fn try_from(value: Zoned) -> Result<Self, Self::Error> {
+        let params = TimeParams {
+            year: u16::try_from(value.year())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            month: u8::try_from(value.month())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            day: u8::try_from(value.day())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            hour: u8::try_from(value.hour())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            minute: u8::try_from(value.minute())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            second: u8::try_from(value.second())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            nanosecond: u32::try_from(value.subsec_nanosecond())
+                .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            time_zone: Some(
+                i16::try_from(value.offset().seconds() / 60 /* seconds per minute */)
+                    .map_err(|_e| TimeConversionError(ConversionErrorInner::InvalidComponent))?,
+            ),
+            daylight: Default::default(),
+        };
+        Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
+    }
+}

--- a/uefi/src/runtime/time/integration_jiff_crate.rs
+++ b/uefi/src/runtime/time/integration_jiff_crate.rs
@@ -124,3 +124,60 @@ impl TryFrom<Zoned> for Time {
         Self::new(params).map_err(|e| TimeConversionError(ConversionErrorInner::InvalidUefiTime(e)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::integration_common::test_helpers;
+    use super::*;
+
+    #[test]
+    fn primitive_roundtrip_basic() {
+        test_helpers::primitive_roundtrip::<DateTime>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_positive_offset() {
+        test_helpers::zoned_roundtrip::<Zoned>();
+    }
+
+    #[test]
+    fn zoned_roundtrip_negative_offset() {
+        test_helpers::negative_offset_roundtrip::<Zoned>();
+    }
+
+    #[test]
+    fn nanoseconds_preserved() {
+        test_helpers::preserves_nanoseconds::<Zoned>();
+    }
+
+    #[test]
+    fn unspecified_timezone_is_rejected() {
+        test_helpers::unspecified_timezone_fails::<Zoned>();
+    }
+
+    #[test]
+    fn invalid_date_is_rejected() {
+        test_helpers::invalid_calendar_date_fails::<DateTime>();
+    }
+
+    // jiff-specific edge case: offset minute precision
+    #[test]
+    fn half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(90); // +01:30
+
+        let z: Zoned = t.try_into().unwrap();
+        let back: Time = z.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, 90);
+    }
+
+    #[test]
+    fn negative_half_hour_timezone_roundtrip() {
+        let t = test_helpers::sample_time(-330); // -05:30
+
+        let z: Zoned = t.try_into().unwrap();
+        let back: Time = z.try_into().unwrap();
+
+        assert_eq!(back.0.time_zone, -330);
+    }
+}

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -10,8 +10,10 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use uefi_raw::time::Daylight;
 
-#[cfg(feature = "time03")]
+#[cfg(any(feature = "jiff02", feature = "time03"))]
 mod integration_common;
+#[cfg(feature = "jiff02")]
+mod integration_jiff_crate;
 #[cfg(feature = "time03")]
 mod integration_time_crate;
 
@@ -28,7 +30,13 @@ mod integration_time_crate;
 /// - [`TryFrom`]: `PrimitiveDateTime` <--> [`Time`] (without timezone)
 /// - [`TryFrom`]: `OffsetDateTime` <--> [`Time`] (with timezone)
 ///
+/// ## Integration with [`jiff`][jiff crate] crate
+///
+/// - [`TryFrom`]: `DateTime` <--> [`Time`] (without timezone)
+/// - [`TryFrom`]: `Zoned` <--> [`Time`] (with timezone)
+///
 /// [time crate]: https://crates.io/crates/time
+/// [jiff crate]: https://crates.io/crates/jiff
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Time(uefi_raw::time::Time);

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -56,6 +56,7 @@ pub enum Feature {
     Unstable,
     PanicHandler,
     Qemu,
+    Jiff02,
     Time03,
 
     // `uefi-test-runner` features.
@@ -77,6 +78,7 @@ impl Feature {
             Self::Unstable => "unstable",
             Self::PanicHandler => "panic_handler",
             Self::Qemu => "qemu",
+            Self::Jiff02 => "jiff02",
             Self::Time03 => "time03",
 
             Self::DebugSupport => "uefi-test-runner/debug_support",
@@ -119,7 +121,13 @@ impl Feature {
     /// - `include_unstable` - add all functionality behind the `unstable` feature
     /// - `runtime_features` - add all functionality that effect the runtime of Rust
     pub fn more_code(include_unstable: bool, runtime_features: bool) -> Vec<Self> {
-        let mut base_features = vec![Self::Alloc, Self::LogDebugcon, Self::Logger, Self::Time03];
+        let mut base_features = vec![
+            Self::Alloc,
+            Self::Jiff02,
+            Self::LogDebugcon,
+            Self::Logger,
+            Self::Time03,
+        ];
         if include_unstable {
             base_features.extend([Self::Unstable])
         }
@@ -389,19 +397,19 @@ mod tests {
     fn test_comma_separated_features() {
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, false)),
-            "alloc,log-debugcon,logger,time03"
+            "alloc,jiff02,log-debugcon,logger,time03"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(false, true)),
-            "alloc,log-debugcon,logger,time03,global_allocator"
+            "alloc,jiff02,log-debugcon,logger,time03,global_allocator"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, false)),
-            "alloc,log-debugcon,logger,time03,unstable"
+            "alloc,jiff02,log-debugcon,logger,time03,unstable"
         );
         assert_eq!(
             Feature::comma_separated_string(&Feature::more_code(true, true)),
-            "alloc,log-debugcon,logger,time03,unstable,global_allocator"
+            "alloc,jiff02,log-debugcon,logger,time03,unstable,global_allocator"
         );
     }
 


### PR DESCRIPTION
Split-out from #1911 and companion of #1955 to add time-related integration with the `jiff` crate.