### PR TITLE
uefi: reject undersized device path nodes

### DIFF
--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -358,7 +358,8 @@ impl<'a> TryFrom<&'a [u8]> for &'a DevicePathNode {
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         let dp = <&DevicePathHeader>::try_from(bytes)?;
-        if usize::from(dp.length()) <= bytes.len() {
+        let length = usize::from(dp.length());
+        if length >= size_of::<DevicePathHeader>() && length <= bytes.len() {
             unsafe { Ok(DevicePathNode::from_ffi_ptr(bytes.as_ptr().cast())) }
         } else {
             Err(ByteConversionError::InvalidLength)
@@ -1122,6 +1123,10 @@ mod tests {
 
         // [`DevicePathNode`] data length exceeds the raw_data slice.
         raw_data[2] += 1;
+        assert!(<&DevicePathNode>::try_from(raw_data.as_slice()).is_err());
+
+        // [`DevicePathNode`] data length is shorter than the fixed header.
+        raw_data[2..4].copy_from_slice(&3_u16.to_le_bytes());
         assert!(<&DevicePathNode>::try_from(raw_data.as_slice()).is_err());
     }
 

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -1154,6 +1154,18 @@ mod tests {
         assert_eq!(nodes.len(), 5);
     }
 
+    #[test]
+    fn test_device_path_from_bytes_rejects_short_node_length() {
+        #[rustfmt::skip]
+        let raw_data = [
+            0xa0, 0xb0,
+            // Length shorter than the fixed header.
+            0x03, 0x00,
+        ];
+
+        assert!(<&DevicePath>::try_from(raw_data.as_slice()).is_err());
+    }
+
     /// Test converting from `&DevicePathNode` to a specific node type.
     #[test]
     fn test_specific_node_from_device_path_node() {


### PR DESCRIPTION
Device path node lengths include the fixed header. A shorter length cannot describe a valid node and must be rejected before constructing the packed DST reference.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
