### PR TITLE
uefi-raw: fix typo in PciRootBridgeIoProtocolAttributes

### DIFF
--- a/uefi-raw/src/protocol/pci/root_bridge.rs
+++ b/uefi-raw/src/protocol/pci/root_bridge.rs
@@ -42,7 +42,7 @@ bitflags! {
     /// Corresponds to the `EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL` attribute bitflags.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct PciRootBridgeIoProtocolAttribute: u64 {
+    pub struct PciRootBridgeIoProtocolAttributes: u64 {
         const EFI_PCI_ATTRIBUTE_ISA_MOTHERBOARD_IO = 0x0001;
         const EFI_PCI_ATTRIBUTE_ISA_IO = 0x0002;
         const EFI_PCI_ATTRIBUTE_VGA_PALETTE_IO = 0x0004;


### PR DESCRIPTION
Fix typo in definition of `PciRootBridgeIoProtocolAttributes`.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
