### PR TITLE
uefi: Add PciRootBridgeIo attribute manipulation

### DIFF
--- a/uefi-test-runner/src/proto/pci/root_bridge.rs
+++ b/uefi-test-runner/src/proto/pci/root_bridge.rs
@@ -9,6 +9,7 @@ use uefi::proto::device_path::DevicePath;
 use uefi::proto::device_path::text::{AllowShortcuts, DisplayOnly};
 use uefi::proto::pci::root_bridge::PciRootBridgeIo;
 use uefi::proto::scsi::pass_thru::ExtScsiPassThru;
+use uefi_raw::protocol::pci::root_bridge::PciRootBridgeIoProtocolAttributes;
 
 const RED_HAT_PCI_VENDOR_ID: u16 = 0x1AF4;
 const MASS_STORAGE_CTRL_CLASS_CODE: u8 = 0x1;
@@ -17,6 +18,11 @@ const SATA_CTRL_SUBCLASS_CODE: u8 = 0x6;
 const REG_SIZE: u8 = size_of::<u32>() as u8;
 
 pub fn test() {
+    test_enumeration_and_address_space_access();
+    test_attributes();
+}
+
+fn test_enumeration_and_address_space_access() {
     let pci_handles = uefi::boot::find_handles::<PciRootBridgeIo>().unwrap();
 
     let mut sata_ctrl_cnt = 0;
@@ -85,6 +91,27 @@ pub fn test() {
             .unwrap()
             .to_string();
         assert!(mass_storage_dev_paths.contains(&device_path));
+    }
+}
+
+fn test_attributes() {
+    let pci_handles = uefi::boot::find_handles::<PciRootBridgeIo>().unwrap();
+    for pci_handle in pci_handles {
+        let mut pci_proto = get_open_protocol::<PciRootBridgeIo>(pci_handle);
+
+        let supported_attributes = pci_proto.supported_attributes().unwrap();
+        log::info!("Supported Attributes: {supported_attributes:?}");
+
+        let current_attributes = pci_proto.attributes().unwrap();
+        log::info!("Current Attributes: {current_attributes:?}");
+
+        unsafe {
+            pci_proto
+                .set_attributes(PciRootBridgeIoProtocolAttributes::empty())
+                .unwrap()
+        }
+        unsafe { pci_proto.set_attributes(supported_attributes).unwrap() }
+        unsafe { pci_proto.set_attributes(current_attributes).unwrap() }
     }
 }
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 - Added `proto::console::text::InputEx`.
+- Added `proto::pci::PciRootBridgeIo::{supported_attributes(), attributes(),
+  set_attributes(), set_attributes_with_range()}`
 
 ## Changed
 - MSRV increased from 1.88 to 1.91.

--- a/uefi/src/proto/pci/root_bridge.rs
+++ b/uefi/src/proto/pci/root_bridge.rs
@@ -12,7 +12,9 @@ use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::ptr;
 use uefi_macros::unsafe_protocol;
-use uefi_raw::protocol::pci::root_bridge::{PciRootBridgeIoAccess, PciRootBridgeIoProtocol};
+use uefi_raw::protocol::pci::root_bridge::{
+    PciRootBridgeIoAccess, PciRootBridgeIoProtocol, PciRootBridgeIoProtocolAttributes,
+};
 
 #[cfg(doc)]
 use crate::Status;
@@ -51,12 +53,73 @@ impl PciRootBridgeIo {
         unsafe { (self.0.flush)(&mut self.0).to_result() }
     }
 
+    /// Gets the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge supports setting.
+    pub fn supported_attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
+        let mut supported = 0;
+
+        unsafe {
+            (self.0.get_attributes)(&self.0, &mut supported, ptr::null_mut()).to_result_with_val(
+                || PciRootBridgeIoProtocolAttributes::from_bits_retain(supported),
+            )
+        }
+    }
+
+    /// Gets the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge is currently using.
+    pub fn attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
+        let mut current = 0;
+
+        unsafe {
+            (self.0.get_attributes)(&self.0, ptr::null_mut(), &mut current)
+                .to_result_with_val(|| PciRootBridgeIoProtocolAttributes::from_bits_retain(current))
+        }
+    }
+
+    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge that does not require a
+    /// resource range.
+    ///
+    /// # Safety
+    ///
+    /// The new [`PciRootBridgeIoProtocolAttributes`] must be valid for the current system
+    /// configuration.
+    pub unsafe fn set_attributes(
+        &mut self,
+        attributes: PciRootBridgeIoProtocolAttributes,
+    ) -> crate::Result {
+        unsafe {
+            (self.0.set_attributes)(
+                &mut self.0,
+                attributes.bits(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+            .to_result()
+        }
+    }
+
+    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge (supporting attributes
+    /// that require a resource range).
+    ///
+    /// The provided base and length are set to the actual base and length of the region whose
+    /// attributes were changed (due to granularity or other requirements).
+    ///
+    /// # Safety
+    ///
+    /// The new [`PciRootBridgeIoProtocolAttributes`] must be valid for the current system
+    /// configuration.
+    pub unsafe fn set_attributes_with_range(
+        &mut self,
+        attributes: PciRootBridgeIoProtocolAttributes,
+        base: &mut u64,
+        length: &mut u64,
+    ) -> crate::Result {
+        unsafe { (self.0.set_attributes)(&mut self.0, attributes.bits(), base, length).to_result() }
+    }
+
     // TODO: poll I/O
     // TODO: mem I/O access
     // TODO: io I/O access
     // TODO: map & unmap & copy memory
     // TODO: buffer management
-    // TODO: get/set attributes
 
     /// Retrieves the current resource settings of this PCI root bridge in the form of a set of ACPI resource descriptors.
     ///

--- a/uefi/src/proto/pci/root_bridge.rs
+++ b/uefi/src/proto/pci/root_bridge.rs
@@ -53,7 +53,8 @@ impl PciRootBridgeIo {
         unsafe { (self.0.flush)(&mut self.0).to_result() }
     }
 
-    /// Gets the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge supports setting.
+    /// Returns the set of [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge
+    /// supports.
     pub fn supported_attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
         let mut supported = 0;
 
@@ -64,7 +65,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Gets the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge is currently using.
+    /// Returns the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge is currently using.
     pub fn attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
         let mut current = 0;
 
@@ -74,8 +75,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge that does not require a
-    /// resource range.
+    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge.
     ///
     /// # Safety
     ///
@@ -97,7 +97,8 @@ impl PciRootBridgeIo {
     }
 
     /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge (supporting attributes
-    /// that require a resource range).
+    /// that require a resource range). For instance, modifying the cache settings of a PCI
+    /// memory range requires the use of this function.
     ///
     /// The provided base and length are set to the actual base and length of the region whose
     /// attributes were changed (due to granularity or other requirements).


### PR DESCRIPTION
Adds functions to acquire and manipulate the `PciRootBridgeIoProtocolAttributes` associated with the `PcIRootBridgeIo` instance and its resource ranges.

Based on #1964.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
