### PR TITLE
release: uefi-raw-0.15.0, uefi-0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ dependencies = [
  "getrandom 0.2.17",
  "libc",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitflags 2.11.1",
  "uguid",
@@ -1233,14 +1233,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1249,15 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uefi = { version = "0.37.0", features = ["panic_handler"] }
+uefi = { version = "0.38.0", features = ["panic_handler"] }

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,6 +1,15 @@
 # uefi-raw - [Unreleased]
 
 ## Added
+
+## Changed
+
+## Removed
+
+
+# uefi-raw - v0.15.0 (2026-06-21)
+
+## Added
 - Added `SimpleTextInputExProtocol`.
 - Added `PciRootBridgeIoProtocolAttributes`
 

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.14.0"
+version = "0.15.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,6 +1,17 @@
 # uefi - [Unreleased]
 
 ## Added
+
+
+## Changed
+
+
+## Removed
+
+
+# uefi - v0.38.0 (2026-06-21)
+
+## Added
 - Added `proto::console::text::InputEx`.
 - Added `proto::pci::PciRootBridgeIo::{supported_attributes(), attributes(),
   set_attributes(), set_attributes_with_range()}`

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.37.0"
+version = "0.38.0"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,
@@ -50,7 +50,7 @@ uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
 uefi-macros = "0.19.0"
-uefi-raw = "0.14.0"
+uefi-raw = "0.15.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Time for anothr release. It's been 3 months and we have many great bug fixes and new functionality.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
