### PR TITLE
uefi: Fix `boot::exit` signature

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Changed
 - Corrected the type of the `driver_image` parameter in
   `BootServices::connect_controller` from `Handle` to `*const Handle`.
+- Corrected signature of `BootServices::exit` from `!` to `Status`.
 
 
 # uefi-raw - v0.14.0 (2026-03-22)

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -134,7 +134,7 @@ pub struct BootServices {
         exit_status: Status,
         exit_data_size: usize,
         exit_data: *mut Char16,
-    ) -> !,
+    ) -> Status,
     pub unload_image: unsafe extern "efiapi" fn(image_handle: Handle) -> Status,
     pub exit_boot_services:
         unsafe extern "efiapi" fn(image_handle: Handle, map_key: usize) -> Status,

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **Breaking:** The `driver_image` parameter of `boot::connect_controller` is
   now a `None`-terminated slice. Callers that previously passed `None` for this
   argument should pass in `&[]` instead.
+- **Breaking:** Corrected function signature of `boot::exit` to enable handling
+  errors during exit.
 
 # uefi - v0.37.0 (2026-03-22)
 

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1306,18 +1306,20 @@ pub unsafe fn exit(
     exit_status: Status,
     exit_data_size: usize,
     exit_data: *mut Char16,
-) -> ! {
+) -> Result {
     let bt = boot_services_raw_panicking();
     let bt = unsafe { bt.as_ref() };
 
-    unsafe {
+    let result = unsafe {
         (bt.exit)(
             image_handle.as_ptr(),
             exit_status,
             exit_data_size,
             exit_data.cast(),
         )
-    }
+    };
+
+    result.to_result()
 }
 
 /// Get the current memory map and exit boot services.


### PR DESCRIPTION
Fixes #1943.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
