### PR TITLE
ci: update QEMU for windows runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Install QEMU
-        run: choco install qemu --version 2023.4.24
+        run: choco install qemu --version 2026.5.1
       - name: Checkout sources
         uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - name: Run VM tests
-        run: cargo xtask run --target x86_64 --ci
+        run: cargo xtask run --target x86_64 --headless --ci
         timeout-minutes: 10
   test:
     name: Unit + Doc Tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Install QEMU
-        run: choco install qemu --version 2026.5.1
+        run: choco install qemu --version 2026.5.1 --no-progress --no-color
       - name: Checkout sources
         uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -87,7 +87,10 @@ impl Pipe {
 
 /// Attempt to connect to a duplex named pipe in byte mode.
 fn windows_open_pipe(path: &Path) -> Result<File> {
-    let max_attempts = 100;
+    let max_duration = Duration::from_secs(5);
+    let sleep_per_iteration = Duration::from_millis(100);
+    let iteration_count = max_duration.as_millis() / sleep_per_iteration.as_millis();
+
     let mut attempt = 0;
     loop {
         attempt += 1;
@@ -96,11 +99,12 @@ fn windows_open_pipe(path: &Path) -> Result<File> {
             Ok(file) => return Ok(file),
             Err(err) => {
                 #[allow(clippy::needless_return_with_question_mark)]
-                if attempt >= max_attempts {
+                if attempt >= iteration_count {
                     return Err(err)?;
                 } else {
                     // Sleep before trying again.
-                    thread::sleep(Duration::from_millis(100));
+                    eprintln!("waiting for pipe {} to appear ...", path.display());
+                    thread::sleep(sleep_per_iteration);
                 }
             }
         }


### PR DESCRIPTION
This will unblock https://github.com/rust-osdev/uefi-rs/pull/1728.
Also, it reverts https://github.com/rust-osdev/uefi-rs/pull/1884 which
reverted https://github.com/rust-osdev/uefi-rs/pull/1876. 