### PR TITLE
xtask: update OVMF from EDK2-STABLE202502 to EDK2-STABLE202605

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,11 +93,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -167,10 +173,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -192,21 +204,21 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -285,16 +297,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -381,6 +383,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "id-arena"
@@ -494,10 +505,11 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ovmf-prebuilt"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc1627ccb67ec2a931d34b5e97840c6f184f58cd2797ae253e848c58aea38a9"
+checksum = "8b2ed5d406bc56f93035547fe364feb90395682dd8cc9efea09e806f8f845a17"
 dependencies = [
+ "base16ct",
  "log",
  "lzma-rs",
  "sha2",
@@ -746,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1053,12 +1065,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"

--- a/uefi-test-runner/src/proto/network/http.rs
+++ b/uefi-test-runner/src/proto/network/http.rs
@@ -87,17 +87,17 @@ pub fn test() {
 
         // hard to find web sites which still allow plain http these days ...
         info!("Testing HTTP");
-        fetch_http(*h, "http://example.com/").expect("http request failed: http://example.com");
+        fetch_http(*h, "http://example.com/").expect("http request to http://example.com failed");
 
         // FYI: not all firmware builds support modern tls versions.
         // request() -> ABORTED typically is a tls handshake error.
         // check the firmware log for details.
         info!("Testing HTTPS");
-        fetch_http(
-            *h,
-            "https://raw.githubusercontent.com/rust-osdev/uefi-rs/refs/heads/main/Cargo.toml",
-        )
-        .expect("https request failed");
+        // Keep this endpoint compatible with edk2's TLS policy. Newer OVMF
+        // defaults OpenSSL to security level 3, so RSA <3072-bit leaf certs
+        // can make Request() fail before any HTTP response is available.
+        fetch_http(*h, "https://example.com/")
+            .expect("https request to https://example.com failed");
 
         info!("PASSED");
     }

--- a/uefi-test-runner/src/proto/network/http.rs
+++ b/uefi-test-runner/src/proto/network/http.rs
@@ -89,15 +89,36 @@ pub fn test() {
         info!("Testing HTTP");
         fetch_http(*h, "http://example.com/").expect("http request to http://example.com failed");
 
-        // FYI: not all firmware builds support modern tls versions.
+        // EDK2 uses platform-specific OpenSSL configurations, which can affect
+        // certificate compatibility with HTTPS hosts. Because both our test
+        // hosts and their certificates may change, try multiple candidates and
+        // require at least one request to succeed.
+        //
+        // Not all firmware builds support modern tls versions.
         // request() -> ABORTED typically is a tls handshake error.
         // check the firmware log for details.
+        let https_url_candidates = [
+            "https://example.com/",
+            "https://raw.githubusercontent.com/rust-osdev/uefi-rs/refs/heads/main/Cargo.toml",
+            "https://www.cloudflare.com/",
+            "https://www.google.com/",
+        ];
+
         info!("Testing HTTPS");
-        // Keep this endpoint compatible with edk2's TLS policy. Newer OVMF
-        // defaults OpenSSL to security level 3, so RSA <3072-bit leaf certs
-        // can make Request() fail before any HTTP response is available.
-        fetch_http(*h, "https://example.com/")
-            .expect("https request to https://example.com failed");
+        let https_results = https_url_candidates
+            .iter()
+            .map(|url| (url, fetch_http(*h, url)))
+            .collect::<Vec<_>>();
+        for (url, res) in &https_results {
+            debug!(
+                "HTTPS request to: {url}: {}",
+                if res.is_some() { "OK" } else { "FAILED" }
+            );
+        }
+        assert!(
+            https_results.iter().any(|(_, res)| res.is_some()),
+            "No HTTPS request succeeded"
+        );
 
         info!("PASSED");
     }

--- a/uefi-test-runner/src/proto/network/http.rs
+++ b/uefi-test-runner/src/proto/network/http.rs
@@ -89,36 +89,53 @@ pub fn test() {
         info!("Testing HTTP");
         fetch_http(*h, "http://example.com/").expect("http request to http://example.com failed");
 
-        // EDK2 uses platform-specific OpenSSL configurations, which can affect
-        // certificate compatibility with HTTPS hosts. Because both our test
-        // hosts and their certificates may change, try multiple candidates and
-        // require at least one request to succeed.
+        // Since edk2-stable202511, the default OpenSSL security level has been
+        // raised from 0 to 3, which rejects older RSA-based keys. Unfortunately,
+        // the EDK2 aarch64 build forcefully disables all EC-based keys
+        // (-DEDK2_OPENSSL_NOEC=1), effectively preventing connections to most
+        // HTTPS/TLS hosts. Temporarily disable this test on aarch64 until
+        // EC-based keys are supported there.
         //
-        // Not all firmware builds support modern tls versions.
-        // request() -> ABORTED typically is a tls handshake error.
-        // check the firmware log for details.
-        let https_url_candidates = [
-            "https://example.com/",
-            "https://raw.githubusercontent.com/rust-osdev/uefi-rs/refs/heads/main/Cargo.toml",
-            "https://www.cloudflare.com/",
-            "https://www.google.com/",
-        ];
+        // See https://github.com/rust-osdev/uefi-rs/issues/1975
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            // EDK2 uses platform-specific OpenSSL configurations, which can affect
+            // certificate compatibility with HTTPS hosts. Because both our test
+            // hosts and their certificates may change, try multiple candidates and
+            // require at least one request to succeed.
+            //
+            // Not all firmware builds support modern tls versions.
+            // request() -> ABORTED typically is a tls handshake error.
+            // check the firmware log for details.
+            let https_url_candidates = [
+                "https://example.com/",
+                "https://raw.githubusercontent.com/rust-osdev/uefi-rs/refs/heads/main/Cargo.toml",
+                "https://www.cloudflare.com/",
+                "https://www.google.com/",
+            ];
 
-        info!("Testing HTTPS");
-        let https_results = https_url_candidates
-            .iter()
-            .map(|url| (url, fetch_http(*h, url)))
-            .collect::<Vec<_>>();
-        for (url, res) in &https_results {
-            debug!(
-                "HTTPS request to: {url}: {}",
-                if res.is_some() { "OK" } else { "FAILED" }
+            info!("Testing HTTPS");
+            let https_results = https_url_candidates
+                .iter()
+                .map(|url| (url, fetch_http(*h, url)))
+                .collect::<Vec<_>>();
+            for (url, res) in &https_results {
+                debug!(
+                    "HTTPS request to: {url}: {}",
+                    if res.is_some() { "OK" } else { "FAILED" }
+                );
+            }
+            assert!(
+                https_results.iter().any(|(_, res)| res.is_some()),
+                "No HTTPS request succeeded"
             );
         }
-        assert!(
-            https_results.iter().any(|(_, res)| res.is_some()),
-            "No HTTPS request succeeded"
-        );
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            // See https://github.com/rust-osdev/uefi-rs/issues/1975
+            warn!("Skipping HTTPS test on aarch64 (see #1975)");
+        }
 
         info!("PASSED");
     }

--- a/uefi/src/proto/network/http.rs
+++ b/uefi/src/proto/network/http.rs
@@ -43,6 +43,7 @@ impl Http {
     /// Configure HTTP Protocol.  Must be called before sending HTTP requests.
     pub fn configure(&mut self, config_data: &HttpConfigData) -> uefi::Result<()> {
         let status = unsafe { (self.0.configure)(&mut self.0, config_data) };
+        debug!("http raw: configure({config_data:?}) -> {status}");
         match status {
             Status::SUCCESS => Ok(()),
             _ => Err(status.into()),
@@ -52,6 +53,12 @@ impl Http {
     /// Send HTTP request.
     pub fn request(&mut self, token: &mut HttpToken) -> uefi::Result<()> {
         let status = unsafe { (self.0.request)(&mut self.0, token) };
+        debug!(
+            "http raw: request(headers={}, body_len={}) -> {status}, token.status={}",
+            unsafe { (*token.message).header_count },
+            unsafe { (*token.message).body_length },
+            token.status,
+        );
         match status {
             Status::SUCCESS => Ok(()),
             _ => Err(status.into()),
@@ -70,6 +77,11 @@ impl Http {
     /// Receive HTTP response.
     pub fn response(&mut self, token: &mut HttpToken) -> uefi::Result<()> {
         let status = unsafe { (self.0.response)(&mut self.0, token) };
+        debug!(
+            "http raw: response(body_len={}) -> {status}, token.status={}",
+            unsafe { (*token.message).body_length },
+            token.status,
+        );
         match status {
             Status::SUCCESS => Ok(()),
             _ => Err(status.into()),
@@ -211,12 +223,16 @@ impl HttpHelper {
     ) -> uefi::Result<()> {
         let url16 = uefi::CString16::try_from(url).unwrap();
 
+        let scheme = url.split(':').next().unwrap_or("<missing>");
         let Some(hostname) = url.split('/').nth(2) else {
             return Err(Status::INVALID_PARAMETER.into());
         };
         let mut c_hostname = String::from(hostname);
         c_hostname.push('\0');
-        debug!("http: host: {hostname}");
+        debug!(
+            "http: request setup: method={method:?}, scheme={scheme}, host={hostname}, body_len={}",
+            body.as_ref().map_or(0, |body| body.len())
+        );
 
         let mut tx_req = HttpRequestData {
             method,
@@ -248,12 +264,18 @@ impl HttpHelper {
         p.request(&mut tx_token)?;
         debug!("http: request sent ok");
 
+        let mut polls = 0;
         loop {
             if tx_token.status != Status::NOT_READY {
                 break;
             }
+            polls += 1;
             p.poll()?;
         }
+        debug!(
+            "http: request token completed after {polls} polls with {}",
+            tx_token.status
+        );
 
         if tx_token.status != Status::SUCCESS {
             return Err(tx_token.status.into());

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.14.0"
 log.workspace = true
 mbrman = "0.6.0"
 nix = { version = "0.31.0", default-features = false, features = ["fs"] }
-ovmf-prebuilt = "0.2.3"
+ovmf-prebuilt = "0.2.9"
 proc-macro2 = { version = "1.0.46", features = ["span-locations"] }
 quote = "1.0.21"
 regex = "1.10.2"

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -21,10 +21,24 @@ use tempfile::TempDir;
 use {std::fs::Permissions, std::os::unix::fs::PermissionsExt};
 
 /// Name of the ovmf-prebuilt release to use by default.
+///
+/// This is typically the latest stable release.
 const OVMF_PREBUILT_SOURCE: Source = Source::EDK2_STABLE202605_R1;
+
+/// Name of the ovmf-prebuilt release to use for IA32.
+///
+/// After EDK2_STABLE202508_R1, IA32 support was dropped in edk2.
+const OVMF_PREBUILT_IA32_SOURCE: Source = Source::EDK2_STABLE202508_R1;
 
 /// Directory into which the prebuilts will be download (relative to the repo root).
 const OVMF_PREBUILT_DIR: &str = "target/ovmf";
+
+fn ovmf_prebuilt_source(arch: UefiArch) -> Source {
+    match arch {
+        UefiArch::IA32 => OVMF_PREBUILT_IA32_SOURCE,
+        UefiArch::AArch64 | UefiArch::X86_64 => OVMF_PREBUILT_SOURCE,
+    }
+}
 
 impl From<UefiArch> for ovmf_prebuilt::Arch {
     fn from(arch: UefiArch) -> Self {
@@ -52,6 +66,7 @@ struct OvmfPaths {
     code: PathBuf,
     vars: PathBuf,
     shell: PathBuf,
+    prebuilt_source_tag: &'static str,
 }
 
 impl OvmfPaths {
@@ -62,7 +77,12 @@ impl OvmfPaths {
     /// 1. Command-line arg
     /// 2. Environment variable
     /// 3. Prebuilt file (automatically downloaded)
-    fn find_ovmf_file(file_type: FileType, opt: &QemuOpt, arch: UefiArch) -> Result<PathBuf> {
+    fn find_ovmf_file(
+        file_type: FileType,
+        opt: &QemuOpt,
+        arch: UefiArch,
+        prebuilt: &Prebuilt,
+    ) -> Result<PathBuf> {
         if let Some(path) = get_user_provided_path(file_type, opt) {
             // The user provided an exact path to use; verify that it
             // exists.
@@ -76,8 +96,6 @@ impl OvmfPaths {
                 );
             }
         } else {
-            let prebuilt = Prebuilt::fetch(OVMF_PREBUILT_SOURCE, OVMF_PREBUILT_DIR)?;
-
             Ok(prebuilt.get_file(arch.into(), file_type))
         }
     }
@@ -85,11 +103,35 @@ impl OvmfPaths {
     /// Find path to OVMF files by the strategy documented for
     /// [`Self::find_ovmf_file`].
     fn find(opt: &QemuOpt, arch: UefiArch) -> Result<Self> {
-        let code = Self::find_ovmf_file(FileType::Code, opt, arch)?;
-        let vars = Self::find_ovmf_file(FileType::Vars, opt, arch)?;
-        let shell = Self::find_ovmf_file(FileType::Shell, opt, arch)?;
+        let prebuilt_source = ovmf_prebuilt_source(arch);
+        let prebuilt = Prebuilt::fetch(prebuilt_source.clone(), OVMF_PREBUILT_DIR)?;
+        let code = Self::find_ovmf_file(FileType::Code, opt, arch, &prebuilt)?;
+        let vars = Self::find_ovmf_file(FileType::Vars, opt, arch, &prebuilt)?;
+        let shell = Self::find_ovmf_file(FileType::Shell, opt, arch, &prebuilt)?;
 
-        Ok(Self { code, vars, shell })
+        Ok(Self {
+            code,
+            vars,
+            shell,
+            prebuilt_source_tag: prebuilt_source.tag,
+        })
+    }
+
+    fn log(&self, arch: UefiArch) {
+        eprintln!("OVMF:");
+        eprintln!("  version: {}", self.prebuilt_source_tag);
+        if arch == UefiArch::IA32 {
+            // https://github.com/tianocore/edk2/commit/1fb88ffe284782cc79e306306b8d19829b6248b7
+            eprintln!(
+                "{leftpadding}note: using this instead of {} as it is the last \
+                 release with IA32 support in edk2",
+                OVMF_PREBUILT_SOURCE.tag,
+                leftpadding = " ".repeat(11)
+            );
+        }
+        eprintln!("  code   : {}", self.code.display());
+        eprintln!("  vars   : {}", self.vars.display());
+        eprintln!("  shell  : {}", self.shell.display());
     }
 }
 
@@ -422,6 +464,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
 
     // Set up OVMF.
     let ovmf_paths = OvmfPaths::find(opt, arch)?;
+    ovmf_paths.log(arch);
 
     // Make a copy of the OVMF vars file so that it can be used
     // read+write without modifying the original. Under AArch64, some

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 use {std::fs::Permissions, std::os::unix::fs::PermissionsExt};
 
 /// Name of the ovmf-prebuilt release to use by default.
-const OVMF_PREBUILT_SOURCE: Source = Source::EDK2_STABLE202502_R2;
+const OVMF_PREBUILT_SOURCE: Source = Source::EDK2_STABLE202605_R1;
 
 /// Directory into which the prebuilts will be download (relative to the repo root).
 const OVMF_PREBUILT_DIR: &str = "target/ovmf";


### PR DESCRIPTION
We update OVMF to include the latest bugfixes and overall most recent
version. This influences the version of OFMF (edk2) that we use in our
integration tests. 

- bump OVMF for x86_64 and aarch64 from EDK2-STABLE202502 to EDK2-STABLE202605
- pin OVMF for IA32 (32-bit x86) to EDK2-STABLE202508 which is the last release with IA32 support
- update the HTTPS test code as OpenSSL changes after 2025-08 influence what certificates are accepted (details in the commit messages)

This will unblock #1728 