### PR TITLE
uefi-raw: enhance Boolean type and make it more type safe

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Corrected the type of the `driver_image` parameter in
   `BootServices::connect_controller` from `Handle` to `*const Handle`.
 - Corrected signature of `BootServices::exit` from `!` to `Status`.
+- We made changes to the `Boolean` type, especially switching to manual
+  implementations of `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` to match
+  the type's logical properties. If you rely on the specific bit pattern,
+  please use `.0` to access the underlying value.
 
 
 # uefi-raw - v0.14.0 (2026-03-22)

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -33,11 +33,13 @@ pub mod time;
 mod net;
 mod status;
 
+use core::cmp;
 pub use net::*;
 pub use status::Status;
 pub use uguid::{Guid, guid};
 
 use core::ffi::c_void;
+use core::hash::{Hash, Hasher};
 
 /// Handle to an event structure.
 pub type Event = *mut c_void;
@@ -73,17 +75,32 @@ pub type VirtualAddress = u64;
 /// This is similar to a `bool`, but allows values other than 0 or 1 to be
 /// stored without it being undefined behavior.
 ///
-/// Any non-zero value is treated as logically `true`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Ord, PartialOrd, Eq, Hash)]
+/// Any non-zero value is treated as logical `true`. The comparison, ordering,
+/// and hashing implementations follow that logical interpretation, so all
+/// non-zero values compare equal and hash the same way. The original byte is
+/// still preserved in the public field; compare the `.0` values directly when
+/// the exact raw bit pattern matters.
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct Boolean(pub u8);
 
 impl Boolean {
     /// [`Boolean`] representing `true`.
+    ///
+    /// # Caution
+    ///
+    /// This is only one possible true bit pattern. In UEFI, every non-zero
+    /// bit pattern is treated as logical `true`.
     pub const TRUE: Self = Self(1);
 
     /// [`Boolean`] representing `false`.
     pub const FALSE: Self = Self(0);
+}
+
+impl From<u8> for Boolean {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
 }
 
 impl From<bool> for Boolean {
@@ -103,6 +120,45 @@ impl From<Boolean> for bool {
             0 => false,
             _ => true,
         }
+    }
+}
+
+impl PartialEq for Boolean {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.0, other.0) {
+            (0, 0) => true,
+            (0, _) => false,
+            (_, 0) => false,
+            // We handle it as in C: Any bit-pattern != 0 equals true
+            (_, _) => true,
+        }
+    }
+}
+
+impl Eq for Boolean {}
+
+impl PartialOrd for Boolean {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Boolean {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        match (self.0, other.0) {
+            (0, 0) => cmp::Ordering::Equal,
+            (0, _) => cmp::Ordering::Less,
+            (_, 0) => cmp::Ordering::Greater,
+            // We handle it as in C: Any bit-pattern != 0 equals true
+            (_, _) => cmp::Ordering::Equal,
+        }
+    }
+}
+
+impl Hash for Boolean {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let seed = if self.0 == 0 { 0 } else { 1 };
+        state.write_u8(seed);
     }
 }
 
@@ -126,5 +182,49 @@ mod tests {
         // We do it as in C: Every bit pattern not 0 is equal to true.
         assert!(bool::from(Boolean(0b11111110)));
         assert!(bool::from(Boolean(0b11111111)));
+    }
+
+    #[test]
+    fn test_order() {
+        assert!(Boolean::FALSE < Boolean::TRUE);
+        assert!(Boolean::TRUE > Boolean::FALSE);
+    }
+
+    #[test]
+    fn test_equality() {
+        assert_eq!(Boolean(0), Boolean(0));
+        assert_ne!(Boolean(0), Boolean(3));
+        assert_ne!(Boolean(7), Boolean(0));
+        assert_eq!(Boolean(1), Boolean(1));
+        assert_eq!(Boolean(13), Boolean(7));
+    }
+
+    // Tests that hash impl matches equal impl
+    #[test]
+    fn test_hash() {
+        #[derive(Default)]
+        struct TestHasher(u64);
+
+        impl Hasher for TestHasher {
+            fn finish(&self) -> u64 {
+                self.0
+            }
+
+            fn write(&mut self, bytes: &[u8]) {
+                for byte in bytes {
+                    self.0 = self.0.wrapping_mul(257).wrapping_add(u64::from(*byte));
+                }
+            }
+        }
+
+        fn calculate_hash(value: Boolean) -> u64 {
+            let mut hasher = TestHasher::default();
+            value.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        assert_eq!(calculate_hash(Boolean(1)), calculate_hash(Boolean(13)));
+        assert_eq!(calculate_hash(Boolean(13)), calculate_hash(Boolean(255)));
+        assert_ne!(calculate_hash(Boolean(0)), calculate_hash(Boolean(13)));
     }
 }


### PR DESCRIPTION
We update OVMF to include the latest bugfixes and overall most recent
version. This influences the version of OFMF (edk2) that we use in our
integration tests (`cargo xtask run`).


## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
