### PR TITLE
remove multilingual field from book.toml

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,5 +1,4 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust UEFI Book"


### PR DESCRIPTION
When running `mdbook serve book/` as shown in book/README.md, mdbook returns an error:
```
ERROR Invalid configuration file
	Caused by: TOML parse error at line 3, column 1
  |
3 | multilingual = false
  | ^^^^^^^^^^^^
unknown field `multilingual`, expected one of `title`, `authors`, `description`, `src`, `language`, `text-direction`
```
Apparently this field never did anything and was removed [here](https://github.com/rust-lang/mdBook/pull/2775).

It's a one-line fix to remove the field from the book/book.toml file.