### PR TITLE
treewide: remove IA32 support

### DIFF
--- a/.github/workflows/nightly_toolchain.toml
+++ b/.github/workflows/nightly_toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]
+targets = ["aarch64-unknown-uefi", "x86_64-unknown-uefi"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,20 +45,6 @@ jobs:
       - name: Run VM tests
         run: cargo xtask run --target x86_64 --headless --ci --tpm=v1
         timeout-minutes: 4
-  test_ia32:
-    name: Integration Test (IA-32)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-      - uses: Swatinem/rust-cache@v2
-      - name: Install qemu
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu-system-x86 swtpm -y
-      - name: Run VM tests
-        run: cargo xtask run --target ia32 --headless --ci --tpm=v2
-        timeout-minutes: 4
   # Ensure that developers can build and use this crate on Windows.
   test_x86_64_windows:
     name: Integration Test (x86_64 Windows)

--- a/book/src/tutorial/building.md
+++ b/book/src/tutorial/building.md
@@ -9,7 +9,7 @@ repository, add `rust-toolchain.toml`:
 
 ```toml
 [toolchain]
-targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]
+targets = ["aarch64-unknown-uefi", "x86_64-unknown-uefi"]
 ```
 
 Here we have specified all three of the currently-supported UEFI targets; you

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "stable"
 # cargo, clippy, rustc, rust-docs, rustfmt, rust-std
 profile = "default"
-targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]
+targets = ["aarch64-unknown-uefi", "x86_64-unknown-uefi"]

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-targets = ["aarch64-unknown-uefi", "i686-unknown-uefi", "x86_64-unknown-uefi"]
+targets = ["aarch64-unknown-uefi", "x86_64-unknown-uefi"]

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -20,6 +20,13 @@
 - **Breaking:** Removed the deprecated `VariableKey::name()` method. Use the
   public `VariableKey::name` field instead.
 
+## Misc
+- We removed testing for IA-32 (32-bit x86, `i686-unknown-uefi`) as OVMF also
+  dropped this target after the 202508 release (see
+  <https://github.com/tianocore/edk2/commit/1fb88ffe284782cc79e306306b8d19829b6248b7>).
+  The crate will likely continue to compile and function with
+  `i686-unknown-uefi`.
+
 # uefi - v0.37.0 (2026-03-22)
 
 ## Added

--- a/xtask/src/arch.rs
+++ b/xtask/src/arch.rs
@@ -7,9 +7,6 @@ pub enum UefiArch {
     #[value(name = "aarch64")]
     AArch64,
 
-    #[value(name = "ia32")]
-    IA32,
-
     #[value(name = "x86_64")]
     #[default]
     X86_64,
@@ -19,7 +16,6 @@ impl UefiArch {
     fn as_str(self) -> &'static str {
         match self {
             Self::AArch64 => "aarch64",
-            Self::IA32 => "ia32",
             Self::X86_64 => "x86_64",
         }
     }
@@ -27,7 +23,6 @@ impl UefiArch {
     pub fn as_triple(self) -> &'static str {
         match self {
             Self::AArch64 => "aarch64-unknown-uefi",
-            Self::IA32 => "i686-unknown-uefi",
             Self::X86_64 => "x86_64-unknown-uefi",
         }
     }

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -30,7 +30,6 @@ impl From<UefiArch> for ovmf_prebuilt::Arch {
     fn from(arch: UefiArch) -> Self {
         match arch {
             UefiArch::AArch64 => Self::Aarch64,
-            UefiArch::IA32 => Self::Ia32,
             UefiArch::X86_64 => Self::X64,
         }
     }
@@ -261,7 +260,6 @@ fn build_esp_dir(opt: &QemuOpt, ovmf_paths: &OvmfPaths) -> Result<PathBuf> {
 
     let boot_file_name = match *opt.target {
         UefiArch::AArch64 => "BootAA64.efi",
-        UefiArch::IA32 => "BootIA32.efi",
         UefiArch::X86_64 => "BootX64.efi",
     };
 
@@ -310,7 +308,7 @@ impl Drop for ChildWrapper {
 pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     let qemu_exe = match arch {
         UefiArch::AArch64 => "qemu-system-aarch64",
-        UefiArch::IA32 | UefiArch::X86_64 => "qemu-system-x86_64",
+        UefiArch::X86_64 => "qemu-system-x86_64",
     };
 
     // The QEMU installer for Windows does not automatically add the
@@ -380,7 +378,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
             // Graphics device.
             cmd.args(["-device", "virtio-gpu-pci"]);
         }
-        UefiArch::IA32 | UefiArch::X86_64 => {
+        UefiArch::X86_64 => {
             // Use a modern machine.
             cmd.args(["-machine", "q35"]);
 
@@ -439,7 +437,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
     // Configure SCSI Controller
     cmd.arg("-device");
     cmd.arg("virtio-scsi-pci");
-    if arch != UefiArch::IA32 && arch != UefiArch::X86_64 {
+    if arch != UefiArch::X86_64 {
         // The "virt" qemu machine does not have SATA-Controller by default
         cmd.arg("-device");
         cmd.arg("ahci,id=ide");
@@ -599,7 +597,7 @@ pub fn run_qemu(arch: UefiArch, opt: &QemuOpt) -> Result<()> {
         .context(format!("qemu was terminated by a signal: {status:?}"))?;
 
     let successful_exit_code = match arch {
-        UefiArch::AArch64 | UefiArch::IA32 => 0,
+        UefiArch::AArch64 => 0,
 
         // The x86_64 version of uefi-test-runner uses exit code 3 to
         // indicate success. See the `shutdown` function in


### PR DESCRIPTION
This is a prerequisite for the next OVMF bump (#1970). EDK2 removed IA32 support
since the 202508 release [0].

[0] https://github.com/tianocore/edk2/commit/1fb88ffe284782cc79e306306b8d19829b6248b7

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
