### PR TITLE
Revert "Make memory maps repr(C)"

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -5,7 +5,6 @@
   the extended processor topology.
 
 ## Changed
-- Made memory map types `#[repr(C)]`
 - Added `char16!` const-compatible macro as convenient replacement for `Char16::try_from().unwrap()`
 - `proto::debug::SystemContextARM` now contains the trailing `IFAR` field
   mandated by the spec.

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -44,7 +44,6 @@ impl core::error::Error for MemoryMapError {}
 
 /// Implementation of [`MemoryMap`] for the given buffer.
 #[derive(Debug)]
-#[repr(C)]
 pub struct MemoryMapRef<'a> {
     buf: &'a [u8],
     meta: MemoryMapMeta,
@@ -108,7 +107,6 @@ impl Index<usize> for MemoryMapRef<'_> {
 
 /// Implementation of [`MemoryMapMut`] for the given buffer.
 #[derive(Debug)]
-#[repr(C)]
 pub struct MemoryMapRefMut<'a> {
     buf: &'a mut [u8],
     meta: MemoryMapMeta,
@@ -289,7 +287,6 @@ impl IndexMut<usize> for MemoryMapRefMut<'_> {
 ///
 /// [`boot::get_memory_map`]: crate::boot::get_memory_map
 #[derive(Debug)]
-#[repr(C)]
 pub(crate) struct MemoryMapBackingMemory(NonNull<[u8]>);
 
 impl MemoryMapBackingMemory {
@@ -389,7 +386,6 @@ impl Drop for MemoryMapBackingMemory {
 
 /// Implementation of [`MemoryMapMut`] that owns the buffer on the UEFI heap.
 #[derive(Debug)]
-#[repr(C)]
 pub struct MemoryMapOwned {
     /// Backing memory, properly initialized at this point.
     pub(crate) buf: MemoryMapBackingMemory,

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -64,7 +64,6 @@ pub struct MemoryMapKey(pub(crate) usize);
 /// called. All following invocations (hidden, subtle, and asynchronous ones)
 /// will likely invalidate this.
 #[derive(Copy, Clone, Debug)]
-#[repr(C)]
 pub struct MemoryMapMeta {
     /// The actual size of the map.
     pub map_size: usize,


### PR DESCRIPTION
Reverting this makes sense, and I don't think it says anything against the idea itself. Passing a memory map from a bootloader to a kernel is a real use case worth solving.

The problem is that `#[repr(C)]` does not actually solve it here. These types contain wide pointers (`&[u8]`, `NonNull<[u8]>`), whose internal layout Rust does not specify. So `repr(C)` fixes the outer field order, but does not make the types ABI-stable. Since all fields are also private or `pub(crate)`, consumers could not rely on that layout anyway. It also conflicts a bit with the existing meaning of `repr(C)` in this crate: "firmware reads this".

I asked for a concrete real-world use case this would unblock, but none came up. The original author also described it more as experimentation than a serious use case. Since this never shipped in a release, reverting it costs us nothing and keeps the door open for a proper solution later.

For now, users can transport `buffer()` together with the scalar fields from `meta()` in their own format and reconstruct it with `MemoryMapRef::new` on the other side. If this pattern proves useful in practice, we can later add a dedicated handoff type with explicit and documented ABI guarantees.
