### PR TITLE
Make memory maps repr(C)

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 ## Changed
+- Made memory map types `#[repr(C)]`
 
 ## Removed
 

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -44,6 +44,7 @@ impl core::error::Error for MemoryMapError {}
 
 /// Implementation of [`MemoryMap`] for the given buffer.
 #[derive(Debug)]
+#[repr(C)]
 pub struct MemoryMapRef<'a> {
     buf: &'a [u8],
     meta: MemoryMapMeta,
@@ -107,6 +108,7 @@ impl Index<usize> for MemoryMapRef<'_> {
 
 /// Implementation of [`MemoryMapMut`] for the given buffer.
 #[derive(Debug)]
+#[repr(C)]
 pub struct MemoryMapRefMut<'a> {
     buf: &'a mut [u8],
     meta: MemoryMapMeta,
@@ -287,6 +289,7 @@ impl IndexMut<usize> for MemoryMapRefMut<'_> {
 ///
 /// [`boot::get_memory_map`]: crate::boot::get_memory_map
 #[derive(Debug)]
+#[repr(C)]
 pub(crate) struct MemoryMapBackingMemory(NonNull<[u8]>);
 
 impl MemoryMapBackingMemory {
@@ -386,6 +389,7 @@ impl Drop for MemoryMapBackingMemory {
 
 /// Implementation of [`MemoryMapMut`] that owns the buffer on the UEFI heap.
 #[derive(Debug)]
+#[repr(C)]
 pub struct MemoryMapOwned {
     /// Backing memory, properly initialized at this point.
     pub(crate) buf: MemoryMapBackingMemory,

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -66,6 +66,7 @@ pub struct MemoryMapKey(pub(crate) usize);
 /// called. All following invocations (hidden, subtle, and asynchronous ones)
 /// will likely invalidate this.
 #[derive(Copy, Clone, Debug)]
+#[repr(C)]
 pub struct MemoryMapMeta {
     /// The actual size of the map.
     pub map_size: usize,


### PR DESCRIPTION
I want to hand over a memory map to a binary that uses the same version of `uefi` but may have been compiled with different rustflags; this makes it easier to do so soundly.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
