### PR TITLE
treewide: streamline rustdoc (LLM assisted overhaul of most documentation)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,27 @@ This repository follows Rust's [standard style][style], the same one imposed by 
 
 You can apply the standard style to the whole package by running `cargo fmt --all`.
 
+### Rustdoc
+
+Start each rustdoc comment with a short, complete summary sentence. The summary
+should normally fit on one line and must not exceed two lines at 80 columns.
+Put additional explanation in a separate paragraph.
+
+Use standard sections for API contracts:
+
+- Use `# Arguments` when parameters need explanation beyond their names and
+  types. Describe parameters as ``- `name`: description.``
+- Use `# Returns` when the return value is not clear from the summary and type.
+- Use `# Errors` for meaningful failure conditions of fallible APIs. Link to
+  specific UEFI status values where applicable, and do not list successful
+  statuses.
+- Use `# Panics` and `# Safety` for their respective contracts.
+- Use `# Example` for one example and `# Examples` for multiple examples.
+
+Prefer these sections over embedding contract details in general prose. Avoid
+generic `# Description` and `# Details` sections; put that information in the
+introductory paragraphs instead.
+
 [style]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md
 
 ## UEFI pitfalls

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate makes it easy to develop Rust software that leverages **safe**,
 ![Stars](https://img.shields.io/github/stars/rust-osdev/uefi-rs)
 
 ![UEFI App running in QEMU](https://imgur.com/SFPSVuO.png)
-Screenshot of an application running in QEMU on an UEFI firmware that leverages
+Screenshot of an application running in QEMU on UEFI firmware that uses
 our Rust library.
 
 ## API and User Documentation

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -103,7 +103,7 @@ pub fn unsafe_protocol(args: TokenStream, input: TokenStream) -> TokenStream {
 /// The global system table pointer and global image handle will be set
 /// automatically.
 ///
-/// # Examples
+/// # Example
 ///
 /// ```no_run
 /// #![no_main]

--- a/uefi-macros/src/lib.rs
+++ b/uefi-macros/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Procedural macros for the `uefi` crate.
+
 #![recursion_limit = "128"]
 
 extern crate proc_macro;

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -3,9 +3,9 @@ name = "uefi-raw"
 version = "0.15.1"
 readme = "README.md"
 description = """
-Raw UEFI types and bindings for protocols, boot, and runtime services. This can
-serve as base for an UEFI firmware implementation or a high-level wrapper to
-access UEFI functionality from an UEFI image.
+Raw UEFI types and bindings for protocols, boot services, and runtime services.
+They can serve as a base for UEFI firmware implementations or high-level
+wrappers.
 """
 
 authors.workspace = true

--- a/uefi-raw/README.md
+++ b/uefi-raw/README.md
@@ -3,7 +3,10 @@
 [![Crates.io](https://img.shields.io/crates/v/uefi-raw)](https://crates.io/crates/uefi-raw)
 [![Docs.rs](https://docs.rs/uefi-raw/badge.svg)](https://docs.rs/uefi-raw)
 
-This crate contains raw UEFI types that closely match the definitions in the
-[UEFI Specification].
+This crate provides raw UEFI types and bindings that closely match the
+definitions in the [UEFI Specification]. It is intended for implementing UEFI
+services and building high-level wrappers. For UEFI applications and drivers,
+prefer the safe abstractions in [`uefi`].
 
 [UEFI Specification]: https://uefi.org/specifications
+[`uefi`]: https://crates.io/crates/uefi

--- a/uefi-raw/src/lib.rs
+++ b/uefi-raw/src/lib.rs
@@ -89,9 +89,7 @@ pub struct Boolean(pub u8);
 impl Boolean {
     /// [`Boolean`] representing `true`.
     ///
-    /// # Caution
-    ///
-    /// This is only one possible true bit pattern. In UEFI, every non-zero
+    /// This is only one possible true bit pattern. In UEFI, every nonzero
     /// bit pattern is treated as logical `true`.
     pub const TRUE: Self = Self(1);
 

--- a/uefi-raw/src/net.rs
+++ b/uefi-raw/src/net.rs
@@ -134,13 +134,10 @@ impl IpAddress {
     /// Zeroed variant where all bytes are guaranteed to be initialized to zero.
     pub const ZERO: Self = Self { addr: [0; 4] };
 
-    /// Construct a new IPv4 address.
+    /// Constructs a new IPv4 address.
     ///
-    /// The type won't know that it is an IPv6 address and additional context
-    /// is needed.
-    ///
-    /// # Safety
-    /// The constructor only initializes the bytes needed for IPv4 addresses.
+    /// Only the IPv4 field is initialized; interpreting this value requires
+    /// external address-family information.
     #[must_use]
     pub const fn new_v4(octets: [u8; 4]) -> Self {
         Self {
@@ -148,10 +145,9 @@ impl IpAddress {
         }
     }
 
-    /// Construct a new IPv6 address.
+    /// Constructs a new IPv6 address.
     ///
-    /// The type won't know that it is an IPv6 address and additional context
-    /// is needed.
+    /// Interpreting this value requires external address-family information.
     #[must_use]
     pub const fn new_v6(octets: [u8; 16]) -> Self {
         Self {
@@ -159,16 +155,17 @@ impl IpAddress {
         }
     }
 
-    /// Transforms this EFI type to the Rust standard library's type
-    /// [`core::net::IpAddr`].
+    /// Converts this value to [`core::net::IpAddr`].
     ///
     /// # Arguments
-    /// - `is_ipv6`: Whether the internal data should be interpreted as IPv6 or
-    ///   IPv4 address.
+    ///
+    /// - `is_ipv6`: Interpret the internal data as IPv6 when `true` and IPv4
+    ///   otherwise.
     ///
     /// # Safety
+    ///
     /// Callers must ensure that the `v4` field is valid if `is_ipv6` is false,
-    /// and that the `v6` field is valid if `is_ipv6` is true
+    /// and that the `v6` field is valid if `is_ipv6` is true.
     #[must_use]
     pub unsafe fn into_core_addr(self, is_ipv6: bool) -> core::net::IpAddr {
         if is_ipv6 {

--- a/uefi-raw/src/protocol/block.rs
+++ b/uefi-raw/src/protocol/block.rs
@@ -6,7 +6,7 @@ use core::ffi::c_void;
 /// Logical block address.
 pub type Lba = u64;
 
-/// Media information structure
+/// Describes block media.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct BlockIoMedia {
@@ -28,7 +28,9 @@ pub struct BlockIoMedia {
     pub optimal_transfer_length_granularity: u32,
 }
 
+/// Block I/O protocol.
 #[derive(Debug)]
+/// Completion token for an asynchronous block I/O operation.
 #[repr(C)]
 pub struct BlockIoProtocol {
     pub revision: u64,
@@ -62,6 +64,7 @@ pub struct BlockIo2Token {
     pub transaction_status: Status,
 }
 
+/// Block I/O 2 protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct BlockIo2Protocol {

--- a/uefi-raw/src/protocol/console/serial.rs
+++ b/uefi-raw/src/protocol/console/serial.rs
@@ -10,33 +10,33 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ControlBits: u32 {
-        /// Clear to send
+        /// Indicates that the remote device is clear to send.
         const CLEAR_TO_SEND = 0x10;
-        /// Data set ready
+        /// Indicates that the remote device is ready.
         const DATA_SET_READY = 0x20;
-        /// Indicates that a phone line is ringing
+        /// Indicates that a phone line is ringing.
         const RING_INDICATE = 0x40;
-        /// Indicates the connection is still connected
+        /// Indicates that the connection is active.
         const CARRIER_DETECT = 0x80;
-        /// The input buffer is empty
+        /// Indicates that the input buffer is empty.
         const INPUT_BUFFER_EMPTY = 0x100;
-        /// The output buffer is empty
+        /// Indicates that the output buffer is empty.
         const OUTPUT_BUFFER_EMPTY = 0x200;
 
-        /// Terminal is ready for communications
+        /// Marks the terminal as ready for communication.
         const DATA_TERMINAL_READY = 0x1;
-        /// Request the device to send data
+        /// Requests that the device send data.
         const REQUEST_TO_SEND = 0x2;
-        /// Enable hardware loop-back
+        /// Enables hardware loopback.
         const HARDWARE_LOOPBACK_ENABLE = 0x1000;
-        /// Enable software loop-back
+        /// Enables software loopback.
         const SOFTWARE_LOOPBACK_ENABLE = 0x2000;
-        /// Allow the hardware to handle flow control
+        /// Allows the hardware to handle flow control.
         const HARDWARE_FLOW_CONTROL_ENABLE = 0x4000;
 
         /// Bitmask of the control bits that can be set.
         ///
-        /// Up to date as of UEFI 2.7 / Serial protocol v1
+        /// This list is current as of UEFI 2.7 and Serial I/O protocol 1.0.
         const SETTABLE =
             ControlBits::DATA_TERMINAL_READY.bits()
             | ControlBits::REQUEST_TO_SEND.bits()
@@ -46,9 +46,9 @@ bitflags! {
     }
 }
 
-/// Structure representing the device's current parameters.
+/// Current serial device parameters.
 ///
-/// The default values for all UART-like devices is:
+/// The default values for all UART-like devices are:
 /// - 115,200 baud
 /// - 1 byte receive FIFO
 /// - 1'000'000 microsecond timeout
@@ -67,7 +67,7 @@ pub struct SerialIoMode {
     pub timeout: u32,
     /// Device's baud rate, or 0 if unknown.
     pub baud_rate: u64,
-    /// Size in character's of the device's buffer.
+    /// Receive FIFO depth in characters.
     pub receive_fifo_depth: u32,
     /// Number of data bits in each character.
     pub data_bits: u32,
@@ -129,17 +129,17 @@ impl SerialIoProtocol_1_1 {
 newtype_enum! {
     /// The parity of the device.
     pub enum Parity: u32 => {
-        /// Device default
+        /// Uses the device default.
         DEFAULT = 0,
-        /// No parity
+        /// Disables parity.
         NONE = 1,
-        /// Even parity
+        /// Uses even parity.
         EVEN = 2,
-        /// Odd parity
+        /// Uses odd parity.
         ODD = 3,
-        /// Mark parity
+        /// Uses mark parity.
         MARK = 4,
-        /// Space parity
+        /// Uses space parity.
         SPACE = 5,
     }
 }
@@ -147,13 +147,13 @@ newtype_enum! {
 newtype_enum! {
     /// Number of stop bits per character.
     pub enum StopBits: u32 => {
-        /// Device default
+        /// Uses the device default.
         DEFAULT = 0,
-        /// 1 stop bit
+        /// Uses one stop bit.
         ONE = 1,
-        /// 1.5 stop bits
+        /// Uses one and a half stop bits.
         ONE_FIVE = 2,
-        /// 2 stop bits
+        /// Uses two stop bits.
         TWO = 3,
     }
 }

--- a/uefi-raw/src/protocol/firmware_management.rs
+++ b/uefi-raw/src/protocol/firmware_management.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Firmware update and reporting
+//! Raw firmware-management protocol and capsule types.
 
 use crate::{Char16, Guid, Status, guid, newtype_enum};
 use core::ffi::c_void;
 
 bitflags::bitflags! {
+    /// Features required to process a firmware-management capsule.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct CapsuleSupport: u64 {
@@ -14,7 +15,7 @@ bitflags::bitflags! {
     }
 }
 
-/// EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER
+/// Header of a firmware-management capsule.
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct FirmwareManagementCapsuleHeader {
@@ -28,7 +29,7 @@ impl FirmwareManagementCapsuleHeader {
     pub const INIT_VERSION: u32 = 1;
 }
 
-/// EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER
+/// Header of an image embedded in a firmware-management capsule.
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct FirmwareManagementCapsuleImageHeader {
@@ -47,7 +48,7 @@ impl FirmwareManagementCapsuleImageHeader {
 }
 
 newtype_enum! {
-    /// FMP dependency expression opcodes (`EFI_FMP_DEP_*`)
+    /// Opcode in a firmware-management dependency expression.
     pub enum FmpDep: u8 => {
         PUSH_GUID = 0x00,
         PUSH_VERSION = 0x01,
@@ -67,7 +68,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_FIRMWARE_IMAGE_DEP
+/// Variable-length firmware-image dependency expression.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FirmwareImageDep {
@@ -75,6 +76,7 @@ pub struct FirmwareImageDep {
 }
 
 bitflags::bitflags! {
+    /// Capabilities and current state of a firmware image.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct ImageAttributes: u64 {
@@ -90,6 +92,7 @@ bitflags::bitflags! {
 bitflags::bitflags! {
     // Lower 16 bits are reserved for UEFI assignment.
     // Other bits are for vendor-specific compatibility checks.
+    /// Compatibility checks supported by a firmware image.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct ImageCompatibilities: u64 {
@@ -99,6 +102,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
+    /// Result of checking whether a firmware image can be updated.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct ImageUpdatable: u32 {
@@ -111,6 +115,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
+    /// Capabilities and current state of a firmware package.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct PackageAttributes: u64 {
@@ -120,7 +125,7 @@ bitflags::bitflags! {
     }
 }
 
-/// EFI_FIRMWARE_IMAGE_DESCRIPTOR
+/// Describes one firmware image managed by the protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FirmwareImageDescriptor {
@@ -145,7 +150,7 @@ impl FirmwareImageDescriptor {
     pub const VERSION: u32 = 4;
 }
 
-/// EFI_FIRMWARE_MANAGEMENT_PROTOCOL
+/// Firmware Management protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FirmwareManagementProtocol {

--- a/uefi-raw/src/protocol/firmware_volume.rs
+++ b/uefi-raw/src/protocol/firmware_volume.rs
@@ -7,7 +7,7 @@ use core::ffi::c_void;
 use core::ops::RangeInclusive;
 
 bitflags::bitflags! {
-    /// EFI_FV_ATTRIBUTES
+    /// Firmware-volume capabilities and current state.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct FvAttributes: u64 {
@@ -64,7 +64,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    /// EFI_FV_FILE_ATTRIBUTES
+    /// Attributes of a firmware-volume file.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct FvFileAttributes: u32 {
@@ -75,7 +75,7 @@ bitflags::bitflags! {
 }
 
 newtype_enum! {
-    /// EFI_FV_WRITE_POLICY
+    /// Reliability policy for firmware-volume writes.
     pub enum FvWritePolicy: u32 => {
         EFI_FV_UNRELIABLE_WRITE = 0,
         EFI_FV_RELIABLE_WRITE = 1,
@@ -83,7 +83,7 @@ newtype_enum! {
 }
 
 newtype_enum! {
-    /// EFI_FV_FILETYPE
+    /// Type of a firmware-volume file.
     pub enum FvFiletype: u8 => {
         ALL = 0x00,
         RAW = 0x01,
@@ -112,7 +112,7 @@ impl FvFiletype {
 }
 
 newtype_enum! {
-    /// EFI_SECTION_TYPE
+    /// Type of a section in a firmware-volume file.
     pub enum SectionType: u8 => {
         ALL = 0x00,
         COMPRESSION = 0x01,
@@ -133,7 +133,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_FV_WRITE_FILE_DATA
+/// Describes a file to write to a firmware volume.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FvWriteFileData {
@@ -144,7 +144,7 @@ pub struct FvWriteFileData {
     pub buffer_size: u32,
 }
 
-/// EFI_FIRMWARE_VOLUME2_PROTOCOL
+/// Firmware Volume 2 protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FirmwareVolume2Protocol {
@@ -204,7 +204,7 @@ impl FirmwareVolume2Protocol {
     pub const GUID: Guid = guid!("220e73b6-6bdb-4413-8405-b974b108619a");
 }
 
-/// EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL
+/// Firmware Volume Block 2 protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FirmwareVolumeBlock2Protocol {

--- a/uefi-raw/src/protocol/hii/config.rs
+++ b/uefi-raw/src/protocol/hii/config.rs
@@ -9,7 +9,7 @@ use super::{FormId, QuestionId, StringId};
 use crate::protocol::device_path::DevicePathProtocol;
 use crate::{Boolean, Char16, Guid, Status, guid, newtype_enum};
 
-/// EFI_CONFIG_KEYWORD_HANDLER_PROTOCOL
+/// HII configuration keyword-handler protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ConfigKeywordHandlerProtocol {
@@ -34,7 +34,7 @@ impl ConfigKeywordHandlerProtocol {
 }
 
 newtype_enum! {
-    /// Type of action taken by the form browser
+    /// Action taken by the form browser.
     #[derive(Default)]
     pub enum BrowserAction: usize => {
         /// Called before the browser changes the value in the display (for questions which have a value)
@@ -71,6 +71,7 @@ newtype_enum! {
     }
 }
 
+/// Time value stored in an internal forms representation.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HiiTime {
@@ -79,6 +80,7 @@ pub struct HiiTime {
     pub second: u8,
 }
 
+/// Date value stored in an internal forms representation.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HiiDate {
@@ -87,6 +89,7 @@ pub struct HiiDate {
     pub day: u8,
 }
 
+/// Reference value stored in an internal forms representation.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HiiRef {
@@ -96,6 +99,7 @@ pub struct HiiRef {
     pub string_id: StringId,
 }
 
+/// Value stored in an internal forms representation.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union IfrTypeValue {
@@ -115,7 +119,7 @@ impl core::fmt::Debug for IfrTypeValue {
     }
 }
 
-/// EFI_HII_CONFIG_ACCESS_PROTOCOL
+/// HII configuration-access protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiConfigAccessProtocol {
@@ -144,7 +148,7 @@ impl HiiConfigAccessProtocol {
     pub const GUID: Guid = guid!("330d4706-f2a0-4e4f-a369-b66fa8d54385");
 }
 
-/// EFI_HII_CONFIG_ROUTING_PROTOCOL
+/// HII configuration-routing protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiConfigRoutingProtocol {

--- a/uefi-raw/src/protocol/hii/database.rs
+++ b/uefi-raw/src/protocol/hii/database.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Bindings for HII Database Protocol
+//! Raw HII database protocol and data types.
 
 use super::{HiiHandle, HiiPackageHeader, HiiPackageListHeader, KeyDescriptor};
 use crate::{Guid, Handle, Status, guid, newtype_enum};
 
-/// EFI_HII_KEYBOARD_LAYOUT
+/// Header and descriptors of an HII keyboard layout.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiKeyboardLayout {
@@ -17,7 +17,7 @@ pub struct HiiKeyboardLayout {
 }
 
 newtype_enum! {
-    /// EFI_HII_DATABASE_NOTIFY_TYPE
+    /// HII package-list changes that trigger a notification.
     pub enum HiiDatabaseNotifyType: usize => {
         NEW_PACK = 1 << 0,
         REMOVE_PACK = 1 << 1,
@@ -26,7 +26,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_HII_DATABASE_NOTIFY
+/// Callback invoked for an HII package-list change.
 pub type HiiDatabaseNotifyFn = unsafe extern "efiapi" fn(
     package_type: u8,
     package_guid: *const Guid,
@@ -35,7 +35,7 @@ pub type HiiDatabaseNotifyFn = unsafe extern "efiapi" fn(
     notify_type: HiiDatabaseNotifyType,
 ) -> Status;
 
-/// EFI_HII_DATABASE_PROTOCOL
+/// HII database protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiDatabaseProtocol {

--- a/uefi-raw/src/protocol/hii/font.rs
+++ b/uefi-raw/src/protocol/hii/font.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Bindings for HII Font protocols and data types
+//! Raw HII font protocols and data types.
 
 use super::image::ImageOutput;
 use super::{HiiHandle, StringId};
 use crate::protocol::console::GraphicsOutputBltPixel;
 use crate::{Char8, Char16, Guid, Status, guid};
 
+/// Handle used to enumerate HII fonts.
 pub type FontHandle = *mut core::ffi::c_void;
 
+/// Dimensions and positioning of an HII glyph.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiGlyphInfo {
@@ -20,7 +22,7 @@ pub struct HiiGlyphInfo {
 }
 
 bitflags::bitflags! {
-    /// EFI_FONT_INFO_MASK
+    /// Selects which font properties are significant.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct FontInfoMask: u32 {
@@ -38,7 +40,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    /// EFI_HII_FONT_STYLE
+    /// HII font styles.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct HiiFontStyle: u32 {
@@ -56,7 +58,7 @@ impl HiiFontStyle {
     pub const NORMAL: Self = Self::empty();
 }
 
-/// EFI_FONT_INFO
+/// Name, size, and style of an HII font.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FontInfo {
@@ -65,7 +67,7 @@ pub struct FontInfo {
     pub font_name: [Char16; 0],
 }
 
-/// EFI_FONT_DISPLAY_INFO
+/// Font and colors used to render text.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FontDisplayInfo {
@@ -76,7 +78,7 @@ pub struct FontDisplayInfo {
 }
 
 bitflags::bitflags! {
-    /// EFI_HII_OUT_FLAGS
+    /// Controls how HII text is rendered.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct HiiOutFlags: u32 {
@@ -91,7 +93,7 @@ bitflags::bitflags! {
     }
 }
 
-/// EFI_HII_ROW_INFO
+/// Layout information for one rendered row.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiRowInfo {
@@ -102,7 +104,7 @@ pub struct HiiRowInfo {
     pub baseline_offset: usize,
 }
 
-/// EFI_HII_FONT_PROTOCOL
+/// HII font protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiFontProtocol {
@@ -153,7 +155,7 @@ impl HiiFontProtocol {
 }
 
 // NOTE: This protocol is declared in the UEFI spec, but not defined in edk2.
-/// EFI_HII_FONT_EX_PROTOCOL
+/// Extended HII font protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiFontExProtocol {

--- a/uefi-raw/src/protocol/hii/form_browser.rs
+++ b/uefi-raw/src/protocol/hii/form_browser.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Form Browser protocol
+//! Raw HII Form Browser protocol.
 
 use super::{FormId, HiiHandle};
 use crate::{Boolean, Char16, Guid, Status, guid, newtype_enum};
 
-/// EFI_SCREEN_DESCRIPTOR
+/// Screen region in which to display a form.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ScreenDescriptor {
@@ -43,7 +43,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_FORM_BROWSER2_PROTOCOL
+/// HII Form Browser 2 protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct FormBrowser2Protocol {

--- a/uefi-raw/src/protocol/hii/image.rs
+++ b/uefi-raw/src/protocol/hii/image.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Bindings for HII Image protocols and data types
+//! Raw HII image protocols and data types.
 
 use super::{HiiHandle, ImageId};
 use crate::protocol::console::{GraphicsOutputBltPixel, GraphicsOutputProtocol};
@@ -8,7 +8,7 @@ use crate::{Guid, Status, guid};
 use core::fmt;
 
 bitflags::bitflags! {
-    /// EFI_HII_DRAW_FLAGS
+    /// Controls how an HII image is drawn.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct HiiDrawFlags: u32 {
@@ -25,6 +25,7 @@ impl HiiDrawFlags {
 }
 
 bitflags::bitflags! {
+    /// Controls interpretation of an image's bitmap.
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[repr(transparent)]
     pub struct ImageInputFlags: u32 {
@@ -32,7 +33,7 @@ bitflags::bitflags! {
     }
 }
 
-/// EFI_IMAGE_INPUT
+/// Bitmap supplied to an HII image protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ImageInput {
@@ -42,6 +43,7 @@ pub struct ImageInput {
     pub bitmap: *const GraphicsOutputBltPixel,
 }
 
+/// Destination of an HII image drawing operation.
 #[repr(C)]
 pub union ImageOutputDest {
     pub bitmap: *mut GraphicsOutputBltPixel,
@@ -69,7 +71,7 @@ impl Default for ImageOutputDest {
     }
 }
 
-/// EFI_IMAGE_OUTPUT
+/// Output target and dimensions for an HII image operation.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ImageOutput {
@@ -78,7 +80,7 @@ pub struct ImageOutput {
     pub image: ImageOutputDest,
 }
 
-/// EFI_HII_IMAGE_PROTOCOL
+/// HII image protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiImageProtocol {
@@ -123,7 +125,7 @@ impl HiiImageProtocol {
     pub const GUID: Guid = guid!("31a6406a-6bdf-4e46-b2a2-ebaa89c40920");
 }
 
-/// EFI_HII_IMAGE_EX_PROTOCOL
+/// Extended HII image protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiImageExProtocol {

--- a/uefi-raw/src/protocol/hii/mod.rs
+++ b/uefi-raw/src/protocol/hii/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! HII Protocols
+//! Raw HII protocols and data types.
 
 pub mod config;
 pub mod database;
@@ -12,16 +12,23 @@ pub mod string;
 
 use crate::{Char16, Guid, newtype_enum};
 
+/// Handle to packages registered with the HII database.
 pub type HiiHandle = *mut core::ffi::c_void;
 
+/// Identifier of a question in a form package.
 pub type QuestionId = u16;
+/// Identifier of an image in an image package.
 pub type ImageId = u16;
+/// Identifier of a string in a string package.
 pub type StringId = u16;
+/// Identifier of a form in a form package.
 pub type FormId = u16;
+/// Identifier of a variable store in a form package.
 pub type VarstoreId = u16;
+/// Identifier of an animation in an animation package.
 pub type AnimationId = u16;
 
-/// EFI_HII_PACKAGE_HEADER
+/// Raw HII package header.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiPackageHeader {
@@ -29,7 +36,7 @@ pub struct HiiPackageHeader {
     pub data: [u8; 0],
 }
 
-/// EFI_HII_PACKAGE_LIST_HEADER
+/// Raw HII package-list header.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiPackageListHeader {
@@ -38,7 +45,7 @@ pub struct HiiPackageListHeader {
 }
 
 newtype_enum! {
-    /// EFI_KEY: A physical key on a keyboard.
+    /// Physical key on a keyboard.
     pub enum Key: u32 => {
         LCTRL = 0,
         A0 = 1,
@@ -160,7 +167,7 @@ newtype_enum! {
 
 // NOTE: This has no associated type in UEFI; They are all top-level defines.
 newtype_enum! {
-    /// Key modifier values
+    /// Key modifier value.
     pub enum Modifier: u16 => {
         NULL = 0x0000,
         LEFT_CONTROL = 0x0001,
@@ -207,7 +214,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_KEY_DESCRIPTOR
+/// Keyboard key descriptor.
 #[derive(Debug)]
 #[repr(C)]
 pub struct KeyDescriptor {

--- a/uefi-raw/src/protocol/hii/popup.rs
+++ b/uefi-raw/src/protocol/hii/popup.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Popup protocol
+//! Raw HII popup protocol.
 
 use super::{HiiHandle, StringId};
 use crate::{Guid, Status, guid, newtype_enum};
 
 newtype_enum! {
-    /// EFI_HII_POPUP_STYLE
+    /// Visual style of an HII popup.
     pub enum HiiPopupStyle: u32 => {
         INFO = 0,
         WARNING = 1,
@@ -15,7 +15,7 @@ newtype_enum! {
 }
 
 newtype_enum! {
-    /// EFI_HII_POPUP_TYPE
+    /// Buttons displayed by an HII popup.
     pub enum HiiPopupType: u32 => {
         OK = 0,
         OK_CANCEL = 1,
@@ -25,7 +25,7 @@ newtype_enum! {
 }
 
 newtype_enum! {
-    /// EFI_HII_POPUP_SELECTION
+    /// Button selected in an HII popup.
     pub enum HiiPopupSelection: u32 => {
         OK = 0,
         CANCEL = 1,
@@ -34,7 +34,7 @@ newtype_enum! {
     }
 }
 
-/// EFI_HII_POPUP_PROTOCOL
+/// HII popup protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiPopupProtocol {

--- a/uefi-raw/src/protocol/hii/string.rs
+++ b/uefi-raw/src/protocol/hii/string.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Bindings for HII String protocols and data types
+//! Raw HII string protocol.
 
 use super::font::FontInfo;
 use super::{HiiHandle, StringId};
 use crate::{Char8, Char16, Guid, Status, guid};
 
-/// EFI_HII_STRING_PROTOCOL
+/// HII string protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct HiiStringProtocol {

--- a/uefi-raw/src/protocol/iommu.rs
+++ b/uefi-raw/src/protocol/iommu.rs
@@ -7,11 +7,12 @@ use core::ffi::c_void;
 
 use crate::newtype_enum;
 
-/// EDKII IOMMU Protocol GUID
 impl EdkiiIommuProtocol {
+    /// EDK II IOMMU protocol GUID.
     pub const GUID: Guid = guid!("4e939de9-d948-4b0f-88ed-e6e1ce517c1e");
 }
 
+/// EDK II IOMMU protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct EdkiiIommuProtocol {
@@ -47,63 +48,63 @@ pub struct EdkiiIommuProtocol {
 }
 
 newtype_enum! {
-    /// IOMMU Operation for Map (matches EDKII_IOMMU_OPERATION)
+    /// DMA operation passed to the IOMMU mapping function.
     pub enum EdkiiIommuOperation: u32 => {
-        /// A read operation from system memory by a bus master that is not capable of producing PCI dual address cycles.
+        /// Reads system memory without PCI dual-address cycles.
         BUS_MASTER_READ = 0,
-        /// A write operation to system memory by a bus master that is not capable of producing PCI dual address cycles.
+        /// Writes system memory without PCI dual-address cycles.
         BUS_MASTER_WRITE = 1,
-        /// Provides both read and write access to system memory by both the processor and a bus master that is not capable of producing PCI dual address cycles.
+        /// Shares a buffer without PCI dual-address cycles.
         BUS_MASTER_COMMON_BUFFER = 2,
-        /// A read operation from system memory by a bus master that is capable of producing PCI dual address cycles.
+        /// Reads system memory with PCI dual-address cycles.
         BUS_MASTER_READ64 = 3,
-        /// A write operation to system memory by a bus master that is capable of producing PCI dual address cycles.
+        /// Writes system memory with PCI dual-address cycles.
         BUS_MASTER_WRITE64 = 4,
-        /// Provides both read and write access to system memory by both the processor and a bus master that is capable of producing PCI dual address cycles.
+        /// Shares a buffer with PCI dual-address cycles.
         BUS_MASTER_COMMON_BUFFER64 = 5,
-        /// Maximum value (not a valid operation, for bounds checking)
+        /// Sentinel used for bounds checking; not a valid operation.
         MAXIMUM = 6,
     }
 }
 
-/// EDKII IOMMU protocol revision constant
+/// EDK II IOMMU protocol revision.
 pub const EDKII_IOMMU_PROTOCOL_REVISION: u64 = 0x0001_0000;
 
 bitflags! {
-    /// EDKII IOMMU attribute flags
+    /// EDK II IOMMU memory attributes.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct EdkiiIommuAttribute: u64 {
-        /// Memory is write-combined
+        /// Uses write-combined memory.
         const MEMORY_WRITE_COMBINE   = 0x0080;
-        /// Memory is cached
+        /// Uses cached memory.
         const MEMORY_CACHED          = 0x0800;
-        /// Dual address cycle supported
+        /// Supports PCI dual-address cycles.
         const DUAL_ADDRESS_CYCLE     = 0x8000;
     }
 }
 
 impl EdkiiIommuAttribute {
-    /// Valid attributes for allocate_buffer
+    /// Attributes accepted by `allocate_buffer`.
     pub const VALID_FOR_ALLOCATE_BUFFER: Self = Self::from_bits_truncate(
         Self::MEMORY_WRITE_COMBINE.bits()
             | Self::MEMORY_CACHED.bits()
             | Self::DUAL_ADDRESS_CYCLE.bits(),
     );
 
-    /// Invalid attributes for allocate_buffer (all bits except valid)
+    /// Attributes rejected by `allocate_buffer`.
     pub const INVALID_FOR_ALLOCATE_BUFFER: Self =
         Self::from_bits_truncate(!Self::VALID_FOR_ALLOCATE_BUFFER.bits());
 }
 
 bitflags! {
-    /// EDKII IOMMU access flags for SetAttribute
+    /// Access permissions passed to `set_attribute`.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct EdkiiIommuAccess: u64 {
-        /// Read access
+        /// Grants read access.
         const READ  = 0x1;
-        /// Write access
+        /// Grants write access.
         const WRITE = 0x2;
     }
 }

--- a/uefi-raw/src/protocol/network/snp.rs
+++ b/uefi-raw/src/protocol/network/snp.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Raw Simple Network protocol and data types.
+
 use core::ffi;
 
 use bitflags::bitflags;
 
 use crate::{Boolean, Event, Guid, IpAddress, MacAddress, Status, guid, newtype_enum};
 
+/// Simple Network protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct SimpleNetworkProtocol {
@@ -84,7 +87,7 @@ impl SimpleNetworkProtocol {
 }
 
 bitflags! {
-    /// Flags to pass to receive_filters to enable/disable reception of some kinds of packets.
+    /// Packet classes accepted by the receive filter.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ReceiveFlags: u32 {
@@ -102,8 +105,7 @@ bitflags! {
 }
 
 bitflags! {
-    /// Flags returned by get_interrupt_status to indicate which interrupts have fired on the
-    /// interface since the last call.
+    /// Interrupts reported since the previous status query.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct InterruptStatus: u32 {
@@ -118,13 +120,10 @@ bitflags! {
     }
 }
 
-/// Network Statistics
+/// Statistics reported by the Simple Network protocol.
 ///
-/// The description of statistics on the network with the SNP's `statistics` function
-/// is returned in this structure
-///
-/// Any of these statistics may or may not be available on the device. So, all the
-/// retriever functions of the statistics return `None` when a statistic is not supported
+/// Individual statistics may be unavailable. Each accessor returns `None` for
+/// a statistic that the device does not support.
 #[repr(C)]
 #[derive(Default, Debug)]
 pub struct NetworkStatistics {
@@ -157,14 +156,14 @@ pub struct NetworkStatistics {
 }
 
 impl NetworkStatistics {
-    /// Any statistic value of -1 is not available
+    /// Returns whether a statistic is available.
     const fn available(&self, stat: u64) -> bool {
         stat as i64 != -1
     }
 
-    /// Takes a statistic and converts it to an option
+    /// Converts a raw statistic to an optional value.
     ///
-    /// When the statistic is not available, `None` is returned
+    /// An unavailable statistic produces `None`.
     const fn to_option(&self, stat: u64) -> Option<u64> {
         match self.available(stat) {
             true => Some(stat),
@@ -172,237 +171,217 @@ impl NetworkStatistics {
         }
     }
 
-    /// The total number of frames received, including error frames
-    /// and dropped frames
+    /// Returns all received frames, including errors and drops.
     #[must_use]
     pub const fn rx_total_frames(&self) -> Option<u64> {
         self.to_option(self.rx_total_frames)
     }
 
-    /// The total number of good frames received and copied
-    /// into receive buffers
+    /// Returns valid frames copied into receive buffers.
     #[must_use]
     pub const fn rx_good_frames(&self) -> Option<u64> {
         self.to_option(self.rx_good_frames)
     }
 
-    /// The number of frames below the minimum length for the
-    /// communications device
+    /// Returns frames below the device's minimum length.
     #[must_use]
     pub const fn rx_undersize_frames(&self) -> Option<u64> {
         self.to_option(self.rx_undersize_frames)
     }
 
-    /// The number of frames longer than the maximum length for
-    /// the communications length device
+    /// Returns frames above the device's maximum length.
     #[must_use]
     pub const fn rx_oversize_frames(&self) -> Option<u64> {
         self.to_option(self.rx_oversize_frames)
     }
 
-    /// The number of valid frames that were dropped because
-    /// the receive buffers were full
+    /// Returns valid frames dropped because receive buffers were full.
     #[must_use]
     pub const fn rx_dropped_frames(&self) -> Option<u64> {
         self.to_option(self.rx_dropped_frames)
     }
 
-    /// The number of valid unicast frames received and not dropped
+    /// Returns valid unicast frames received without being dropped.
     #[must_use]
     pub const fn rx_unicast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_unicast_frames)
     }
 
-    /// The number of valid broadcast frames received and not dropped
+    /// Returns valid broadcast frames received without being dropped.
     #[must_use]
     pub const fn rx_broadcast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_broadcast_frames)
     }
 
-    /// The number of valid multicast frames received and not dropped
+    /// Returns valid multicast frames received without being dropped.
     #[must_use]
     pub const fn rx_multicast_frames(&self) -> Option<u64> {
         self.to_option(self.rx_multicast_frames)
     }
 
-    /// Number of frames with CRC or alignment errors
+    /// Returns received frames with CRC or alignment errors.
     #[must_use]
     pub const fn rx_crc_error_frames(&self) -> Option<u64> {
         self.to_option(self.rx_crc_error_frames)
     }
 
-    /// The total number of bytes received including frames with errors
-    /// and dropped frames
+    /// Returns all received bytes, including errors and drops.
     #[must_use]
     pub const fn rx_total_bytes(&self) -> Option<u64> {
         self.to_option(self.rx_total_bytes)
     }
 
-    /// The total number of frames transmitted including frames
-    /// with errors and dropped frames
+    /// Returns all transmitted frames, including errors and drops.
     #[must_use]
     pub const fn tx_total_frames(&self) -> Option<u64> {
         self.to_option(self.tx_total_frames)
     }
 
-    /// The total number of valid frames transmitted and copied
-    /// into receive buffers
+    /// Returns valid frames accepted for transmission.
     #[must_use]
     pub const fn tx_good_frames(&self) -> Option<u64> {
         self.to_option(self.tx_good_frames)
     }
 
-    /// The number of frames below the minimum length for
-    /// the media. This would be less than 64 for Ethernet
+    /// Returns frames below the medium's minimum length.
     #[must_use]
     pub const fn tx_undersize_frames(&self) -> Option<u64> {
         self.to_option(self.tx_undersize_frames)
     }
 
-    /// The number of frames longer than the maximum length for
-    /// the media. This would be 1500 for Ethernet
+    /// Returns frames above the medium's maximum length.
     #[must_use]
     pub const fn tx_oversize_frames(&self) -> Option<u64> {
         self.to_option(self.tx_oversize_frames)
     }
 
-    /// The number of valid frames that were dropped because
-    /// received buffers were full
+    /// Returns valid transmit frames dropped because buffers were full.
     #[must_use]
     pub const fn tx_dropped_frames(&self) -> Option<u64> {
         self.to_option(self.tx_dropped_frames)
     }
 
-    /// The number of valid unicast frames transmitted and not
-    /// dropped
+    /// Returns valid unicast frames transmitted without being dropped.
     #[must_use]
     pub const fn tx_unicast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_unicast_frames)
     }
 
-    /// The number of valid broadcast frames transmitted and
-    /// not dropped
+    /// Returns valid broadcast frames transmitted without being dropped.
     #[must_use]
     pub const fn tx_broadcast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_broadcast_frames)
     }
 
-    /// The number of valid multicast frames transmitted
-    /// and not dropped
+    /// Returns valid multicast frames transmitted without being dropped.
     #[must_use]
     pub const fn tx_multicast_frames(&self) -> Option<u64> {
         self.to_option(self.tx_multicast_frames)
     }
 
-    /// The number of transmitted frames with CRC or
-    /// alignment errors
+    /// Returns transmitted frames with CRC or alignment errors.
     #[must_use]
     pub const fn tx_crc_error_frames(&self) -> Option<u64> {
         self.to_option(self.tx_crc_error_frames)
     }
 
-    /// The total number of bytes transmitted including
-    /// error frames and dropped frames
+    /// Returns all transmitted bytes, including errors and drops.
     #[must_use]
     pub const fn tx_total_bytes(&self) -> Option<u64> {
         self.to_option(self.tx_total_bytes)
     }
 
-    /// The number of collisions detected on this subnet
+    /// Returns collisions detected on the subnet.
     #[must_use]
     pub const fn collisions(&self) -> Option<u64> {
         self.to_option(self.collisions)
     }
 
-    /// The number of frames destined for unsupported protocol
+    /// Returns frames for unsupported network protocols.
     #[must_use]
     pub const fn unsupported_protocol(&self) -> Option<u64> {
         self.to_option(self.unsupported_protocol)
     }
 
-    /// The number of valid frames received that were duplicated
+    /// Returns valid received frames that were duplicates.
     #[must_use]
     pub const fn rx_duplicated_frames(&self) -> Option<u64> {
         self.to_option(self.rx_duplicated_frames)
     }
 
-    /// The number of encrypted frames received that failed
-    /// to decrypt
+    /// Returns encrypted frames that failed decryption.
     #[must_use]
     pub const fn rx_decrypt_error_frames(&self) -> Option<u64> {
         self.to_option(self.rx_decrypt_error_frames)
     }
 
-    /// The number of frames that failed to transmit after
-    /// exceeding the retry limit
+    /// Returns frames that exceeded the transmit retry limit.
     #[must_use]
     pub const fn tx_error_frames(&self) -> Option<u64> {
         self.to_option(self.tx_error_frames)
     }
 
-    /// The number of frames that transmitted successfully
-    /// after more than one attempt
+    /// Returns frames transmitted successfully after a retry.
     #[must_use]
     pub const fn tx_retry_frames(&self) -> Option<u64> {
         self.to_option(self.tx_retry_frames)
     }
 }
 
-/// Information about the current configuration of an interface obtained by the
-/// [`SimpleNetworkProtocol`].
+/// Current configuration of a Simple Network interface.
 #[repr(C)]
 #[derive(Debug)]
 pub struct NetworkMode {
-    /// Reports the current state of the network interface
+    /// Current state of the network interface.
     pub state: NetworkState,
-    /// The size of the network interface's hardware address in bytes
+    /// Hardware-address size in bytes.
     pub hw_address_size: u32,
-    /// The size of the network interface's media header in bytes
+    /// Media-header size in bytes.
     pub media_header_size: u32,
-    /// The maximum size of the packets supported by the network interface in bytes
+    /// Maximum supported packet size in bytes.
     pub max_packet_size: u32,
-    /// The size of the NVRAM device attached to the network interface in bytes
+    /// Attached NVRAM size in bytes.
     pub nv_ram_size: u32,
-    /// The size that must be used for all NVRAM reads and writes
+    /// Required granularity of NVRAM reads and writes.
     pub nv_ram_access_size: u32,
-    /// The multicast receive filter settings supported by the network interface
+    /// Supported receive-filter settings.
     pub receive_filter_mask: u32,
-    /// The current multicast receive filter settings
+    /// Active receive-filter settings.
     pub receive_filter_setting: u32,
-    /// The maximum number of multicast address receive filters supported by the driver
+    /// Maximum number of multicast-address filters.
     pub max_mcast_filter_count: u32,
-    /// The current number of multicast address receive filters
+    /// Number of active multicast-address filters.
     pub mcast_filter_count: u32,
-    /// The array containing the addresses of the current multicast address receive filters
+    /// Active multicast-address filters.
     pub mcast_filter: [MacAddress; 16],
-    /// The current hardware MAC address for the network interface
+    /// Current hardware MAC address.
     pub current_address: MacAddress,
-    /// The current hardware MAC address for broadcast packets
+    /// Hardware MAC address used for broadcasts.
     pub broadcast_address: MacAddress,
-    /// The permanent hardware MAC address for the network interface
+    /// Permanent hardware MAC address.
     pub permanent_address: MacAddress,
-    /// The interface type of the network interface
+    /// Network interface type.
     pub if_type: u8,
-    /// Tells if the MAC address can be changed
+    /// Whether the MAC address can be changed.
     pub mac_address_changeable: Boolean,
-    /// Tells if the network interface can transmit more than one packet at a time
+    /// Whether multiple packets can be transmitted concurrently.
     pub multiple_tx_supported: Boolean,
-    /// Tells if the presence of the media can be determined
+    /// Whether media presence can be detected.
     pub media_present_supported: Boolean,
-    /// Tells if media are connected to the network interface
+    /// Whether media are connected to the interface.
     pub media_present: Boolean,
 }
 
 newtype_enum! {
     /// The state of a network interface.
     pub enum NetworkState: u32 => {
-        /// The interface has been stopped
+        /// The interface is stopped.
         STOPPED = 0,
-        /// The interface has been started
+        /// The interface is started.
         STARTED = 1,
-        /// The interface has been initialized
+        /// The interface is initialized.
         INITIALIZED = 2,
-        /// No state can have a number higher than this
+        /// Sentinel above every valid state.
         MAX_STATE = 3,
     }
 }

--- a/uefi-raw/src/protocol/network/tcp4.rs
+++ b/uefi-raw/src/protocol/network/tcp4.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! TCPv4 Protocol
+//! Raw TCPv4 protocol and data types.
 //!
 //! This module provides the TCPv4 Protocol interface definitions. The
 //! TCPv4 Protocol provides services to send and receive data streams
@@ -14,6 +14,7 @@ use crate::{Boolean, Event, Guid, Handle, Ipv4Address, Status, guid, newtype_enu
 use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
 
+/// TCPv4 protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4Protocol {
@@ -32,8 +33,7 @@ pub struct Tcp4Protocol {
         simple_network_mode: *mut NetworkMode,
     ) -> Status,
 
-    /// Initialize or brutally reset the operational parameters for
-    /// this instance.
+    /// Initializes or immediately resets this instance's parameters.
     ///
     /// No other [`Tcp4Protocol`] operation can be executed by this
     /// instance until it is configured properly. For an active
@@ -93,8 +93,7 @@ pub struct Tcp4Protocol {
         gateway_address: *const Ipv4Address,
     ) -> Status,
 
-    /// Initiate a nonblocking TCP connection request for an active
-    /// TCP instance.
+    /// Initiates a nonblocking connection for an active TCP instance.
     ///
     /// `connect` initiates an active open to the remote peer
     /// configured in the current TCP instance if it is configured as
@@ -111,8 +110,7 @@ pub struct Tcp4Protocol {
     pub connect:
         unsafe extern "efiapi" fn(this: *mut Self, token: *mut Tcp4ConnectionToken) -> Status,
 
-    /// Listen on the passive instance to accept an incoming
-    /// connection request. This is a nonblocking operation.
+    /// Queues a nonblocking accept operation on a passive instance.
     ///
     /// The `accept` function initiates an asynchronous accept request
     /// to wait for an incoming connection on the passive TCP
@@ -142,8 +140,7 @@ pub struct Tcp4Protocol {
     /// data is sent out or some error occurs.
     pub transmit: unsafe extern "efiapi" fn(this: *mut Self, token: *mut Tcp4IoToken) -> Status,
 
-    /// Places an asynchronous receive request into the receiving
-    /// queue.
+    /// Queues an asynchronous receive request.
     ///
     /// `receive` places a completion token into the receive packet
     /// queue. This function is always asynchronous. The caller must
@@ -165,8 +162,7 @@ pub struct Tcp4Protocol {
     /// to not be re-entered.
     pub receive: unsafe extern "efiapi" fn(this: *mut Self, token: *mut Tcp4IoToken) -> Status,
 
-    /// Disconnect a TCP connection gracefully or reset a TCP
-    /// connection. This function is a nonblocking operation.
+    /// Queues a graceful disconnect or connection reset.
     ///
     /// Initiate an asynchronous close token to TCP driver. After
     /// `close` is called, any buffered transmission data will be sent
@@ -181,8 +177,7 @@ pub struct Tcp4Protocol {
     pub close:
         unsafe extern "efiapi" fn(this: *mut Self, close_token: *mut Tcp4CloseToken) -> Status,
 
-    /// Abort an asynchronous connection, listen, transmission or
-    /// receive request.
+    /// Aborts one or all asynchronous requests.
     ///
     /// The `cancel` function aborts a pending connection, listen,
     /// transmit or receive request. If `completion_token` is not
@@ -228,6 +223,7 @@ impl Tcp4Protocol {
 }
 
 newtype_enum! {
+    /// State of a TCPv4 connection.
     pub enum Tcp4ConnectionState: i32 => {
         CLOSED = 0,
         LISTEN = 1,
@@ -243,6 +239,7 @@ newtype_enum! {
     }
 }
 
+/// Configuration of a TCPv4 instance.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4ConfigData {
@@ -256,6 +253,7 @@ pub struct Tcp4ConfigData {
     pub control_option: *mut Tcp4Option,
 }
 
+/// Local and remote endpoints of a TCPv4 instance.
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct Tcp4AccessPoint {
@@ -275,6 +273,7 @@ pub struct Tcp4AccessPoint {
     pub active_flag: Boolean,
 }
 
+/// Optional tuning parameters for a TCPv4 instance.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4Option {
@@ -310,6 +309,7 @@ pub struct Tcp4Option {
     pub enable_path_mtu_discovery: Boolean,
 }
 
+/// Completion event and status for a TCPv4 operation.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4CompletionToken {
@@ -319,12 +319,14 @@ pub struct Tcp4CompletionToken {
     pub status: Status,
 }
 
+/// Completion token for an active connection request.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4ConnectionToken {
     pub completion_token: Tcp4CompletionToken,
 }
 
+/// Completion token for a passive connection request.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4ListenToken {
@@ -335,6 +337,7 @@ pub struct Tcp4ListenToken {
     pub new_child_handle: Handle,
 }
 
+/// Completion token for a TCPv4 I/O operation.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4IoToken {
@@ -344,7 +347,9 @@ pub struct Tcp4IoToken {
     pub packet: Tcp4Packet,
 }
 
+/// Completion token for closing a TCPv4 connection.
 #[derive(Debug)]
+/// Receive or transmit packet attached to an I/O token.
 #[repr(C)]
 pub struct Tcp4CloseToken {
     /// Completion token for the close operation.
@@ -369,6 +374,7 @@ impl Debug for Tcp4Packet {
     }
 }
 
+/// One buffer in a fragmented TCPv4 packet.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4FragmentData {
@@ -379,6 +385,7 @@ pub struct Tcp4FragmentData {
     pub fragment_buf: *mut u8,
 }
 
+/// Buffers and metadata for a TCPv4 receive operation.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4ReceiveData {
@@ -400,6 +407,7 @@ pub struct Tcp4ReceiveData {
     pub fragment_table: [Tcp4FragmentData; 0],
 }
 
+/// Buffers and metadata for a TCPv4 transmit operation.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4TransmitData {
@@ -423,6 +431,7 @@ pub struct Tcp4TransmitData {
     pub fragment_table: [Tcp4FragmentData; 0],
 }
 
+/// Remote endpoint of an established TCPv4 child connection.
 #[derive(Debug)]
 #[repr(C)]
 pub struct Tcp4ClientConnectionModeParams {

--- a/uefi-raw/src/protocol/rng.rs
+++ b/uefi-raw/src/protocol/rng.rs
@@ -5,36 +5,35 @@
 use crate::{Guid, Status, guid, newtype_enum};
 
 newtype_enum! {
-    /// The algorithms listed are optional, not meant to be exhaustive
-    /// and may be augmented by vendors or other industry standards.
+    /// Algorithm supported by a random-number generator.
+    ///
+    /// The defined algorithms are optional and not exhaustive. Vendors and
+    /// future standards may define additional values.
     pub enum RngAlgorithmType: Guid => {
-        /// Indicates a empty algorithm, used to instantiate a buffer
-        /// for `get_info`
+        /// Placeholder used to initialize an algorithm-list buffer.
         EMPTY_ALGORITHM = guid!("00000000-0000-0000-0000-000000000000"),
 
-        /// The “raw” algorithm, when supported, is intended to provide
-        /// entropy directly from the source, without it going through
-        /// some deterministic random bit generator.
+        /// Provides source entropy without a deterministic random-bit generator.
         ALGORITHM_RAW = guid!("e43176d7-b6e8-4827-b784-7ffdc4b68561"),
 
-        /// ALGORITHM_SP800_90_HASH_256
+        /// NIST SP 800-90 Hash_DRBG algorithm identified by UEFI.
         ALGORITHM_SP800_90_HASH_256 = guid!("a7af67cb-603b-4d42-ba21-70bfb6293f96"),
 
-        /// ALGORITHM_SP800_90_HMAC_256
+        /// NIST SP 800-90 HMAC_DRBG algorithm identified by UEFI.
         ALGORITHM_SP800_90_HMAC_256 = guid!("c5149b43-ae85-4f53-9982-b94335d3a9e7"),
 
-        /// ALGORITHM_SP800_90_CTR_256
+        /// NIST SP 800-90 CTR_DRBG algorithm identified by UEFI.
         ALGORITHM_SP800_90_CTR_256 = guid!("44f0de6e-4d8c-4045-a8c7-4dd168856b9e"),
 
-        /// ALGORITHM_X9_31_3DES
+        /// ANSI X9.31 generator using two-key or three-key 3DES.
         ALGORITHM_X9_31_3DES = guid!("63c4785a-ca34-4012-a3c8-0b6a324f5546"),
 
-        /// ALGORITHM_X9_31_AES
+        /// ANSI X9.31 generator using AES.
         ALGORITHM_X9_31_AES = guid!("acd03321-777e-4d3d-b1c8-20cfd88820c9"),
     }
 }
 
-/// Rng protocol.
+/// Random Number Generator protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct RngProtocol {

--- a/uefi-raw/src/protocol/shell.rs
+++ b/uefi-raw/src/protocol/shell.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! EFI Shell Protocol v2.2
+//! Raw bindings for EFI Shell Protocol 2.2.
 
 use core::ffi::c_void;
 
@@ -12,7 +12,7 @@ use super::shell_params::ShellFileHandle;
 
 use bitflags::bitflags;
 
-/// List Entry for File Lists
+/// Link in a shell file list.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ListEntry {
@@ -20,7 +20,7 @@ pub struct ListEntry {
     pub b_link: *mut Self,
 }
 
-/// ShellFileInfo for File Lists
+/// Entry in a shell file list.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ShellFileInfo {
@@ -33,18 +33,18 @@ pub struct ShellFileInfo {
 }
 
 bitflags! {
-    /// Specifies the source of the component name
+    /// Sources from which to obtain a component name.
     #[repr(transparent)]
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ShellDeviceNameFlags: u32 {
-        /// Use Component Name
+        /// Uses the Component Name protocols.
         const USE_COMPONENT_NAME = 0x0000001;
-        /// Use Device Path
+        /// Uses the device path.
         const USE_DEVICE_PATH = 0x0000002;
     }
 }
 
-/// Shell Protocol
+/// EFI Shell protocol.
 #[derive(Debug)]
 #[repr(C)]
 pub struct ShellProtocol {

--- a/uefi-raw/src/status.rs
+++ b/uefi-raw/src/status.rs
@@ -84,7 +84,7 @@ pub enum Status: usize => {
     SECURITY_VIOLATION      = Self::ERROR_BIT | 26,
     /// A CRC error was detected.
     CRC_ERROR               = Self::ERROR_BIT | 27,
-    /// Beginning or end of media was reached
+    /// The beginning or end of the medium was reached.
     END_OF_MEDIA            = Self::ERROR_BIT | 28,
     /// The end of the file was reached.
     END_OF_FILE             = Self::ERROR_BIT | 31,
@@ -93,7 +93,7 @@ pub enum Status: usize => {
     /// The security status of the data is unknown or compromised and
     /// the data must be updated or replaced to restore a valid security status.
     COMPROMISED_DATA        = Self::ERROR_BIT | 33,
-    /// There is an address conflict address allocation
+    /// Address allocation encountered an IP address conflict.
     IP_ADDRESS_CONFLICT     = Self::ERROR_BIT | 34,
     /// A HTTP error occurred during the network operation.
     HTTP_ERROR              = Self::ERROR_BIT | 35,

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -283,7 +283,7 @@ bitflags! {
 newtype_enum! {
 /// Interface type of a protocol interface.
 pub enum InterfaceType: u32 => {
-    /// Native interface
+    /// Native protocol interface.
     NATIVE_INTERFACE = 0,
 }}
 
@@ -301,7 +301,7 @@ bitflags! {
         const WRITE_COMBINE = 0x2;
         /// Supports write-through.
         const WRITE_THROUGH = 0x4;
-        /// Support write-back.
+        /// Supports write-back.
         const WRITE_BACK = 0x8;
         /// Supports marking as uncacheable, exported and
         /// supports the "fetch and add" semaphore mechanism.
@@ -404,7 +404,7 @@ pub enum MemoryType: u32 => {
     RESERVED                =  0,
     /// The code portions of a loaded UEFI application.
     LOADER_CODE             =  1,
-    /// The data portions of a loaded UEFI applications,
+    /// The data portions of a loaded UEFI application,
     /// as well as any memory allocated by it.
     LOADER_DATA             =  2,
     /// Code of the boot drivers.
@@ -450,10 +450,15 @@ impl MemoryType {
     /// Range reserved for OS loaders.
     pub const RESERVED_FOR_OS_LOADER: RangeInclusive<u32> = 0x8000_0000..=0xffff_ffff;
 
-    /// Construct a custom `MemoryType`. Values in the range `0x8000_0000..=0xffff_ffff` are free for use if you are
-    /// an OS loader.
+    /// Constructs an OS-loader-defined memory type.
+    ///
+    /// Values in `0x8000_0000..=0xffff_ffff` are reserved for OS loaders.
     ///
     /// **Warning**: Some EFI firmware versions (e.g., OVMF r11337) may crash or [behave incorrectly](https://wiki.osdev.org/UEFI#My_bootloader_hangs_if_I_use_user_defined_EFI_MEMORY_TYPE_values) when using a custom `MemoryType`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` is below `0x8000_0000`.
     #[must_use]
     pub const fn custom(value: u32) -> Self {
         assert!(value >= 0x80000000);

--- a/uefi-test-runner/src/bin/shell_launcher.rs
+++ b/uefi-test-runner/src/bin/shell_launcher.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! This application launches the UEFI shell app and runs the main
-//! uefi-test-running app inside that shell. This allows testing of protocols
+//! Launches the main test application inside the UEFI shell.
+//!
+//! This allows testing of protocols
 //! that require the shell.
 //!
 //! Launching the shell this way (rather than directly making it the boot
@@ -22,7 +23,9 @@ use uefi::proto::device_path::build::{self, DevicePathBuilder};
 use uefi::proto::device_path::{DevicePath, DeviceSubType, DeviceType, LoadedImageDevicePath};
 use uefi::proto::loaded_image::LoadedImage;
 
-/// Get the device path of the shell app. This is the same as the
+/// Returns the device path of the shell application.
+///
+/// This is the same as the
 /// currently-loaded image's device path, but with the file path part changed.
 fn get_shell_app_device_path(storage: &mut Vec<u8>) -> &DevicePath {
     let loaded_image_device_path =

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -137,7 +137,7 @@ fn test_watchdog() {
     boot::set_watchdog_timer(0, 0x10000, None).expect("Could not set watchdog timer");
 }
 
-/// Dummy protocol for tests
+/// Dummy protocol used by tests.
 #[unsafe_protocol("1a972918-3f69-4b5d-8cb4-cece2309c7f5")]
 struct TestProtocol {
     data: u32,

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -95,12 +95,13 @@ fn check_system() {
 
 #[derive(Clone, Copy, Debug)]
 enum HostRequest {
-    /// Tell the host to take a screenshot and compare against the
+    /// Tells the host to compare a screenshot with the
     /// golden image.
     Screenshot(&'static str),
 
-    /// Tell the host that tests are complete. The host will consider
-    /// the tests failed if this message is not received.
+    /// Tells the host that testing is complete.
+    ///
+    /// The host considers the tests failed if this message is not received.
     TestsComplete,
 }
 
@@ -156,9 +157,9 @@ fn reconnect_serial_to_console(serial_handle: Handle) {
         .expect("failed to reconnect serial to console");
 }
 
-/// Send the `request` string to the host via the `serial` device, then
-/// wait up to 10 seconds to receive a reply. Returns an error if the
-/// reply is not `"OK\n"`.
+/// Sends a request to the host through the serial device.
+///
+/// The function waits up to 10 seconds for an `"OK\n"` reply.
 fn send_request_to_host(request: HostRequest) {
     let serial_handle =
         uefi::boot::get_handle_for_protocol::<Serial>().expect("Failed to get serial handle");

--- a/uefi-test-runner/src/proto/media.rs
+++ b/uefi-test-runner/src/proto/media.rs
@@ -290,12 +290,12 @@ fn test_raw_disk_io(handle: Handle) {
     info!("Raw disk I/O succeeded");
 }
 
-/// Asynchronous disk I/O task context
+/// Context for an asynchronous disk I/O task.
 #[repr(C)]
 struct DiskIoTask {
-    /// Token for the transaction
+    /// Transaction token.
     token: DiskIo2Token,
-    /// Buffer holding the read data
+    /// Buffer that holds the read data.
     buffer: [u8; 512],
 }
 

--- a/uefi/src/allocator.rs
+++ b/uefi/src/allocator.rs
@@ -15,7 +15,7 @@ use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicU32, Ordering};
 use uefi_raw::table::boot::PAGE_SIZE;
 
-/// Get the memory type to use for allocation.
+/// Returns the memory type used for allocation.
 ///
 /// The first time this is called, the data type of the loaded image will be
 /// retrieved. That value is cached in a static and reused on subsequent

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -902,8 +902,7 @@ pub fn register_protocol_notify(
     )
 }
 
-/// Get the list of protocol interface [`Guids`][Guid] that are installed
-/// on a [`Handle`].
+/// Returns the protocol interface [`Guid`]s installed on a [`Handle`].
 ///
 /// # Errors
 ///
@@ -1091,15 +1090,13 @@ pub fn find_handles<P: ProtocolPointer + ?Sized>() -> Result<Vec<Handle>> {
     Ok(handles)
 }
 
-/// Find an arbitrary handle that supports a particular [`Protocol`]. Returns
-/// [`NOT_FOUND`] if no handles support the protocol.
+/// Returns an arbitrary handle that supports a particular [`Protocol`].
 ///
 /// This method is a convenient wrapper around [`locate_handle_buffer`] for
 /// getting just one handle. This is useful when you don't care which handle the
 /// protocol is opened on. For example, [`DevicePathToText`] isn't tied to a
 /// particular device, so only a single handle is expected to exist.
 ///
-/// [`NOT_FOUND`]: Status::NOT_FOUND
 /// [`DevicePathToText`]: uefi::proto::device_path::text::DevicePathToText
 ///
 /// # Example

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -131,30 +131,28 @@ pub unsafe fn raise_tpl(tpl: Tpl) -> TplGuard {
     }
 }
 
-/// Allocates a consecutive set of memory pages using the UEFI allocator.
+/// Allocates consecutive pages using the UEFI allocator.
 ///
-/// The buffer will be [`PAGE_SIZE`] aligned. Callers are responsible for
-/// freeing the memory using [`free_pages`].
+/// The result is [`PAGE_SIZE`] aligned and must be freed with [`free_pages`].
+/// The returned memory is uninitialized; initialize it before reading it or
+/// creating a reference to it.
 ///
 /// # Arguments
+///
 /// - `allocation_type`: The [`AllocateType`] to choose the allocation strategy.
 /// - `memory_type`: The [`MemoryType`] used to persist the allocation in the
 ///   UEFI memory map. Typically, UEFI OS loaders should allocate memory of
 ///   type [`MemoryType::LOADER_DATA`].
-///- `count`: Number of pages to allocate.
-///
-/// # Safety
-///
-/// Using this function is safe, but it returns a raw pointer to uninitialized
-/// memory. The memory must be initialized before creating a reference to it
-/// or reading from it eventually.
+/// - `count`: Number of pages to allocate.
 ///
 /// # Errors
 ///
-/// * [`Status::OUT_OF_RESOURCES`]: allocation failed.
-/// * [`Status::INVALID_PARAMETER`]: `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
-///   [`MemoryType::UNACCEPTED`], or in the range <code>[MemoryType::MAX]..=0x6fff_ffff</code>.
-/// * [`Status::NOT_FOUND`]: the requested pages could not be found.
+/// - [`Status::OUT_OF_RESOURCES`]: allocation failed.
+/// - [`Status::INVALID_PARAMETER`]: `memory_type` is
+///   [`MemoryType::PERSISTENT_MEMORY`],
+///   [`MemoryType::UNACCEPTED`], or in the range
+///   <code>[MemoryType::MAX]..=0x6fff_ffff</code>.
+/// - [`Status::NOT_FOUND`]: the requested pages could not be found.
 pub fn allocate_pages(
     allocation_type: AllocateType,
     memory_type: MemoryType,
@@ -224,28 +222,26 @@ pub unsafe fn free_pages(ptr: NonNull<u8>, count: usize) -> Result {
     unsafe { (bt.free_pages)(addr, count) }.to_result()
 }
 
-/// Allocates a consecutive region of bytes using the UEFI allocator.
+/// Allocates bytes using the UEFI allocator.
 ///
-/// The buffer will be 8-byte aligned. Callers are responsible for freeing the
-/// memory using [`free_pool`].
+/// The result is eight-byte aligned and must be freed with [`free_pool`]. The
+/// returned memory is uninitialized; initialize it before reading it or
+/// creating a reference to it.
 ///
 /// # Arguments
+///
 /// - `memory_type`: The [`MemoryType`] used to persist the allocation in the
 ///   UEFI memory map. Typically, UEFI OS loaders should allocate memory of
 ///   type [`MemoryType::LOADER_DATA`].
-///- `size`: Number of bytes to allocate.
-///
-/// # Safety
-///
-/// Using this function is safe, but it returns a raw pointer to uninitialized
-/// memory. The memory must be initialized before creating a reference to it
-/// or reading from it eventually.
+/// - `size`: Number of bytes to allocate.
 ///
 /// # Errors
 ///
-/// * [`Status::OUT_OF_RESOURCES`]: allocation failed.
-/// * [`Status::INVALID_PARAMETER`]: `mem_ty` is [`MemoryType::PERSISTENT_MEMORY`],
-///   [`MemoryType::UNACCEPTED`], or in the range <code>[MemoryType::MAX]..=0x6fff_ffff</code>.
+/// - [`Status::OUT_OF_RESOURCES`]: allocation failed.
+/// - [`Status::INVALID_PARAMETER`]: `memory_type` is
+///   [`MemoryType::PERSISTENT_MEMORY`],
+///   [`MemoryType::UNACCEPTED`], or in the range
+///   <code>[MemoryType::MAX]..=0x6fff_ffff</code>.
 pub fn allocate_pool(memory_type: MemoryType, size: usize) -> Result<NonNull<u8>> {
     let bt = boot_services_raw_panicking();
     // SAFETY: The pointer is not null and we assume it to be initialized.

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -60,7 +60,7 @@ use {alloc::vec::Vec, uefi::ResultExt};
 /// only read by [`image_handle`].
 static IMAGE_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 
-/// Get the [`Handle`] of the currently-executing image.
+/// Returns the [`Handle`] of the currently executing image.
 #[must_use]
 pub fn image_handle() -> Handle {
     let ptr = IMAGE_HANDLE.load(Ordering::Acquire);
@@ -1386,7 +1386,7 @@ pub unsafe fn exit(
     result.to_result()
 }
 
-/// Get the current memory map and exit boot services.
+/// Gets the current memory map and exits boot services.
 unsafe fn get_memory_map_and_exit_boot_services(buf: &mut [u8]) -> Result<MemoryMapMeta> {
     let bt = boot_services_raw_panicking();
     // SAFETY: The pointer is not null and we assume it to be initialized.
@@ -1778,7 +1778,7 @@ impl<P: Protocol + ?Sized> DerefMut for ScopedProtocol<P> {
 }
 
 impl<P: Protocol + ?Sized> ScopedProtocol<P> {
-    /// Get the protocol interface data, or `None` if the open protocol's
+    /// Returns the protocol data, or `None` if the open protocol's
     /// interface is null.
     #[must_use]
     pub fn get(&self) -> Option<&P> {
@@ -1787,7 +1787,7 @@ impl<P: Protocol + ?Sized> ScopedProtocol<P> {
         self.interface.map(|p| unsafe { p.as_ref() })
     }
 
-    /// Get the protocol interface data, or `None` if the open protocol's
+    /// Returns the protocol data, or `None` if the open protocol's
     /// interface is null.
     #[must_use]
     pub fn get_mut(&mut self) -> Option<&mut P> {
@@ -2018,14 +2018,14 @@ pub enum AllocateType {
 /// The type of handle search to perform.
 #[derive(Debug, Copy, Clone)]
 pub enum SearchType<'guid> {
-    /// Return all handles present on the system.
+    /// Returns all handles present on the system.
     AllHandles,
     /// Returns all handles supporting a certain protocol, specified by its GUID.
     ///
     /// If the protocol implements the `Protocol` interface,
     /// you can use the `from_proto` function to construct a new `SearchType`.
     ByProtocol(&'guid Guid),
-    /// Return all handles that implement a protocol when an interface for that protocol
+    /// Returns all handles that implement a protocol when its interface
     /// is (re)installed.
     ByRegisterNotify(ProtocolSearchKey),
 }

--- a/uefi/src/data_types/chars.rs
+++ b/uefi/src/data_types/chars.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! UEFI character handling
+//! UEFI character handling.
 //!
-//! UEFI uses both Latin-1 and UCS-2 character encoding, this module implements
-//! support for the associated character types.
+//! UEFI uses both Latin-1 and UCS-2 encodings. This module provides the
+//! corresponding character types.
 
 use core::fmt::{self, Display, Formatter};
 
-/// Character conversion error
+/// Error converting a character to a UEFI character type.
 #[derive(Clone, Copy, Debug)]
 pub struct CharConversionError;
 
@@ -19,7 +19,7 @@ impl Display for CharConversionError {
 
 impl core::error::Error for CharConversionError {}
 
-/// A Latin-1 character
+/// Latin-1 character.
 #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Char8(u8);
@@ -71,10 +71,10 @@ impl PartialEq<char> for Char8 {
     }
 }
 
-/// Latin-1 version of the NUL character
+/// Latin-1 NUL character.
 pub const NUL_8: Char8 = Char8(0);
 
-/// An UCS-2 code point
+/// UCS-2 code point.
 #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Char16(u16);
@@ -83,13 +83,14 @@ impl Char16 {
     /// Creates a UCS-2 character from a Rust character without checks.
     ///
     /// # Safety
+    ///
     /// The caller must be sure that the character is valid.
     #[must_use]
     pub const unsafe fn from_u16_unchecked(val: u16) -> Self {
         Self(val)
     }
 
-    /// Checks if the value is within the ASCII range.
+    /// Returns whether the value is in the ASCII range.
     #[must_use]
     pub const fn is_ascii(&self) -> bool {
         self.0 <= 127
@@ -159,7 +160,7 @@ impl PartialEq<char> for Char16 {
     }
 }
 
-/// UCS-2 version of the NUL character
+/// UCS-2 NUL character.
 // SAFETY: The character is valid.
 pub const NUL_16: Char16 = unsafe { Char16::from_u16_unchecked(0) };
 

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Data type definitions
+//! Core UEFI data types.
 //!
-//! This module defines the basic data types that are used throughout uefi-rs
+//! These types are used throughout `uefi-rs`.
 
 pub mod chars;
 
@@ -178,7 +178,7 @@ impl Handle {
 pub struct Event(NonNull<c_void>);
 
 impl Event {
-    /// Clone this `Event`
+    /// Clones this event without tracking the duplicate handle.
     ///
     /// # Safety
     /// When an event is closed by calling [`boot::close_event`], that event and ALL references
@@ -218,10 +218,10 @@ impl Event {
 /// of the buffer must be checked. The `Align` trait makes that possible by
 /// allowing the appropriate alignment to be manually specified.
 pub trait Align {
-    /// Required memory alignment for this type
+    /// Returns the required memory alignment for this type.
     fn alignment() -> usize;
 
-    /// Calculate the offset from `val` necessary to make it aligned,
+    /// Calculates the offset needed to align `val`, rounding up.
     /// rounding up. For example, if `val` is 1 and the alignment is 8,
     /// this will return 7. Returns 0 if `val == 0`.
     #[must_use]
@@ -237,9 +237,7 @@ pub trait Align {
         val + Self::offset_up_to_alignment(val)
     }
 
-    /// Returns a subslice of `buf` whose first element's address
-    /// is aligned. Returns `None` if no element of the buffer is
-    /// aligned.
+    /// Returns the aligned suffix of `buf`, if one exists.
     fn align_buf(buf: &mut [u8]) -> Option<&mut [u8]> {
         let offset = buf.as_ptr().align_offset(Self::alignment());
         buf.get_mut(offset..)

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -41,7 +41,7 @@ impl core::error::Error for FromStrError {}
 /// For convenience, a [`CString16`] is comparable with `&str` and `String` from
 /// the standard library through the trait [`EqStrUntilNul`].
 ///
-/// # Examples
+/// # Example
 ///
 /// Round-trip conversion from a [`&str`] to a `CString16` and back:
 ///

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -489,7 +489,7 @@ impl CStr16 {
     /// The backing buffer must be big enough to hold the converted string as
     /// well as a trailing null character.
     ///
-    /// # Examples
+    /// # Example
     ///
     /// Converts the UTF-8 string "ABC" to a `&CStr16`:
     ///
@@ -571,7 +571,7 @@ impl CStr16 {
     ///
     /// See [`FromSliceWithNulError`].
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use uefi::CStr16;

--- a/uefi/src/data_types/strs.rs
+++ b/uefi/src/data_types/strs.rs
@@ -17,14 +17,13 @@ use core::{ptr, slice};
 #[cfg(feature = "alloc")]
 use super::CString16;
 
-/// Error converting from a slice (which can contain interior nuls) to a string
-/// type.
+/// Error converting a slice that may contain interior nulls to a string.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FromSliceUntilNulError {
     /// An invalid character was encountered before the end of the slice.
     InvalidChar(usize),
 
-    /// The does not contain a nul character.
+    /// The slice does not contain a null character.
     NoNul,
 }
 
@@ -39,17 +38,16 @@ impl Display for FromSliceUntilNulError {
 
 impl core::error::Error for FromSliceUntilNulError {}
 
-/// Error converting from a slice (which cannot contain interior nuls) to a
-/// string type.
+/// Error converting a null-terminated slice to a string.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FromSliceWithNulError {
-    /// An invalid character was encountered before the end of the slice
+    /// An invalid character was encountered before the end of the slice.
     InvalidChar(usize),
 
-    /// A null character was encountered before the end of the slice
+    /// A null character was encountered before the end of the slice.
     InteriorNul(usize),
 
-    /// The slice was not null-terminated
+    /// The slice was not null-terminated.
     NotNulTerminated,
 
     /// Slice is not aligned to a 16-bit boundary.
@@ -81,8 +79,7 @@ pub enum UnalignedCStr16Error {
     /// The data was not null-terminated.
     NotNulTerminated,
 
-    /// The buffer is not big enough to hold the entire string and
-    /// trailing null character.
+    /// The buffer cannot hold the entire string and its trailing null.
     BufferTooSmall,
 }
 
@@ -102,14 +99,13 @@ impl core::error::Error for UnalignedCStr16Error {}
 /// Error returned by [`CStr16::from_str_with_buf`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FromStrWithBufError {
-    /// An invalid character was encountered before the end of the string
+    /// An invalid character was encountered before the end of the string.
     InvalidChar(usize),
 
-    /// A null character was encountered in the string
+    /// A null character was encountered in the string.
     InteriorNul(usize),
 
-    /// The buffer is not big enough to hold the entire string and
-    /// trailing null character
+    /// The buffer cannot hold the entire string and its trailing null.
     BufferTooSmall,
 }
 
@@ -142,12 +138,12 @@ impl core::error::Error for FromStrWithBufError {}
 pub struct CStr8([Char8]);
 
 impl CStr8 {
-    /// Takes a raw pointer to a null-terminated Latin-1 string and wraps it in a CStr8 reference.
+    /// Wraps a raw null-terminated Latin-1 string in a [`CStr8`] reference.
     ///
     /// # Safety
     ///
     /// The function will start accessing memory from `ptr` until the first
-    /// null byte. It's the callers responsibility to ensure `ptr` points to
+    /// null byte. It is the caller's responsibility to ensure `ptr` points to
     /// a valid null-terminated string in accessible memory.
     #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char8) -> &'ptr Self {
@@ -161,7 +157,13 @@ impl CStr8 {
         unsafe { Self::from_bytes_with_nul_unchecked(slice::from_raw_parts(ptr, len + 1)) }
     }
 
-    /// Creates a CStr8 reference from bytes.
+    /// Creates a [`CStr8`] reference from null-terminated bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FromSliceWithNulError::InteriorNul`] if a null occurs before
+    /// the end, or [`FromSliceWithNulError::NotNulTerminated`] if the final byte
+    /// is not null.
     pub fn from_bytes_with_nul(chars: &[u8]) -> Result<&Self, FromSliceWithNulError> {
         let nul_pos = chars.iter().position(|&c| c == 0);
         if let Some(nul_pos) = nul_pos {
@@ -175,11 +177,11 @@ impl CStr8 {
         }
     }
 
-    /// Unsafely creates a CStr8 reference from bytes.
+    /// Creates a [`CStr8`] reference from bytes without validation.
     ///
     /// # Safety
     ///
-    /// It's the callers responsibility to ensure chars is a valid Latin-1
+    /// It is the caller's responsibility to ensure `chars` is a valid Latin-1
     /// null-terminated string, with no interior null bytes.
     #[must_use]
     pub const unsafe fn from_bytes_with_nul_unchecked(chars: &[u8]) -> &Self {
@@ -187,14 +189,13 @@ impl CStr8 {
         unsafe { &*(ptr::from_ref(chars) as *const Self) }
     }
 
-    /// Returns the inner pointer to this CStr8.
+    /// Returns the string's inner pointer.
     #[must_use]
     pub const fn as_ptr(&self) -> *const Char8 {
         self.0.as_ptr()
     }
 
-    /// Returns the underlying bytes as slice including the terminating null
-    /// character.
+    /// Returns the underlying bytes, including the terminating null.
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8] {
         // SAFETY: The source layout matches the target view.
@@ -356,12 +357,12 @@ pub const fn str_to_latin1<const N: usize>(s: &str) -> [u8; N] {
 pub struct CStr16([Char16]);
 
 impl CStr16 {
-    /// Wraps a raw UEFI string with a safe C string wrapper
+    /// Wraps a raw UEFI string in a [`CStr16`] reference.
     ///
     /// # Safety
     ///
     /// The function will start accessing memory from `ptr` until the first
-    /// null character. It's the callers responsibility to ensure `ptr` points to
+    /// null character. It is the caller's responsibility to ensure `ptr` points to
     /// a valid string, in accessible memory.
     #[must_use]
     pub unsafe fn from_ptr<'ptr>(ptr: *const Char16) -> &'ptr Self {
@@ -393,8 +394,12 @@ impl CStr16 {
         Err(FromSliceUntilNulError::NoNul)
     }
 
-    /// Creates a `&CStr16` from a u16 slice, if the slice contains exactly
-    /// one terminating null-byte and all chars are valid UCS-2 chars.
+    /// Creates a [`CStr16`] from a null-terminated `u16` slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the slice contains invalid UCS-2, has an interior
+    /// null, or is not null-terminated.
     pub fn from_u16_with_nul(codes: &[u16]) -> Result<&Self, FromSliceWithNulError> {
         for (pos, &code) in codes.iter().enumerate() {
             match code.try_into() {
@@ -419,7 +424,7 @@ impl CStr16 {
     ///
     /// # Safety
     ///
-    /// It's the callers responsibility to ensure chars is a valid UCS-2
+    /// It is the caller's responsibility to ensure `codes` is a valid UCS-2
     /// null-terminated string, with no interior null characters.
     #[must_use]
     pub const unsafe fn from_u16_with_nul_unchecked(codes: &[u16]) -> &Self {
@@ -427,7 +432,7 @@ impl CStr16 {
         unsafe { &*(ptr::from_ref(codes) as *const Self) }
     }
 
-    /// Creates a `&CStr16` from a [`Char16`] slice, stopping at the first nul character.
+    /// Creates a [`CStr16`] from a [`Char16`] slice up to its first null.
     ///
     /// # Errors
     ///
@@ -444,8 +449,12 @@ impl CStr16 {
         unsafe { Ok(Self::from_char16_with_nul_unchecked(&chars[..=end])) }
     }
 
-    /// Creates a `&CStr16` from a [`Char16`] slice, if the slice is
-    /// null-terminated and has no interior null characters.
+    /// Creates a [`CStr16`] from a null-terminated [`Char16`] slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the slice has an interior null or is not
+    /// null-terminated.
     pub fn from_char16_with_nul(chars: &[Char16]) -> Result<&Self, FromSliceWithNulError> {
         // Fail early if the input is empty.
         if chars.is_empty() {
@@ -471,7 +480,7 @@ impl CStr16 {
     ///
     /// # Safety
     ///
-    /// It's the callers responsibility to ensure chars is null-terminated and
+    /// It is the caller's responsibility to ensure `chars` is null-terminated and
     /// has no interior null characters.
     #[must_use]
     pub const unsafe fn from_char16_with_nul_unchecked(chars: &[Char16]) -> &Self {
@@ -499,6 +508,11 @@ impl CStr16 {
     /// let mut buf = [0; 4];
     /// CStr16::from_str_with_buf("ABC", &mut buf).unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` contains invalid UCS-2 or a null character,
+    /// or if `buf` is too small for the converted string and trailing null.
     pub fn from_str_with_buf<'a>(
         input: &str,
         buf: &'a mut [u16],
@@ -528,9 +542,14 @@ impl CStr16 {
         })
     }
 
-    /// Creates a `&CStr16` from an [`UnalignedSlice`] using an aligned
-    /// buffer for storage. The lifetime of the output is tied to `buf`,
-    /// not `src`.
+    /// Copies an unaligned UCS-2 string into `buf` and returns a [`CStr16`].
+    ///
+    /// The returned string borrows `buf`, not `src`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `buf` is too small or the source is not a valid,
+    /// null-terminated UCS-2 string without interior nulls.
     pub fn from_unaligned_slice<'buf>(
         src: &UnalignedSlice<'_, u16>,
         buf: &'buf mut [MaybeUninit<u16>],
@@ -672,12 +691,12 @@ impl CStr16 {
         self.0.iter().all(|c| c.is_ascii())
     }
 
-    /// Writes each [`Char16`] as a [`char`] (4 bytes long in Rust language) into the buffer.
-    /// It is up to the implementer of [`core::fmt::Write`] to convert the char to a string
-    /// with proper encoding/charset. For example, in the case of [`alloc::string::String`]
-    /// all Rust chars (UTF-32) get converted to UTF-8.
+    /// Writes each [`Char16`] to a formatting buffer as a [`char`].
     ///
-    /// ## Example
+    /// The [`core::fmt::Write`] implementation determines the output encoding.
+    /// For example, [`alloc::string::String`] encodes the characters as UTF-8.
+    ///
+    /// # Example
     ///
     /// ```ignore
     /// let firmware_vendor_c16_str: CStr16 = ...;
@@ -695,8 +714,7 @@ impl CStr16 {
         Ok(())
     }
 
-    /// Returns the underlying bytes as slice including the terminating null
-    /// character.
+    /// Returns the underlying bytes, including the terminating null.
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8] {
         // SAFETY: The pointer is valid for the requested slice length.
@@ -806,13 +824,16 @@ impl PartialEq<CString16> for &CStr16 {
 pub struct PoolString(PoolAllocation);
 
 impl PoolString {
-    /// Creates a [`PoolString`] from a [`CStr16`] residing in a buffer allocated
-    /// using [`allocate_pool()`][cbap].
+    /// Takes ownership of a pool-allocated [`CStr16`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Status::OUT_OF_RESOURCES`] if `text` is null.
     ///
     /// # Safety
     ///
     /// The caller must ensure that the buffer points to a valid [`CStr16`] and
-    /// resides in a buffer allocated using [`allocate_pool()`][cbap]
+    /// resides in a buffer allocated using [`allocate_pool()`][cbap].
     ///
     /// [cbap]: crate::boot::allocate_pool()
     pub unsafe fn new(text: *const Char16) -> crate::Result<Self> {
@@ -832,9 +853,14 @@ impl Deref for PoolString {
 }
 
 impl UnalignedSlice<'_, u16> {
-    /// Creates a [`CStr16`] from an [`UnalignedSlice`] using an aligned
-    /// buffer for storage. The lifetime of the output is tied to `buf`,
-    /// not `self`.
+    /// Copies this unaligned string into `buf` and returns a [`CStr16`].
+    ///
+    /// The returned string borrows `buf`, not `self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `buf` is too small or this slice is not a valid,
+    /// null-terminated UCS-2 string without interior nulls.
     pub fn to_cstr16<'buf>(
         &self,
         buf: &'buf mut [MaybeUninit<u16>],
@@ -843,18 +869,17 @@ impl UnalignedSlice<'_, u16> {
     }
 }
 
-/// The EqStrUntilNul trait helps to compare Rust strings against UEFI string types (UCS-2 strings).
+/// Compares Rust strings with null-terminated UEFI strings.
 ///
 /// The given generic implementation of this trait enables us that we only have to
 /// implement one direction (`left.eq_str_until_nul(&right)`) for each UEFI string type and we
 /// get the other direction (`right.eq_str_until_nul(&left)`) for free. Hence, the relation is
 /// reflexive.
 pub trait EqStrUntilNul<StrType: ?Sized> {
-    /// Checks whether the provided Rust string `StrType` equals [`Self`] until
-    /// the first null character.
-    /// is found. An exception is the terminating null character of [Self] which is ignored.
+    /// Compares `other` with this string up to the first null character.
     ///
-    /// As soon as the first null character in either `&self` or `other` is found, this method returns.
+    /// The terminating null in [`Self`] is ignored. Comparison stops at the
+    /// first null in either string.
     /// Note that Rust strings are allowed to contain null bytes that do not terminate the string.
     /// Although this is rather unusual, you can compare `"foo\0bar"` with an instance of [Self].
     /// In that case, only `foo"` is compared against [Self] (if [Self] is long enough).

--- a/uefi/src/fs/dir_entry_iter.rs
+++ b/uefi/src/fs/dir_entry_iter.rs
@@ -18,7 +18,7 @@ pub const COMMON_SKIP_DIRS: &[&CStr16] = &[cstr16!("."), cstr16!("..")];
 pub struct UefiDirectoryIter(UefiDirectoryHandle);
 
 impl UefiDirectoryIter {
-    /// Constructor.
+    /// Creates an iterator over `handle`.
     #[must_use]
     pub const fn new(handle: UefiDirectoryHandle) -> Self {
         Self(handle)

--- a/uefi/src/fs/file_system/fs.rs
+++ b/uefi/src/fs/file_system/fs.rs
@@ -15,9 +15,9 @@ use uefi::boot::ScopedProtocol;
 /// Return type for public [`FileSystem`] operations.
 pub type FileSystemResult<T> = Result<T, Error>;
 
-/// High-level file-system abstraction for UEFI volumes with an API that is
-/// close to `std::fs`. It acts as convenient accessor around the
-/// [`SimpleFileSystemProtocol`].
+/// High-level file-system abstraction for UEFI volumes.
+///
+/// Its API resembles `std::fs` and wraps [`SimpleFileSystemProtocol`].
 ///
 /// Please refer to the [module documentation] for more information.
 ///
@@ -25,7 +25,7 @@ pub type FileSystemResult<T> = Result<T, Error>;
 pub struct FileSystem(ScopedProtocol<SimpleFileSystemProtocol>);
 
 impl FileSystem {
-    /// Constructor.
+    /// Creates a file-system accessor for `proto`.
     #[must_use]
     pub fn new(proto: impl Into<Self>) -> Self {
         proto.into()
@@ -35,6 +35,11 @@ impl FileSystem {
     ///
     /// If the file does not exist, `Ok(false)` is returned. If it cannot be
     /// determined whether the file exists or not, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot inspect the path.
     pub fn try_exists(&mut self, path: impl AsRef<Path>) -> FileSystemResult<bool> {
         match self.open(path.as_ref(), UefiFileMode::Read, false) {
             Ok(_) => Ok(true),
@@ -49,8 +54,14 @@ impl FileSystem {
         }
     }
 
-    /// Copies the contents of one file to another. Creates the destination file
-    /// if it doesn't exist and overwrites any content, if it exists.
+    /// Copies one file to another.
+    ///
+    /// The destination is created if necessary and overwritten if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if a file
+    /// operation fails.
     pub fn copy(
         &mut self,
         src_path: impl AsRef<Path>,
@@ -149,15 +160,24 @@ impl FileSystem {
         Ok(())
     }
 
-    /// Creates a new, empty directory at the provided path
+    /// Creates an empty directory at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot create the directory.
     pub fn create_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
         let path = path.as_ref();
         self.open(path, UefiFileMode::CreateReadWrite, true)
             .map(|_| ())
     }
 
-    /// Recursively create a directory and all of its parent components if they
-    /// are missing.
+    /// Creates a directory and any missing parents.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot inspect or create a directory.
     pub fn create_dir_all(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
         let path = path.as_ref();
 
@@ -181,8 +201,12 @@ impl FileSystem {
         Ok(())
     }
 
-    /// Given a path, query the file system to get information about a file,
-    /// directory, etc. Returns [`UefiFileInfo`].
+    /// Returns metadata for a file or directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot open the path or read its metadata.
     pub fn metadata(&mut self, path: impl AsRef<Path>) -> FileSystemResult<Box<UefiFileInfo>> {
         let path = path.as_ref();
         let mut file = self.open(path, UefiFileMode::Read, false)?;
@@ -195,7 +219,12 @@ impl FileSystem {
         })
     }
 
-    /// Read the entire contents of a file into a bytes vector.
+    /// Reads an entire file into a byte vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot open, inspect, or read the file.
     pub fn read(&mut self, path: impl AsRef<Path>) -> FileSystemResult<Vec<u8>> {
         let path = path.as_ref();
 
@@ -238,6 +267,11 @@ impl FileSystem {
     }
 
     /// Returns an iterator over the entries within a directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot open the directory.
     pub fn read_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<UefiDirectoryIter> {
         let path = path.as_ref();
         let dir = self
@@ -255,12 +289,22 @@ impl FileSystem {
         Ok(UefiDirectoryIter::new(dir))
     }
 
-    /// Read the entire contents of a file into a Rust string.
+    /// Reads an entire UTF-8 file into a [`String`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path, [`Error::Io`] if firmware
+    /// cannot read the file, or [`Error::Utf8Encoding`] for invalid UTF-8.
     pub fn read_to_string(&mut self, path: impl AsRef<Path>) -> FileSystemResult<String> {
         String::from_utf8(self.read(path)?).map_err(Error::Utf8Encoding)
     }
 
     /// Removes an empty directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if the path
+    /// is not a directory or firmware cannot remove it.
     pub fn remove_dir(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
         let path = path.as_ref();
 
@@ -289,8 +333,12 @@ impl FileSystem {
         }
     }
 
-    /// Removes a directory at this path, after removing all its contents. Use
-    /// carefully!
+    /// Recursively removes a directory and all of its contents.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot enumerate or remove an entry.
     pub fn remove_dir_all(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
         let path = path.as_ref();
         for file_info in self
@@ -319,6 +367,11 @@ impl FileSystem {
     }
 
     /// Removes a file from the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if the path
+    /// is not a file or firmware cannot remove it.
     pub fn remove_file(&mut self, path: impl AsRef<Path>) -> FileSystemResult<()> {
         let path = path.as_ref();
 
@@ -345,8 +398,12 @@ impl FileSystem {
         }
     }
 
-    /// Rename a file or directory to a new name, replacing the original file if
-    /// it already exists.
+    /// Renames a file, replacing the destination if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot copy or remove the file.
     pub fn rename(
         &mut self,
         src_path: impl AsRef<Path>,
@@ -356,9 +413,14 @@ impl FileSystem {
         self.remove_file(src_path)
     }
 
-    /// Write a slice as the entire contents of a file. This function will
-    /// create a file if it does not exist, and will entirely replace its
-    /// contents if it does.
+    /// Writes bytes as the entire contents of a file.
+    ///
+    /// The file is created if necessary and replaced if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] for an invalid path or [`Error::Io`] if firmware
+    /// cannot create, write, or flush the file.
     pub fn write(
         &mut self,
         path: impl AsRef<Path>,

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -16,7 +16,7 @@ use core::ptr;
 pub struct Path(CStr16);
 
 impl Path {
-    /// Constructor.
+    /// Creates a path from a [`CStr16`].
     #[must_use]
     pub fn new<S: AsRef<CStr16> + ?Sized>(s: &S) -> &Self {
         // SAFETY: The handle is known to point to live storage here.

--- a/uefi/src/fs/path/pathbuf.rs
+++ b/uefi/src/fs/path/pathbuf.rs
@@ -13,13 +13,13 @@ use core::fmt::{Display, Formatter};
 pub struct PathBuf(CString16);
 
 impl PathBuf {
-    /// Constructor.
+    /// Creates an empty path buffer.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Constructor that replaces all occurrences of `/` with `\`.
+    /// Creates a path buffer and converts `/` separators to `\`.
     fn new_from_cstring16(mut string: CString16) -> Self {
         // SAFETY: The memory is valid.
         const SEARCH: Char16 = unsafe { Char16::from_u16_unchecked('/' as u16) };

--- a/uefi/src/helpers/logger.rs
+++ b/uefi/src/helpers/logger.rs
@@ -6,8 +6,6 @@
 //! The main export of this module is the `Logger` structure,
 //! which implements the `log` crate's trait `Log`.
 //!
-//! # Implementation Details
-//!
 //! The implementation is not the most efficient, since there is no buffering done,
 //! and the messages have to be converted from UTF-8 to UEFI's UCS-2.
 //!
@@ -20,13 +18,14 @@ use core::fmt::{self, Write};
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-/// Global logger object
+/// Global logger instance.
 static LOGGER: Logger = Logger::new();
 
-/// Set up logging
+/// Enables the global logger.
 ///
-/// This is unsafe because you must arrange for the logger to be reset with
-/// disable() on exit from UEFI boot services.
+/// # Safety
+///
+/// The caller must call [`disable`] before exiting UEFI boot services.
 pub unsafe fn init() {
     // Connect the logger to stdout.
     system::with_stdout(|stdout| {
@@ -43,6 +42,7 @@ pub unsafe fn init() {
     log::set_max_level(log::STATIC_MAX_LEVEL);
 }
 
+/// Disables the global logger.
 pub fn disable() {
     LOGGER.disable();
 }
@@ -106,13 +106,13 @@ impl Logger {
         }
     }
 
-    /// Get the output pointer (may be null).
+    /// Returns the output pointer, which may be null.
     #[must_use]
     fn output(&self) -> *mut Output {
         self.writer.load(Ordering::Acquire)
     }
 
-    /// Set the [`Output`] to which the logger will write.
+    /// Sets the [`Output`] to which the logger writes.
     ///
     /// If a null pointer is passed for `output`, this method is equivalent to
     /// calling [`disable`].
@@ -131,7 +131,7 @@ impl Logger {
         self.writer.store(output, Ordering::Release);
     }
 
-    /// Disable the logger.
+    /// Disables the logger.
     pub fn disable(&self) {
         // SAFETY: Passing a null pointer disables output without dereferencing it.
         unsafe { self.set_output(ptr::null_mut()) }
@@ -192,7 +192,7 @@ unsafe impl Sync for Logger {}
 // under the same single-processor assumption.
 unsafe impl Send for Logger {}
 
-/// Writer wrapper which prints a log level in front of every line of text
+/// Writer that prefixes every line with its log level.
 ///
 /// This is less easy than it sounds because...
 ///

--- a/uefi/src/helpers/println.rs
+++ b/uefi/src/helpers/println.rs
@@ -19,8 +19,7 @@ pub fn _print(args: core::fmt::Arguments) {
 
 /// Prints to the standard output of the UEFI boot service console.
 ///
-/// # Usage
-/// Use this similar to `print!` from the Rust standard library, but only
+/// Use this like `print!` from the Rust standard library, but only
 /// as long as boot services have not been exited.
 ///
 /// You should never use this macro in a custom Logger ([`log::Log`] impl) to
@@ -29,7 +28,7 @@ pub fn _print(args: core::fmt::Arguments) {
 /// # Panics
 /// Will panic if the system table's `stdout` is not set, or if writing fails.
 ///
-/// # Examples
+/// # Example
 /// ```
 /// print!("");
 /// print!("Hello World\n");
@@ -43,8 +42,7 @@ macro_rules! print {
 /// Prints to the standard output of the UEFI boot service console, but with a
 /// newline.
 ///
-/// # Usage
-/// Use this similar to `println!` from the Rust standard library, but only
+/// Use this like `println!` from the Rust standard library, but only
 /// as long as boot services have not been exited.
 ///
 /// You should never use this macro in a custom Logger ([`log::Log`] impl) to
@@ -53,7 +51,7 @@ macro_rules! print {
 /// # Panics
 /// Will panic if the system table's `stdout` is not set, or if writing fails.
 ///
-/// # Examples
+/// # Example
 /// ```
 /// println!();
 /// println!("Hello World");

--- a/uefi/src/mem/aligned_buffer.rs
+++ b/uefi/src/mem/aligned_buffer.rs
@@ -52,21 +52,21 @@ impl AlignedBuffer {
         self.ptr.as_ptr()
     }
 
-    /// Get the underlying memory region as immutable slice.
+    /// Returns the underlying memory region as an immutable slice.
     #[must_use]
     pub const fn as_slice(&self) -> &[u8] {
         // SAFETY: The pointer is valid for the requested slice length.
         unsafe { slice::from_raw_parts(self.ptr(), self.size()) }
     }
 
-    /// Get the underlying memory region as mutable slice.
+    /// Returns the underlying memory region as a mutable slice.
     #[must_use]
     pub const fn as_slice_mut(&mut self) -> &mut [u8] {
         // SAFETY: The pointer is valid for the requested slice length.
         unsafe { slice::from_raw_parts_mut(self.ptr_mut(), self.size()) }
     }
 
-    /// Get the size of the aligned memory region managed by this instance.
+    /// Returns the size of the managed aligned memory region.
     #[must_use]
     pub const fn size(&self) -> usize {
         self.layout.size()

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -281,8 +281,7 @@ impl IndexMut<usize> for MemoryMapRefMut<'_> {
 /// When this type is dropped and boot services are not exited yet, the memory
 /// is freed.
 ///
-/// # Usage
-/// The type is intended to be used like this:
+/// The type is intended to be used as follows:
 /// 1. create it using [`MemoryMapBackingMemory::new`]
 /// 2. pass it to [`boot::get_memory_map`]
 /// 3. construct a [`MemoryMapOwned`] from it

--- a/uefi/src/proto/ata/mod.rs
+++ b/uefi/src/proto/ata/mod.rs
@@ -179,7 +179,8 @@ impl<'a> AtaRequestBuilder<'a> {
     }
 
     /// Configure the `device_head` field.
-    /// DEVICE
+    ///
+    /// This field contains the ATA DEVICE bit.
     #[must_use]
     pub const fn with_device_head(mut self, device_head: u8) -> Self {
         self.req.acb.device_head = device_head;

--- a/uefi/src/proto/ata/mod.rs
+++ b/uefi/src/proto/ata/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! ATA Protocols.
+//! ATA protocols.
 
 use crate::mem::{AlignedBuffer, AlignmentError};
 use crate::util::usize_from_u32;
@@ -14,14 +14,13 @@ use uefi_raw::protocol::ata::{
 
 pub mod pass_thru;
 
-/// Represents the protocol for ATA Pass Thru command handling.
+/// ATA command protocol used by the pass-through interface.
 ///
-/// This type defines the protocols supported for passing ATA commands through to an
-/// ATA compliant controller. Over time, multiple possible transports for ATA commands
-/// have evolved. The UEFI spec generically abstracts all of these transports below
-/// this one protocol, so old PATA drives and controllers, as well as modern AHCI-only
-/// SATA controllers are supported with the same set of APIs.
-/// see: <https://uefi.org/specs/PI/1.8/V5_IDE_Controller.html>
+/// UEFI abstracts the transports for ATA commands behind this protocol, so
+/// the same API supports PATA and modern AHCI-only SATA controllers. See the
+/// [Platform Initialization specification].
+///
+/// [Platform Initialization specification]: https://uefi.org/specs/PI/1.8/V5_IDE_Controller.html
 pub use uefi_raw::protocol::ata::AtaPassThruCommandProtocol;
 
 /// Represents an ATA request built for execution on an ATA controller.
@@ -38,26 +37,24 @@ pub struct AtaRequest<'a> {
 
 /// Builder for creating and configuring an [`AtaRequest`].
 ///
-/// This builder simplifies the creation of an [`AtaRequest`] by providing chainable methods for
-/// configuring fields like timeout, buffers, and ATA command details.
+/// Its chainable methods configure the timeout, buffers, and ATA command
+/// fields.
 #[derive(Debug)]
 pub struct AtaRequestBuilder<'a> {
     req: AtaRequest<'a>,
 }
 
 impl<'a> AtaRequestBuilder<'a> {
-    /// Creates a new [`AtaRequestBuilder`] with the specified alignment, command, and protocol.
+    /// Creates a new [`AtaRequestBuilder`].
     ///
     /// # Arguments
-    /// - `io_align`: The I/O buffer alignment required for the ATA controller.
-    /// - `command`: The ATA command byte specifying the operation to execute.
-    /// - `protocol`: The protocol type for the command (e.g., DMA, UDMA, etc.).
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or memory allocation failure.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    /// - `command`: ATA command byte to execute.
+    /// - `protocol`: Transport protocol for the command.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    /// Returns an error if the status buffer cannot satisfy `io_align`.
     fn new(
         io_align: u32,
         command: u8,
@@ -95,25 +92,22 @@ impl<'a> AtaRequestBuilder<'a> {
     // # PIO
     // ########################################################################
 
-    /// Creates a builder for a PIO write operation.
+    /// Creates a builder for a PIO read operation.
     ///
     /// Since the ATA specification mandates the support for PIO mode for all
     /// compliant drives and controllers, this is the protocol variant with the
-    /// highest compatibility in the field.
-    /// So probing, (sending ATA IDENTIFY commands to device ports to find out
-    /// whether there is actually a device connected to it) should probably be
-    /// done using this method most of the time.
-    /// If this errors with Status "UNSUPPORTED", try UDMA next.
+    /// highest compatibility. Prefer it when probing ports with ATA IDENTIFY
+    /// commands to detect connected devices.
+    /// If this returns [`uefi_raw::Status::UNSUPPORTED`], try UDMA next.
     ///
     /// # Arguments
-    /// - `io_align`: The I/O buffer alignment required for the ATA controller.
-    /// - `command`: The ATA command byte specifying the write operation.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or memory allocation failure.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    /// - `command`: ATA command byte to execute.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the status buffer cannot satisfy `io_align`.
     pub fn read_pio(io_align: u32, command: u8) -> Result<Self, LayoutError> {
         Self::new(io_align, command, AtaPassThruCommandProtocol::PIO_DATA_IN)
     }
@@ -124,14 +118,13 @@ impl<'a> AtaRequestBuilder<'a> {
     /// Creates a builder for a UDMA read operation.
     ///
     /// # Arguments
-    /// - `io_align`: The I/O buffer alignment required for the ATA controller.
-    /// - `command`: The ATA command byte specifying the read operation.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or memory allocation failure.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    /// - `command`: ATA command byte to execute.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the status buffer cannot satisfy `io_align`.
     pub fn read_udma(io_align: u32, command: u8) -> Result<Self, LayoutError> {
         Self::new(io_align, command, AtaPassThruCommandProtocol::UDMA_DATA_IN)
     }
@@ -139,14 +132,13 @@ impl<'a> AtaRequestBuilder<'a> {
     /// Creates a builder for a UDMA write operation.
     ///
     /// # Arguments
-    /// - `io_align`: The I/O buffer alignment required for the ATA controller.
-    /// - `command`: The ATA command byte specifying the write operation.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or memory allocation failure.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    /// - `command`: ATA command byte to execute.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the status buffer cannot satisfy `io_align`.
     pub fn write_udma(io_align: u32, command: u8) -> Result<Self, LayoutError> {
         Self::new(io_align, command, AtaPassThruCommandProtocol::UDMA_DATA_OUT)
     }
@@ -239,17 +231,16 @@ impl<'a> AtaRequestBuilder<'a> {
     // # READ BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied buffer for reading data from the device.
+    /// Uses `bfr` to receive data from the device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] that will be used to store data read from the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Buffer in which to receive the data.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `in_data_buffer` of the underlying [`AtaRequest`].
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not meet the protocol's alignment
+    /// requirement.
     pub fn use_read_buffer(mut self, bfr: &'a mut AlignedBuffer) -> Result<Self, AlignmentError> {
         // check alignment of externally supplied buffer
         bfr.check_alignment(self.req.io_align as usize)?;
@@ -259,13 +250,15 @@ impl<'a> AtaRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Adds a newly allocated read buffer to the built ATA request.
+    /// Allocates a `len`-byte buffer to receive data from the device.
     ///
     /// # Arguments
-    /// - `len`: The size of the buffer (in bytes) to allocate for receiving data.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `len`: Number of bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requested buffer layout is invalid.
     pub fn with_read_buffer(mut self, len: usize) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(len, self.req.io_align as usize)?;
         self.req.packet.in_data_buffer = bfr.ptr_mut().cast();
@@ -277,17 +270,16 @@ impl<'a> AtaRequestBuilder<'a> {
     // # WRITE BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied buffer for writing data to the device.
+    /// Uses `bfr` to send data to the device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] containing the data to be written to the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Buffer containing the data to send.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `out_data_buffer` of the underlying [`AtaRequest`].
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not meet the protocol's alignment
+    /// requirement.
     pub fn use_write_buffer(mut self, bfr: &'a mut AlignedBuffer) -> Result<Self, AlignmentError> {
         // check alignment of externally supplied buffer
         bfr.check_alignment(self.req.io_align as usize)?;
@@ -297,14 +289,16 @@ impl<'a> AtaRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Adds a newly allocated write buffer to the built ATA request that is filled from the
-    /// given data buffer. (Done for memory alignment and lifetime purposes)
+    /// Allocates a write buffer, copies `data` into it, and uses it for the
+    /// request.
     ///
     /// # Arguments
-    /// - `data`: A slice of bytes representing the data to be written.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `data`: Data to copy into the request buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requested buffer layout is invalid.
     pub fn with_write_data(mut self, data: &[u8]) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(data.len(), self.req.io_align as usize)?;
         bfr.copy_from_slice(data);
@@ -314,10 +308,7 @@ impl<'a> AtaRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Build the final [`AtaRequest`].
-    ///
-    /// # Returns
-    /// A fully-configured [`AtaRequest`] ready for execution.
+    /// Builds the configured [`AtaRequest`].
     #[must_use]
     pub fn build(self) -> AtaRequest<'a> {
         self.req
@@ -334,10 +325,7 @@ pub struct AtaResponse<'a> {
 }
 
 impl<'a> AtaResponse<'a> {
-    /// Retrieves the status block from the response.
-    ///
-    /// # Returns
-    /// A reference to the [`AtaStatusBlock`] containing details about the status of the executed operation.
+    /// Returns the status block from the response.
     #[must_use]
     pub const fn status(&self) -> &'a AtaStatusBlock {
         // SAFETY: The memory is valid.
@@ -351,10 +339,7 @@ impl<'a> AtaResponse<'a> {
         }
     }
 
-    /// Retrieves the buffer containing data read from the device (if available).
-    ///
-    /// # Returns
-    /// `Option<&[u8]>`: A slice of the data read from the device, or `None` if no read buffer was used.
+    /// Returns the data read from the device, if a read buffer was used.
     #[must_use]
     pub const fn read_buffer(&self) -> Option<&'a [u8]> {
         if self.req.packet.in_data_buffer.is_null() {

--- a/uefi/src/proto/ata/pass_thru.rs
+++ b/uefi/src/proto/ata/pass_thru.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! ATA Pass Thru Protocol.
+//! ATA Pass Thru protocol.
 
 use super::{AtaRequest, AtaResponse};
 use crate::StatusExt;
@@ -21,9 +21,9 @@ pub type AtaPassThruMode = uefi_raw::protocol::ata::AtaPassThruMode;
 ///
 /// One protocol instance represents one ATA controller connected to the machine.
 ///
-/// This API offers a safe and convenient, yet still low-level interface to ATA devices.
-/// It is designed as a foundational layer, leaving higher-level abstractions responsible for implementing
-/// richer storage semantics, device-specific commands, and advanced use cases.
+/// This API offers a safe, convenient, but still low-level interface to ATA
+/// devices. Higher-level abstractions remain responsible for storage
+/// semantics and device-specific commands.
 ///
 /// # UEFI Specification
 /// Provides services that allow ATA commands to be sent to ATA Devices attached to an ATA controller. Packet-
@@ -37,10 +37,7 @@ pub type AtaPassThruMode = uefi_raw::protocol::ata::AtaPassThruMode;
 pub struct AtaPassThru(UnsafeCell<AtaPassThruProtocol>);
 
 impl AtaPassThru {
-    /// Retrieves the mode structure for the Extended SCSI Pass Thru protocol.
-    ///
-    /// # Returns
-    /// The [`AtaPassThruMode`] structure containing configuration details of the protocol.
+    /// Returns the ATA Pass Thru mode.
     #[must_use]
     pub fn mode(&self) -> AtaPassThruMode {
         // SAFETY: The memory is valid.
@@ -49,42 +46,36 @@ impl AtaPassThru {
         mode
     }
 
-    /// Retrieves the I/O buffer alignment required by this SCSI channel.
-    ///
-    /// # Returns
-    /// - A `u32` value representing the required I/O alignment in bytes.
+    /// Returns the required I/O buffer alignment in bytes.
     #[must_use]
     pub fn io_align(&self) -> u32 {
         self.mode().io_align
     }
 
-    /// Allocates an I/O buffer with the necessary alignment for this ATA Controller.
+    /// Allocates an I/O buffer with the alignment required by this controller.
     ///
-    /// You can alternatively do this yourself using the [`AlignedBuffer`] helper directly.
-    /// The `ata` api will validate that your buffers have the correct alignment and error
-    /// if they don't.
+    /// Callers can instead allocate an [`AlignedBuffer`] directly. ATA request
+    /// builders validate user-provided buffer alignment.
     ///
     /// # Arguments
-    /// - `len`: The size (in bytes) of the buffer to allocate.
     ///
-    /// # Returns
-    /// [`AlignedBuffer`] containing the allocated memory.
+    /// - `len`: Number of bytes to allocate.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn alloc_io_buffer(&self, len: usize) -> Result<AlignedBuffer, LayoutError> {
         AlignedBuffer::from_size_align(len, self.io_align() as usize)
     }
 
-    /// Iterate over all potential ATA devices on this channel.
+    /// Returns an iterator over all potential ATA devices on this channel.
     ///
     /// # Warnings
-    /// Depending on the UEFI implementation, this does not only return all actually available devices.
-    /// Most implementations instead return a list of all possible fully-qualified device addresses.
-    /// You have to probe for availability yourself, using [`AtaDevice::execute_command`].
     ///
-    /// # Returns
-    /// [`AtaDeviceIterator`] to iterate through connected ATA devices.
+    /// Firmware may return every possible fully qualified device address, not
+    /// only addresses with a connected device. Probe each address with
+    /// [`AtaDevice::execute_command`].
     #[must_use]
     pub const fn iter_devices(&self) -> AtaDeviceIterator<'_> {
         AtaDeviceIterator {
@@ -99,8 +90,9 @@ impl AtaPassThru {
 /// Represents an ATA device on a controller.
 ///
 /// # Warnings
-/// This is only a potentially valid device address. Verify it by probing for an actually
-/// available / connected device using [`AtaDevice::execute_command`] before doing anything meaningful.
+///
+/// This is only a potentially valid device address. Probe it with
+/// [`AtaDevice::execute_command`] before use.
 #[derive(Debug)]
 pub struct AtaDevice<'a> {
     proto: &'a UnsafeCell<AtaPassThruProtocol>,
@@ -111,9 +103,8 @@ pub struct AtaDevice<'a> {
 impl AtaDevice<'_> {
     /// Returns the port number of the device.
     ///
-    /// # Details
-    /// - For SATA: This is the port number on the motherboard or controller.
-    /// - For IDE: This is `0` for the primary bus and `1` for the secondary bus.
+    /// For SATA, this is the port on the motherboard or controller. For IDE,
+    /// `0` is the primary bus and `1` is the secondary bus.
     #[must_use]
     pub const fn port(&self) -> u16 {
         self.port
@@ -121,10 +112,9 @@ impl AtaDevice<'_> {
 
     /// Returns the port multiplier port (PMP) number for the device.
     ///
-    /// # Details
-    /// - For SATA: `0xFFFF` indicates a direct connection to the port, while other values
-    ///   indicate the port number on a port-multiplier device.
-    /// - For IDE: `0` represents the master device, and `1` represents the slave device.
+    /// For SATA, `0xFFFF` indicates a direct connection; other values identify
+    /// a port on a port-multiplier device. For IDE, `0` is the master and `1`
+    /// is the slave device.
     #[must_use]
     pub const fn port_multiplier_port(&self) -> u16 {
         self.pmp
@@ -132,13 +122,13 @@ impl AtaDevice<'_> {
 
     /// Resets the ATA device.
     ///
-    /// This method attempts to reset the specified ATA device, restoring it to its default state.
+    /// This restores the device to its default state.
     ///
     /// # Errors
-    /// - [`Status::UNSUPPORTED`] The ATA controller does not support a device reset operation.
-    /// - [`Status::INVALID_PARAMETER`] The `Port` or `PortMultiplierPort` values are invalid.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to reset the specified ATA device.
-    /// - [`Status::TIMEOUT`] A timeout occurred while attempting to reset the specified ATA device.
+    /// - [`Status::UNSUPPORTED`]: the controller does not support device reset.
+    /// - [`Status::INVALID_PARAMETER`]: the port or PMP value is invalid.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::TIMEOUT`]: the reset timed out.
     pub fn reset(&mut self) -> crate::Result<()> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -146,10 +136,14 @@ impl AtaDevice<'_> {
         }
     }
 
-    /// Get the final device path node for this device.
+    /// Returns the final device path node for this device.
     ///
-    /// For a full [`crate::proto::device_path::DevicePath`] pointing to this device, this needs to be appended to
-    /// the controller's device path.
+    /// Append this node to the controller's device path to form a complete
+    /// [`crate::proto::device_path::DevicePath`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot build the node or allocation fails.
     pub fn path_node(&self) -> crate::Result<PoolDevicePathNode> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -169,22 +163,20 @@ impl AtaDevice<'_> {
 
     /// Executes a command on the device.
     ///
-    /// # Arguments
-    /// - `req`: The request structure containing details about the command to execute.
-    ///
-    /// # Returns
-    /// [`AtaResponse`] containing the results of the operation, such as data and status.
+    /// On failure, the error contains an [`AtaResponse`] with any status and
+    /// transfer information produced by the controller.
     ///
     /// # Errors
-    /// - [`Status::BAD_BUFFER_SIZE`] The ATA command was not executed because the buffer size exceeded the allowed transfer size.
-    ///   The number of bytes that could be transferred is returned in `InTransferLength` or `OutTransferLength`.
-    /// - [`Status::NOT_READY`] The ATA command could not be sent because too many commands are already queued. Retry the operation later.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to send the ATA command. Refer to `Asb` for additional status details.
-    /// - [`Status::INVALID_PARAMETER`] The `Port`, `PortMultiplierPort`, or the contents of `Acb` are invalid.
-    ///   The command was not sent, and no additional status information is available.
-    /// - [`Status::UNSUPPORTED`] The host adapter does not support the command described by the ATA command.
-    ///   The command was not sent, and no additional status information is available.
-    /// - [`Status::TIMEOUT`] A timeout occurred while waiting for the ATA command to execute. Refer to `Asb` for additional status details.
+    ///
+    /// - [`Status::BAD_BUFFER_SIZE`]: the buffer exceeds the allowed transfer
+    ///   size.
+    /// - [`Status::NOT_READY`]: too many commands are queued; retry later.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::INVALID_PARAMETER`]: the port, PMP, or command block is
+    ///   invalid.
+    /// - [`Status::UNSUPPORTED`]: the host adapter does not support the
+    ///   command.
+    /// - [`Status::TIMEOUT`]: the command timed out.
     #[expect(clippy::result_large_err)]
     pub fn execute_command<'req>(
         &mut self,

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -473,7 +473,7 @@ pub struct BltPixel {
 }
 
 impl BltPixel {
-    /// Create a new pixel from RGB values.
+    /// Creates a pixel from RGB values.
     #[must_use]
     pub const fn new(red: u8, green: u8, blue: u8) -> Self {
         Self {
@@ -605,7 +605,7 @@ impl FrameBuffer<'_> {
         unsafe { self.base.add(index).write_volatile(value) }
     }
 
-    /// Read the i-th byte of the frame buffer
+    /// Reads one byte at `index` from the frame buffer.
     ///
     /// # Safety
     ///
@@ -620,7 +620,7 @@ impl FrameBuffer<'_> {
         unsafe { self.base.add(index).read_volatile() }
     }
 
-    /// Write a value in the frame buffer, starting at the i-th byte
+    /// Writes a value to the frame buffer at `index`.
     ///
     /// We only recommend using this method with [u8; N] arrays. Once Rust has
     /// const generics, it will be deprecated and replaced with a write_bytes()

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -262,7 +262,7 @@ impl GraphicsOutput {
         }
     }
 
-    /// Memory-safety check for accessing a region of the framebuffer
+    /// Checks that a frame-buffer region is in bounds.
     fn check_framebuffer_region(&self, coords: (usize, usize), dims: (usize, usize)) {
         let (width, height) = self.current_mode_info().resolution();
         assert!(
@@ -275,7 +275,7 @@ impl GraphicsOutput {
         );
     }
 
-    /// Memory-safety check for accessing a region of a user-provided buffer
+    /// Checks that a BLT buffer region is in bounds.
     fn check_blt_buffer_region(&self, region: BltRegion, dims: (usize, usize), buf_length: usize) {
         match region {
             BltRegion::Full => assert!(
@@ -305,7 +305,7 @@ impl GraphicsOutput {
         unsafe { *self.mode().info.cast_const().cast::<ModeInfo>() }
     }
 
-    /// Access the frame buffer directly
+    /// Returns direct access to the frame buffer.
     pub fn frame_buffer(&mut self) -> FrameBuffer<'_> {
         assert!(
             self.current_mode_info().pixel_format() != PixelFormat::BltOnly,
@@ -502,15 +502,15 @@ impl From<u32> for BltPixel {
 /// sub-rectangle of it, but require the stride to be known in the latter case.
 #[derive(Clone, Copy, Debug)]
 pub enum BltRegion {
-    /// Operate on the full `BltBuffer`
+    /// Operates on the full `BltBuffer`.
     Full,
 
-    /// Operate on a sub-rectangle of the `BltBuffer`
+    /// Operates on a sub-rectangle of the `BltBuffer`.
     SubRectangle {
-        /// Coordinate of the rectangle in the `BltBuffer`
+        /// Coordinates of the rectangle in the `BltBuffer`.
         coords: (usize, usize),
 
-        /// Stride (length of each row of the `BltBuffer`) in **pixels**
+        /// Row stride of the `BltBuffer` in pixels.
         px_stride: usize,
     },
 }
@@ -533,7 +533,7 @@ pub enum BltOp<'buf> {
         buffer: &'buf mut [BltPixel],
         /// Coordinates of the source rectangle, in the frame buffer.
         src: (usize, usize),
-        /// Location of the destination rectangle in the user-provided buffer
+        /// Destination rectangle in the caller-provided buffer.
         dest: BltRegion,
         /// Width / height of the rectangles.
         dims: (usize, usize),
@@ -562,7 +562,7 @@ pub enum BltOp<'buf> {
     },
 }
 
-/// Direct access to a memory-mapped frame buffer
+/// Direct access to a memory-mapped frame buffer.
 #[derive(Debug)]
 pub struct FrameBuffer<'gop> {
     base: *mut u8,
@@ -571,7 +571,7 @@ pub struct FrameBuffer<'gop> {
 }
 
 impl FrameBuffer<'_> {
-    /// Access the raw framebuffer pointer
+    /// Returns the raw frame-buffer pointer.
     ///
     /// To use this pointer safely and correctly, you must...
     /// - Honor the pixel format and stride specified by the mode info
@@ -585,7 +585,7 @@ impl FrameBuffer<'_> {
         self.base
     }
 
-    /// Query the framebuffer size in bytes
+    /// Returns the frame-buffer size in bytes.
     #[must_use]
     pub const fn size(&self) -> usize {
         self.size

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -20,11 +20,13 @@ impl Pointer {
     /// Resets the pointer device hardware.
     ///
     /// # Arguments
-    /// The `extended_verification` parameter is used to request that UEFI
-    /// performs an extended check and reset of the input device.
+    ///
+    /// - `extended_verification`: Requests an extended check and reset of the
+    ///   input device.
     ///
     /// # Errors
-    /// - `DeviceError` if the device is malfunctioning and cannot be reset.
+    /// - [`Status::DEVICE_ERROR`]: the device is malfunctioning and cannot be
+    ///   reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
@@ -37,7 +39,7 @@ impl Pointer {
     /// interface in order to wait for input from the pointer device.
     ///
     /// # Errors
-    /// - `DeviceError` if there was an issue with the pointer device.
+    /// - [`Status::DEVICE_ERROR`]: the pointer device reported an error.
     ///
     /// [`boot::wait_for_event`]: crate::boot::wait_for_event
     pub fn read_state(&mut self) -> Result<Option<PointerState>> {

--- a/uefi/src/proto/console/serial.rs
+++ b/uefi/src/proto/console/serial.rs
@@ -199,21 +199,17 @@ impl Serial {
         unsafe { (self.0.set_control_bits)(&mut self.0, bits) }.to_result()
     }
 
-    /// Reads data from the device. This function has the raw semantics of the
-    /// underlying UEFI protocol.
+    /// Reads data from the device with the raw UEFI protocol semantics.
     ///
     /// The function will read bytes until either the buffer is full or a
     /// timeout or overrun error occurs.
     ///
+    /// Consider setting non-default properties via [`Self::set_attributes`]
+    /// and [`Self::set_control_bits`] for the device.
+    ///
     /// # Arguments
     ///
-    /// - `buffer`: buffer to fill
-    ///
-    /// # Tips
-    ///
-    /// Consider setting non-default properties via [`Self::set_attributes`]
-    /// and [`Self::set_control_bits`] matching your use-case. For more info,
-    /// please read the general [documentation](Self) of the protocol.
+    /// - `buffer`: Buffer to fill.
     ///
     /// # Errors
     ///
@@ -232,28 +228,23 @@ impl Serial {
         )
     }
 
-    /// Reads bytes into the provided buffer, blocking until it is full.
+    /// Reads bytes into `buffer`, blocking until it is full.
     ///
     /// Retries automatically on [`Status::TIMEOUT`], stalling briefly between
     /// attempts based on the current baud rate. A maximum retry limit prevents
     /// spinning forever in the unlikely event of a hardware fault.
     ///
+    /// Consider setting non-default properties via [`Self::set_attributes`]
+    /// and [`Self::set_control_bits`] for the device.
+    ///
     /// # Arguments
     ///
-    /// - `buffer`: buffer to fill
-    ///
-    /// # Tips
-    ///
-    /// Consider setting non-default properties via [`Self::set_attributes`]
-    /// and [`Self::set_control_bits`] matching your use-case. For more info,
-    /// please read the general [documentation](Self) of the protocol.
+    /// - `buffer`: Buffer to fill.
     ///
     /// # Errors
     ///
-    /// - [`Status::DEVICE_ERROR`]: serial device reported an error
-    /// - [`Status::TIMEOUT`]: This timeout happens if the underlying device
-    ///   seem to stopped its normal operation and is only reported to prevent
-    ///   an endless loop.
+    /// - [`Status::DEVICE_ERROR`]: the serial device reported an error.
+    /// - [`Status::TIMEOUT`]: the device stopped making progress.
     pub fn read_exact(&mut self, buffer: &mut [u8]) -> Result<()> {
         // Chosen at will, tested on real hardware.
         const MAX_ZERO_PROGRESS: usize = 16;
@@ -293,21 +284,17 @@ impl Serial {
         Ok(())
     }
 
-    /// Writes data to this device. This function has the raw semantics of the
-    /// underlying UEFI protocol.
+    /// Writes data with the raw UEFI protocol semantics.
     ///
     /// The function will try to write all provided bytes in the configured
     /// timeout.
     ///
+    /// Consider setting non-default properties via [`Self::set_attributes`]
+    /// and [`Self::set_control_bits`] for the device.
+    ///
     /// # Arguments
     ///
-    /// - `data`: bytes to write
-    ///
-    /// # Tips
-    ///
-    /// Consider setting non-default properties via [`Self::set_attributes`]
-    /// and [`Self::set_control_bits`] matching your use-case. For more info,
-    /// please read the general [documentation](Self) of the protocol.
+    /// - `data`: Bytes to write.
     ///
     /// # Errors
     ///
@@ -326,28 +313,23 @@ impl Serial {
         )
     }
 
-    /// Writes all provided bytes, blocking until every byte has been sent.
+    /// Writes all bytes in `data`, blocking until every byte has been sent.
     ///
     /// Retries automatically on [`Status::TIMEOUT`], stalling briefly between
     /// attempts based on the current baud rate. A maximum retry limit prevents
     /// spinning forever in the unlikely event of a hardware fault.
     ///
+    /// Consider setting non-default properties via [`Self::set_attributes`]
+    /// and [`Self::set_control_bits`] for the device.
+    ///
     /// # Arguments
     ///
-    /// - `data`: bytes to write
-    ///
-    /// # Tips
-    ///
-    /// Consider setting non-default properties via [`Self::set_attributes`]
-    /// and [`Self::set_control_bits`] matching your use-case. For more info,
-    /// please read the general [documentation](Self) of the protocol.
+    /// - `data`: Bytes to write.
     ///
     /// # Errors
     ///
-    /// - [`Status::DEVICE_ERROR`]: serial device reported an error
-    /// - [`Status::TIMEOUT`]: This timeout happens if the underlying device
-    ///   seem to stopped its normal operation and is only reported to prevent
-    ///   an endless loop.
+    /// - [`Status::DEVICE_ERROR`]: the serial device reported an error.
+    /// - [`Status::TIMEOUT`]: the device stopped making progress.
     pub fn write_exact(&mut self, data: &[u8]) -> Result<()> {
         // Chosen at will, tested on real hardware.
         const MAX_ZERO_PROGRESS: usize = 16;

--- a/uefi/src/proto/console/text/input.rs
+++ b/uefi/src/proto/console/text/input.rs
@@ -42,7 +42,7 @@ impl Input {
     ///
     /// - [`Status::DEVICE_ERROR`] if there was an issue with the input device
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use log::info;

--- a/uefi/src/proto/debug/context.rs
+++ b/uefi/src/proto/debug/context.rs
@@ -3,8 +3,7 @@
 // note from the spec:
 // When the context record field is larger than the register being stored in it, the upper bits of the
 // context record field are unused and ignored
-/// Universal EFI_SYSTEM_CONTEXT definition
-/// This is passed to debug callbacks
+/// Architecture-dependent processor context passed to debug callbacks.
 #[repr(C)]
 #[expect(missing_debug_implementations)]
 pub union SystemContext {
@@ -19,7 +18,7 @@ pub union SystemContext {
     aarch64: *mut SystemContextAARCH64,
 }
 
-/// System context for virtual EBC processors
+/// Processor context for the UEFI bytecode interpreter.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SystemContextEBC {
@@ -288,7 +287,7 @@ pub struct SystemContextIA32 {
     eax: u32,
 }
 
-/// FP / MMX / XMM registers for IA-32
+/// Floating-point, MMX, and XMM registers for IA-32.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct FxSaveStateIA32 {
@@ -329,7 +328,7 @@ pub struct FxSaveStateIA32 {
     reserved_11: [u8; 14 * 16],
 }
 
-/// System context for x64 processors
+/// Processor context for x86-64.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SystemContextX64 {
@@ -377,7 +376,7 @@ pub struct SystemContextX64 {
     r15: u64,
 }
 
-/// FP / MMX / XMM registers for X64
+/// Floating-point, MMX, and XMM registers for x86-64.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct FxSaveStateX64 {
@@ -543,7 +542,7 @@ pub struct SystemContextIPF {
     int_nat: u64, // nat bits for r1-r31
 }
 
-/// System context for ARM processors
+/// Processor context for 32-bit ARM.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SystemContextARM {
@@ -569,7 +568,7 @@ pub struct SystemContextARM {
     ifsr: u32,
 }
 
-/// System context for AARCH64 processors
+/// Processor context for AArch64.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SystemContextAARCH64 {

--- a/uefi/src/proto/debug/exception.rs
+++ b/uefi/src/proto/debug/exception.rs
@@ -6,183 +6,183 @@
 pub struct ExceptionType(isize);
 
 impl ExceptionType {
-    /// Undefined Exception
+    /// Indicates an undefined EBC exception.
     pub const EXCEPT_EBC_UNDEFINED: Self = Self(0);
-    /// Divide-by-zero Error
+    /// Indicates an EBC divide-by-zero error.
     pub const EXCEPT_EBC_DIVIDE_ERROR: Self = Self(1);
-    /// Debug Exception
+    /// Indicates an EBC debug exception.
     pub const EXCEPT_EBC_DEBUG: Self = Self(2);
-    /// Breakpoint
+    /// Indicates an EBC breakpoint.
     pub const EXCEPT_EBC_BREAKPOINT: Self = Self(3);
-    /// Overflow
+    /// Indicates an EBC overflow.
     pub const EXCEPT_EBC_OVERFLOW: Self = Self(4);
-    /// Invalid Opcode
+    /// Indicates an invalid EBC opcode.
     pub const EXCEPT_EBC_INVALID_OPCODE: Self = Self(5);
-    /// Stack-Segment Fault
+    /// Indicates an EBC stack fault.
     pub const EXCEPT_EBC_STACK_FAULT: Self = Self(6);
-    /// Alignment Check
+    /// Indicates an EBC alignment check.
     pub const EXCEPT_EBC_ALIGNMENT_CHECK: Self = Self(7);
-    /// Instruction Encoding Exception
+    /// Indicates an EBC instruction-encoding exception.
     pub const EXCEPT_EBC_INSTRUCTION_ENCODING: Self = Self(8);
-    /// Bad Breakpoint Exception
+    /// Indicates an invalid EBC breakpoint.
     pub const EXCEPT_EBC_BAD_BREAK: Self = Self(9);
-    /// Single Step Exception
+    /// Indicates an EBC single-step exception.
     pub const EXCEPT_EBC_SINGLE_STEP: Self = Self(10);
 }
 
 #[cfg(target_arch = "x86")]
 impl ExceptionType {
-    /// Divide-by-zero Error
+    /// Indicates a divide-by-zero error.
     pub const EXCEPT_IA32_DIVIDE_ERROR: Self = Self(0);
-    /// Debug Exception
+    /// Indicates a debug exception.
     pub const EXCEPT_IA32_DEBUG: Self = Self(1);
-    /// Non-maskable Interrupt
+    /// Indicates a non-maskable interrupt.
     pub const EXCEPT_IA32_NMI: Self = Self(2);
-    /// Breakpoint
+    /// Indicates a breakpoint.
     pub const EXCEPT_IA32_BREAKPOINT: Self = Self(3);
-    /// Overflow
+    /// Indicates an overflow.
     pub const EXCEPT_IA32_OVERFLOW: Self = Self(4);
-    /// Bound Range Exceeded
+    /// Indicates that a bound range was exceeded.
     pub const EXCEPT_IA32_BOUND: Self = Self(5);
-    /// Invalid Opcode
+    /// Indicates an invalid opcode.
     pub const EXCEPT_IA32_INVALID_OPCODE: Self = Self(6);
-    /// Double Fault
+    /// Indicates a double fault.
     pub const EXCEPT_IA32_DOUBLE_FAULT: Self = Self(8);
-    /// Invalid TSS
+    /// Indicates an invalid task-state segment.
     pub const EXCEPT_IA32_INVALID_TSS: Self = Self(10);
-    /// Segment Not Present
+    /// Indicates a missing segment.
     pub const EXCEPT_IA32_SEG_NOT_PRESENT: Self = Self(11);
-    /// Stack-Segment Fault
+    /// Indicates a stack-segment fault.
     pub const EXCEPT_IA32_STACK_FAULT: Self = Self(12);
-    /// General Protection Fault
+    /// Indicates a general-protection fault.
     pub const EXCEPT_IA32_GP_FAULT: Self = Self(13);
-    /// Page Fault
+    /// Indicates a page fault.
     pub const EXCEPT_IA32_PAGE_FAULT: Self = Self(14);
-    /// x87 Floating-Point Exception
+    /// Indicates an x87 floating-point exception.
     pub const EXCEPT_IA32_FP_ERROR: Self = Self(16);
-    /// Alignment Check
+    /// Indicates an alignment check.
     pub const EXCEPT_IA32_ALIGNMENT_CHECK: Self = Self(17);
-    /// Machine Check
+    /// Indicates a machine check.
     pub const EXCEPT_IA32_MACHINE_CHECK: Self = Self(18);
-    /// SIMD Floating-Point Exception
+    /// Indicates a SIMD floating-point exception.
     pub const EXCEPT_IA32_SIMD: Self = Self(19);
 }
 
 #[cfg(target_arch = "x86_64")]
 impl ExceptionType {
-    /// Divide-by-zero Error
+    /// Indicates a divide-by-zero error.
     pub const EXCEPT_X64_DIVIDE_ERROR: Self = Self(0);
-    /// Debug Exception
+    /// Indicates a debug exception.
     pub const EXCEPT_X64_DEBUG: Self = Self(1);
-    /// Non-maskable Interrupt
+    /// Indicates a non-maskable interrupt.
     pub const EXCEPT_X64_NMI: Self = Self(2);
-    /// Breakpoint
+    /// Indicates a breakpoint.
     pub const EXCEPT_X64_BREAKPOINT: Self = Self(3);
-    /// Overflow
+    /// Indicates an overflow.
     pub const EXCEPT_X64_OVERFLOW: Self = Self(4);
-    /// Bound Range Exceeded
+    /// Indicates that a bound range was exceeded.
     pub const EXCEPT_X64_BOUND: Self = Self(5);
-    /// Invalid Opcode
+    /// Indicates an invalid opcode.
     pub const EXCEPT_X64_INVALID_OPCODE: Self = Self(6);
-    /// Double Fault
+    /// Indicates a double fault.
     pub const EXCEPT_X64_DOUBLE_FAULT: Self = Self(8);
-    /// Invalid TSS
+    /// Indicates an invalid task-state segment.
     pub const EXCEPT_X64_INVALID_TSS: Self = Self(10);
-    /// Segment Not Present
+    /// Indicates a missing segment.
     pub const EXCEPT_X64_SEG_NOT_PRESENT: Self = Self(11);
-    /// Stack-Segment Fault
+    /// Indicates a stack-segment fault.
     pub const EXCEPT_X64_STACK_FAULT: Self = Self(12);
-    /// General Protection Fault
+    /// Indicates a general-protection fault.
     pub const EXCEPT_X64_GP_FAULT: Self = Self(13);
-    /// Page Fault
+    /// Indicates a page fault.
     pub const EXCEPT_X64_PAGE_FAULT: Self = Self(14);
-    /// x87 Floating-Point Exception
+    /// Indicates an x87 floating-point exception.
     pub const EXCEPT_X64_FP_ERROR: Self = Self(16);
-    /// Alignment Check
+    /// Indicates an alignment check.
     pub const EXCEPT_X64_ALIGNMENT_CHECK: Self = Self(17);
-    /// Machine Check
+    /// Indicates a machine check.
     pub const EXCEPT_X64_MACHINE_CHECK: Self = Self(18);
-    /// SIMD Floating-Point Exception
+    /// Indicates a SIMD floating-point exception.
     pub const EXCEPT_X64_SIMD: Self = Self(19);
 }
 
 #[cfg(target_arch = "arm")]
 impl ExceptionType {
-    /// Processor reset
+    /// Indicates a processor reset.
     pub const EXCEPT_ARM_RESET: Self = Self(0);
-    /// Undefined instruction
+    /// Indicates an undefined instruction.
     pub const EXCEPT_ARM_UNDEFINED_INSTRUCTION: Self = Self(1);
-    /// Software Interrupt
+    /// Indicates a software interrupt.
     pub const EXCEPT_ARM_SOFTWARE_INTERRUPT: Self = Self(2);
-    /// Prefetch aborted
+    /// Indicates an aborted prefetch.
     pub const EXCEPT_ARM_PREFETCH_ABORT: Self = Self(3);
-    /// Data access memory abort
+    /// Indicates a data-access memory abort.
     pub const EXCEPT_ARM_DATA_ABORT: Self = Self(4);
-    /// Reserved
+    /// Represents the reserved exception value.
     pub const EXCEPT_ARM_RESERVED: Self = Self(5);
-    /// Normal interrupt
+    /// Indicates a normal interrupt.
     pub const EXCEPT_ARM_IRQ: Self = Self(6);
-    /// Fast interrupt
+    /// Indicates a fast interrupt.
     pub const EXCEPT_ARM_FIQ: Self = Self(7);
-    /// In the UEFI spec for "convenience", unsure if we'll need it. Set to `EXCEPT_ARM_FIQ`
+    /// Provides the maximum ARM exception value defined by UEFI.
     pub const MAX_ARM_EXCEPTION: Self = Self::EXCEPT_ARM_FIQ;
 }
 
 #[cfg(target_arch = "aarch64")]
 impl ExceptionType {
-    /// Synchronous exception, such as attempting to execute an invalid instruction
+    /// Indicates a synchronous exception, such as an invalid instruction.
     pub const EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS: Self = Self(0);
-    /// Normal interrupt
+    /// Indicates a normal interrupt.
     pub const EXCEPT_AARCH64_IRQ: Self = Self(1);
-    /// Fast interrupt
+    /// Indicates a fast interrupt.
     pub const EXCEPT_AARCH64_FIQ: Self = Self(2);
-    /// System Error
+    /// Indicates a system error.
     pub const EXCEPT_AARCH64_SERROR: Self = Self(3);
-    /// In the UEFI spec for "convenience", unsure if we'll need it. Set to `EXCEPT_AARCH64_SERROR`
+    /// Provides the maximum AArch64 exception value defined by UEFI.
     pub const MAX_AARCH64_EXCEPTION: Self = Self::EXCEPT_AARCH64_SERROR;
 }
 
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 impl ExceptionType {
-    /// Instruction misaligned
+    /// Indicates a misaligned instruction address.
     pub const EXCEPT_RISCV_INST_MISALIGNED: Self = Self(0);
-    /// Instruction access fault
+    /// Indicates an instruction-access fault.
     pub const EXCEPT_RISCV_INST_ACCESS_FAULT: Self = Self(1);
-    /// Illegal instruction
+    /// Indicates an illegal instruction.
     pub const EXCEPT_RISCV_ILLEGAL_INST: Self = Self(2);
-    /// Breakpoint
+    /// Indicates a breakpoint.
     pub const EXCEPT_RISCV_BREAKPOINT: Self = Self(3);
-    /// Load address misaligned
+    /// Indicates a misaligned load address.
     pub const EXCEPT_RISCV_LOAD_ADDRESS_MISALIGNED: Self = Self(4);
-    /// Load accept fault
+    /// Indicates a load-access fault.
     pub const EXCEPT_RISCV_LOAD_ACCESS_FAULT: Self = Self(5);
-    /// Store AMO address misaligned
+    /// Indicates a misaligned store or AMO address.
     pub const EXCEPT_RISCV_STORE_AMO_ADDRESS_MISALIGNED: Self = Self(6);
-    /// Store AMO access fault
+    /// Indicates a store or AMO access fault.
     pub const EXCEPT_RISCV_STORE_AMO_ACCESS_FAULT: Self = Self(7);
-    /// ECALL from User mode
+    /// Indicates an environment call from user mode.
     pub const EXCEPT_RISCV_ENV_CALL_FROM_UMODE: Self = Self(8);
-    /// ECALL from Supervisor mode
+    /// Indicates an environment call from supervisor mode.
     pub const EXCEPT_RISCV_ENV_CALL_FROM_SMODE: Self = Self(9);
-    /// ECALL from Machine mode
+    /// Indicates an environment call from machine mode.
     pub const EXCEPT_RISCV_ENV_CALL_FROM_MMODE: Self = Self(11);
-    /// Instruction page fault
+    /// Indicates an instruction page fault.
     pub const EXCEPT_RISCV_INST_PAGE_FAULT: Self = Self(12);
-    /// Load page fault
+    /// Indicates a load page fault.
     pub const EXCEPT_RISCV_LOAD_PAGE_FAULT: Self = Self(13);
-    /// Store AMO page fault
+    /// Indicates a store or AMO page fault.
     pub const EXCEPT_RISCV_STORE_AMO_PAGE_FAULT: Self = Self(15);
     // RISC-V interrupt types
-    /// Supervisor software interrupt
+    /// Indicates a supervisor software interrupt.
     pub const EXCEPT_RISCV_SUPERVISOR_SOFTWARE_INT: Self = Self(1);
-    /// Machine software interrupt
+    /// Indicates a machine software interrupt.
     pub const EXCEPT_RISCV_MACHINE_SOFTWARE_INT: Self = Self(3);
-    /// Supervisor timer interrupt
+    /// Indicates a supervisor timer interrupt.
     pub const EXCEPT_RISCV_SUPERVISOR_TIMER_INT: Self = Self(5);
-    /// Machine timer interrupt
+    /// Indicates a machine timer interrupt.
     pub const EXCEPT_RISCV_MACHINE_TIMER_INT: Self = Self(7);
-    /// Supervisor external interrupt
+    /// Indicates a supervisor external interrupt.
     pub const EXCEPT_RISCV_SUPERVISOR_EXTERNAL_INT: Self = Self(9);
-    /// Machine external interrupt
+    /// Indicates a machine external interrupt.
     pub const EXCEPT_RISCV_MACHINE_EXTERNAL_INT: Self = Self(11);
 }

--- a/uefi/src/proto/debug/mod.rs
+++ b/uefi/src/proto/debug/mod.rs
@@ -68,10 +68,10 @@ impl DebugSupport {
         self.isa
     }
 
-    /// Returns the maximum value that may be used for the processor_index parameter in
-    /// `register_periodic_callback()` and `register_exception_callback()`.
+    /// Returns the maximum processor index accepted by callback registration.
     ///
-    /// Note: Applications built with EDK2 (such as OVMF) always return `0` as of 2021-09-15
+    /// Applications built with EDK II, including OVMF, returned `0` as of
+    /// 2021-09-15.
     pub fn get_maximum_processor_index(&mut self) -> usize {
         // initially set to a canary value for testing purposes
         let mut max_processor_index: usize = usize::MAX;
@@ -87,9 +87,20 @@ impl DebugSupport {
     /// a specified `processor_index`. Will return `Status::INVALID_PARAMETER` if
     /// `processor_index` exceeds the current maximum from `Self::get_maximum_processor_index`.
     ///
-    /// Note: Applications built with EDK2 (such as OVMF) ignore the `processor_index` parameter
+    /// Applications built with EDK II, including OVMF, ignore `processor_index`.
+    ///
+    /// # Arguments
+    ///
+    /// - `processor_index`: Processor on which the callback runs.
+    /// - `callback`: Function to register, or `None` to remove the current one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Status::INVALID_PARAMETER`] if `processor_index` is too large
+    /// or firmware rejects the callback.
     ///
     /// # Safety
+    ///
     /// No portion of the debug agent that runs in interrupt context may make any
     /// calls to EFI services or other protocol interfaces.
     pub unsafe fn register_periodic_callback(
@@ -111,9 +122,21 @@ impl DebugSupport {
     /// given `exception_type` and `processor_index`. Will return `Status::INVALID_PARAMETER`
     /// if `processor_index` exceeds the current maximum from `Self::get_maximum_processor_index`.
     ///
-    /// Note: Applications built with EDK2 (such as OVMF) ignore the `processor_index` parameter
+    /// Applications built with EDK II, including OVMF, ignore `processor_index`.
+    ///
+    /// # Arguments
+    ///
+    /// - `processor_index`: Processor whose exception is monitored.
+    /// - `callback`: Function to register, or `None` to remove the current one.
+    /// - `exception_type`: Exception that triggers the callback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Status::INVALID_PARAMETER`] if `processor_index` is too large
+    /// or firmware rejects the callback.
     ///
     /// # Safety
+    ///
     /// No portion of the debug agent that runs in interrupt context may make any
     /// calls to EFI services or other protocol interfaces.
     pub unsafe fn register_exception_callback(
@@ -134,12 +157,24 @@ impl DebugSupport {
         .to_result()
     }
 
-    /// Invalidates processor instruction cache for a memory range for a given `processor_index`.
+    /// Invalidates a processor's instruction cache for a memory range.
     ///
-    /// Note: Applications built with EDK2 (such as OVMF) ignore the `processor_index` parameter
+    /// Applications built with EDK II, including OVMF, ignore `processor_index`.
+    ///
+    /// # Arguments
+    ///
+    /// - `processor_index`: Processor whose cache is invalidated.
+    /// - `start`: Start of the memory range.
+    /// - `length`: Length of the memory range in bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Status::INVALID_PARAMETER`] if `processor_index` or the memory
+    /// range is invalid.
     ///
     /// # Safety
-    /// `start` must be a c_void ptr to a valid memory address
+    ///
+    /// `start` must point to a valid memory range of at least `length` bytes.
     pub unsafe fn invalidate_instruction_cache(
         &mut self,
         processor_index: usize,
@@ -165,23 +200,23 @@ newtype_enum! {
 /// therefore modeling this C enum as a Rust enum (where the compiler must know
 /// about every variant in existence) would _not_ be safe.
 pub enum ProcessorArch: u32 => {
-    /// 32-bit x86 PC
+    /// Represents 32-bit x86.
     X86_32      = 0x014C,
-    /// 64-bit x86 PC
+    /// Represents 64-bit x86.
     X86_64      = 0x8664,
-    /// Intel Itanium
+    /// Represents Intel Itanium.
     ITANIUM     = 0x200,
-    /// UEFI Interpreter bytecode
+    /// Represents UEFI bytecode.
     EBC         = 0x0EBC,
-    /// ARM Thumb / Mixed
+    /// Represents 32-bit ARM or Thumb.
     ARM         = 0x01C2,
-    /// ARM 64-bit
+    /// Represents 64-bit ARM.
     AARCH_64    = 0xAA64,
-    /// RISC-V 32-bit
+    /// Represents 32-bit RISC-V.
     RISCV_32    = 0x5032,
-    /// RISC-V 64-bit
+    /// Represents 64-bit RISC-V.
     RISCV_64    = 0x5064,
-    /// RISC-V 128-bit
+    /// Represents 128-bit RISC-V.
     RISCV_128   = 0x5128,
 }}
 
@@ -213,13 +248,24 @@ pub struct DebugPort {
 
 impl DebugPort {
     /// Resets the debugport device.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot reset the device.
     pub fn reset(&self) -> Result {
         (self.reset)(self).to_result()
     }
 
-    /// Write data to the debugport device.
+    /// Writes data to the debug-port device.
     ///
-    /// Note: `timeout` is given in microseconds
+    /// # Arguments
+    ///
+    /// - `timeout`: Maximum wait in microseconds.
+    /// - `data`: Bytes to write.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error with the reported buffer size if the write fails.
     pub fn write(&self, timeout: u32, data: &[u8]) -> Result<(), usize> {
         let mut buffer_size = data.len();
 
@@ -235,9 +281,16 @@ impl DebugPort {
         )
     }
 
-    /// Read data from the debugport device.
+    /// Reads data from the debug-port device.
     ///
-    /// Note: `timeout` is given in microseconds
+    /// # Arguments
+    ///
+    /// - `timeout`: Maximum wait in microseconds.
+    /// - `data`: Buffer to fill.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error with the reported buffer size if the read fails.
     pub fn read(&self, timeout: u32, data: &mut [u8]) -> Result<(), usize> {
         let mut buffer_size = data.len();
 
@@ -253,7 +306,11 @@ impl DebugPort {
         )
     }
 
-    /// Check to see if any data is available to be read from the debugport device.
+    /// Checks whether the debug-port device has data available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot query the device.
     pub fn poll(&self) -> Result {
         (self.poll)(self).to_result()
     }

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -153,7 +153,7 @@ impl<'a> DevicePathBuilder<'a> {
     }
 }
 
-/// Reference to the backup storage for [`DevicePathBuilder`]
+/// Backing storage borrowed by a [`DevicePathBuilder`].
 #[derive(Debug)]
 enum BuilderStorage<'a> {
     Buf {

--- a/uefi/src/proto/device_path/build.rs
+++ b/uefi/src/proto/device_path/build.rs
@@ -43,7 +43,7 @@ use alloc::vec::Vec;
 /// [`finalize`]: DevicePathBuilder::finalize
 /// [`push`]: DevicePathBuilder::push
 ///
-/// # Examples
+/// # Example
 ///
 /// ```
 /// use core::mem::MaybeUninit;

--- a/uefi/src/proto/device_path/mod.rs
+++ b/uefi/src/proto/device_path/mod.rs
@@ -469,7 +469,6 @@ impl ToOwned for DevicePathInstance {
 ///
 /// See the [module-level documentation] for more details.
 ///
-/// # Usage
 /// This type implements [`Protocol`] and therefore can be used on any
 /// device handle to obtain generic path/location information concerning the
 /// physical device or logical device. If the handle does not logically map to a

--- a/uefi/src/proto/device_path/util.rs
+++ b/uefi/src/proto/device_path/util.rs
@@ -16,27 +16,19 @@ use uefi_raw::protocol::device_path::DevicePathUtilitiesProtocol;
 pub struct DevicePathUtilities(DevicePathUtilitiesProtocol);
 
 impl DevicePathUtilities {
-    /// Retrieves the size of the specified device path in bytes, including the
+    /// Returns the size of `device_path` in bytes, including its
     /// end-of-device-path node.
-    ///
-    /// # Arguments
-    /// - `device_path`: A reference to the [`DevicePath`] whose size is to be determined.
-    ///
-    /// # Returns
-    /// The size of the specified device path in bytes.
     #[must_use]
     pub fn get_size(&self, device_path: &DevicePath) -> usize {
         // SAFETY: The memory is valid.
         unsafe { (self.0.get_device_path_size)(device_path.as_ffi_ptr().cast()) }
     }
 
-    /// Create a new device path by cloning the given `path` into newly allocated memory.
+    /// Clones `path` into a newly allocated [`PoolDevicePath`].
     ///
-    /// # Arguments
-    /// - `path`: A reference to the device path to clone.
+    /// # Errors
     ///
-    /// # Returns
-    /// A [`PoolDevicePath`] instance created by cloning the given `path`.
+    /// Returns [`Status::OUT_OF_RESOURCES`] if allocation fails.
     pub fn duplicate_path(&self, path: &DevicePath) -> crate::Result<PoolDevicePath> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -47,15 +39,11 @@ impl DevicePathUtilities {
         }
     }
 
-    /// Creates a new device path by appending the second device path to the first.
+    /// Appends `path1` to `path0` in a newly allocated [`PoolDevicePath`].
     ///
-    /// # Arguments
-    /// - `path0`: A reference to the base device path.
-    /// - `path1`: A reference to the device path to append.
+    /// # Errors
     ///
-    /// # Returns
-    /// A [`PoolDevicePath`] instance containing the newly created device path,
-    /// or an error if memory could not be allocated.
+    /// Returns [`Status::OUT_OF_RESOURCES`] if allocation fails.
     pub fn append_path(
         &self,
         path0: &DevicePath,
@@ -71,15 +59,11 @@ impl DevicePathUtilities {
         }
     }
 
-    /// Creates a new device path by appending a device node to the base device path.
+    /// Appends `node` to `basepath` in a newly allocated [`PoolDevicePath`].
     ///
-    /// # Arguments
-    /// - `basepath`: A reference to the base device path.
-    /// - `node`: A reference to the device node to append.
+    /// # Errors
     ///
-    /// # Returns
-    /// A [`PoolDevicePath`] instance containing the newly created device path,
-    /// or an error if memory could not be allocated.
+    /// Returns [`Status::OUT_OF_RESOURCES`] if allocation fails.
     pub fn append_node(
         &self,
         basepath: &DevicePath,
@@ -95,15 +79,11 @@ impl DevicePathUtilities {
         }
     }
 
-    /// Creates a new device path by appending the specified device path instance to the base path.
+    /// Appends `instance` to `basepath` in a newly allocated [`PoolDevicePath`].
     ///
-    /// # Arguments
-    /// - `basepath`: A reference to the base device path.
-    /// - `instance`: A reference to the device path instance to append.
+    /// # Errors
     ///
-    /// # Returns
-    /// A [`PoolDevicePath`] instance containing the newly created device path,
-    /// or an error if memory could not be allocated.
+    /// Returns [`Status::OUT_OF_RESOURCES`] if allocation fails.
     pub fn append_instance(
         &self,
         basepath: &DevicePath,

--- a/uefi/src/proto/dma/iommu.rs
+++ b/uefi/src/proto/dma/iommu.rs
@@ -23,7 +23,7 @@ pub use uefi_raw::protocol::iommu::{
 pub struct Iommu(EdkiiIommuProtocol);
 
 impl Iommu {
-    /// Get the IOMMU protocol revision
+    /// Returns the IOMMU protocol revision.
     #[must_use]
     pub const fn revision(&self) -> u64 {
         self.0.revision
@@ -31,12 +31,18 @@ impl Iommu {
 
     /// Set access attributes for a mapping.
     ///
+    /// # Arguments
+    ///
+    /// - `device_handle`: Device that uses the mapping.
+    /// - `mapping`: Active mapping whose permissions are changed.
+    /// - `iommu_access`: New access permissions for the device.
+    ///
     /// # Errors
     ///
-    /// * [`crate::Status::INVALID_PARAMETER`]: invalid device handle, mapping, or access flags
-    /// * [`crate::Status::UNSUPPORTED`]: operation not supported by this IOMMU
-    /// * [`crate::Status::OUT_OF_RESOURCES`]: insufficient resources to modify IOMMU access
-    /// * [`crate::Status::DEVICE_ERROR`]: IOMMU device reported an error
+    /// - [`Status::INVALID_PARAMETER`]: A handle, mapping, or access flag is invalid.
+    /// - [`Status::UNSUPPORTED`]: The IOMMU does not support the operation.
+    /// - [`Status::OUT_OF_RESOURCES`]: The IOMMU cannot update the mapping.
+    /// - [`Status::DEVICE_ERROR`]: The IOMMU reported a device error.
     pub fn set_attribute(
         &self,
         device_handle: Handle,
@@ -59,13 +65,19 @@ impl Iommu {
     /// The mapping is tied to `host_buffer` and will be automatically unmapped when
     /// dropped.
     ///
+    /// # Arguments
+    ///
+    /// - `operation`: Direction and address-width requirements of the DMA operation.
+    /// - `host_buffer`: Host buffer to expose to the device.
+    /// - `number_of_bytes`: Requested prefix of `host_buffer` to map.
+    ///
     /// # Errors
     ///
-    /// * [`crate::Status::INVALID_PARAMETER`]: invalid operation or buffer
-    /// * [`crate::Status::BAD_BUFFER_SIZE`]: `number_of_bytes` is larger than `host_buffer`
-    /// * [`crate::Status::UNSUPPORTED`]: host address cannot be mapped as a common buffer
-    /// * [`crate::Status::OUT_OF_RESOURCES`]: insufficient resources
-    /// * [`crate::Status::DEVICE_ERROR`]: system hardware could not map the requested address
+    /// - [`Status::INVALID_PARAMETER`]: The operation or buffer is invalid.
+    /// - [`Status::BAD_BUFFER_SIZE`]: The requested size exceeds `host_buffer`.
+    /// - [`Status::UNSUPPORTED`]: The host address cannot be mapped as requested.
+    /// - [`Status::OUT_OF_RESOURCES`]: The mapping cannot be allocated.
+    /// - [`Status::DEVICE_ERROR`]: The hardware could not map the address.
     pub fn map<'iommu, 'buf>(
         &'iommu self,
         operation: EdkiiIommuOperation,
@@ -104,7 +116,7 @@ impl Iommu {
         })
     }
 
-    /// Unmap a previously mapped buffer
+    /// Unmaps a previously mapped buffer.
     pub(crate) fn unmap_raw(&self, mapping: *mut c_void) -> Result {
         // SAFETY: The safe `Mapping` API only stores active mapping
         // pointers returned by this protocol, and `Drop` calls this once.
@@ -116,11 +128,17 @@ impl Iommu {
     ///
     /// The buffer will be automatically freed when dropped.
     ///
+    /// # Arguments
+    ///
+    /// - `memory_type`: UEFI memory type assigned to the allocation.
+    /// - `pages`: Number of UEFI pages to allocate.
+    /// - `attributes`: Required cache and addressing attributes.
+    ///
     /// # Errors
     ///
-    /// * [`crate::Status::INVALID_PARAMETER`]: invalid memory type or attributes
-    /// * [`crate::Status::UNSUPPORTED`]: unsupported attributes
-    /// * [`crate::Status::OUT_OF_RESOURCES`]: memory pages could not be allocated
+    /// - [`Status::INVALID_PARAMETER`]: The memory type or attributes are invalid.
+    /// - [`Status::UNSUPPORTED`]: The IOMMU does not support the attributes.
+    /// - [`Status::OUT_OF_RESOURCES`]: The pages could not be allocated.
     pub fn allocate_buffer(
         &self,
         memory_type: MemoryType,
@@ -152,7 +170,7 @@ impl Iommu {
         })
     }
 
-    /// Free a buffer allocated with allocate_buffer
+    /// Frees a buffer allocated with `allocate_buffer`.
     pub(crate) fn free_buffer_raw(&self, ptr: *mut c_void, pages: usize) -> Result {
         // SAFETY: `DmaBuffer` calls this only for buffers allocated by this
         // protocol, preserving the original page count.

--- a/uefi/src/proto/dma/mod.rs
+++ b/uefi/src/proto/dma/mod.rs
@@ -25,7 +25,7 @@ pub struct DmaBuffer<'a> {
 }
 
 impl<'a> DmaBuffer<'a> {
-    /// Create a new DmaBuffer from a raw pointer and page count.
+    /// Creates a DMA buffer from a raw pointer and page count.
     ///
     /// # Safety
     /// The caller must ensure that:
@@ -37,25 +37,25 @@ impl<'a> DmaBuffer<'a> {
         Self { ptr, pages, iommu }
     }
 
-    /// Get the raw pointer to the buffer.
+    /// Returns the buffer's raw pointer.
     #[must_use]
     pub const fn as_ptr(&self) -> *const c_void {
         self.ptr.cast_const()
     }
 
-    /// Get the raw mutable pointer to the buffer.
+    /// Returns the buffer's raw mutable pointer.
     #[must_use]
     pub const fn as_mut_ptr(&mut self) -> *mut c_void {
         self.ptr
     }
 
-    /// Get the number of pages in the buffer.
+    /// Returns the number of pages in the buffer.
     #[must_use]
     pub const fn pages(&self) -> usize {
         self.pages
     }
 
-    /// Get the size of the buffer in bytes.
+    /// Returns the buffer size in bytes.
     #[must_use]
     pub const fn size(&self) -> usize {
         self.pages * PAGE_SIZE
@@ -101,7 +101,7 @@ pub struct Mapping<'a, 'buf> {
 }
 
 impl<'a, 'buf> Mapping<'a, 'buf> {
-    /// Create a new Mapping from a raw pointer.
+    /// Creates a mapping from a raw pointer.
     ///
     /// # Safety
     /// The caller must ensure that:
@@ -122,13 +122,13 @@ impl<'a, 'buf> Mapping<'a, 'buf> {
         }
     }
 
-    /// Get the raw mapping pointer.
+    /// Returns the raw mapping pointer.
     #[must_use]
     pub const fn as_ptr(&self) -> *const c_void {
         self.ptr.cast_const()
     }
 
-    /// Get the raw mutable mapping pointer.
+    /// Returns the raw mutable mapping pointer.
     #[must_use]
     pub const fn as_mut_ptr(&mut self) -> *mut c_void {
         self.ptr

--- a/uefi/src/proto/driver/component_name.rs
+++ b/uefi/src/proto/driver/component_name.rs
@@ -52,7 +52,7 @@ impl ComponentName1 {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V1)
     }
 
-    /// Get the human-readable name of the driver in the given language.
+    /// Returns the human-readable driver name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///
@@ -66,7 +66,7 @@ impl ComponentName1 {
             .to_result_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
     }
 
-    /// Get the human-readable name of a controller in the given language.
+    /// Returns a controller name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///
@@ -128,7 +128,7 @@ impl ComponentName2 {
         LanguageIter::new(self.0.supported_languages, LanguageIterKind::V2)
     }
 
-    /// Get the human-readable name of the driver in the given language.
+    /// Returns the human-readable driver name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///
@@ -142,7 +142,7 @@ impl ComponentName2 {
             .to_result_with_val(|| unsafe { CStr16::from_ptr(driver_name.cast()) })
     }
 
-    /// Get the human-readable name of a controller in the given language.
+    /// Returns a controller name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///
@@ -209,7 +209,7 @@ impl ComponentName {
         }
     }
 
-    /// Get the human-readable name of the driver in the given language.
+    /// Returns the human-readable driver name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///
@@ -221,7 +221,7 @@ impl ComponentName {
         }
     }
 
-    /// Get the human-readable name of a controller in the given language.
+    /// Returns a controller name in the requested language.
     ///
     /// `language` must be one of the languages returned by [`supported_languages`].
     ///

--- a/uefi/src/proto/hii/config_str.rs
+++ b/uefi/src/proto/hii/config_str.rs
@@ -60,13 +60,13 @@ impl<'a> Iterator for ConfigurationStringIter<'a> {
 /// routing and identification information for UEFI components.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ConfigHdrSection {
-    /// UEFI ConfigurationString {GuidHdr} element
+    /// GUID header element of a UEFI configuration string.
     Guid,
-    /// UEFI ConfigurationString {NameHdr} element
+    /// Name header element of a UEFI configuration string.
     Name,
-    /// UEFI ConfigurationString {PathHdr} element
+    /// Path header element of a UEFI configuration string.
     Path,
-    /// UEFI ConfigurationString {DescHdr} element
+    /// Descriptor header element of a UEFI configuration string.
     DescHdr,
 }
 

--- a/uefi/src/proto/hii/config_str.rs
+++ b/uefi/src/proto/hii/config_str.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! UEFI Configuration String parsing according to Spec 35.2.1
+//! UEFI configuration string parsing as defined by specification section 35.2.1.
 
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
@@ -14,13 +14,13 @@ use crate::mem::AlignedBuffer;
 use crate::proto::device_path::DevicePath;
 use crate::{CStr16, Char16};
 
-/// A helper struct to split and parse a UEFI Configuration String.
+/// Iterator over the fields of a UEFI configuration string.
 ///
 /// Configuration strings consist of key-value pairs separated by `&`. Keys
 /// and values are separated by `=`. This struct provides an iterator for
 /// easy traversal of the key-value pairs.
 ///
-/// For reasons of developer sanity, this is operating on &str instead of &CStr16.
+/// This operates on `&str` rather than [`CStr16`] for easier parsing.
 #[derive(Debug)]
 pub struct ConfigurationStringIter<'a> {
     bfr: &'a str,
@@ -54,7 +54,7 @@ impl<'a> Iterator for ConfigurationStringIter<'a> {
     }
 }
 
-/// Enum representing different sections of a UEFI Configuration Header.
+/// Section of a UEFI configuration header.
 ///
 /// These sections include GUID, Name, and Path elements, which provide
 /// routing and identification information for UEFI components.
@@ -70,8 +70,7 @@ pub enum ConfigHdrSection {
     DescHdr,
 }
 
-/// Enum representing possible parsing errors encountered when processing
-/// UEFI Configuration Strings.
+/// Error encountered while parsing a UEFI configuration string.
 #[derive(Debug)]
 pub enum ParseError {
     /// Error while parsing the UEFI {ConfigHdr} configuration string section.
@@ -82,17 +81,17 @@ pub enum ParseError {
     BlockConfig,
 }
 
-/// Represents an individual element within a UEFI Configuration String.
+/// Element within a UEFI configuration string.
 ///
 /// Each element contains an offset, width, and value, defining the data
 /// stored at specific memory locations within the configuration.
 #[derive(Debug, Default)]
 pub struct ConfigurationStringElement {
-    /// Byte offset in the configuration block
+    /// Byte offset in the configuration block.
     pub offset: u64,
-    /// Length of the value starting at offset
+    /// Length of `value` at [`Self::offset`].
     pub width: u64,
-    /// Value bytes
+    /// Value bytes.
     pub value: Vec<u8>,
     // TODO
     // nvconfig: HashMap<String, Vec<u8>>,
@@ -108,21 +107,21 @@ mod keys {
     pub const WIDTH: &str = "WIDTH";
 }
 
-/// A full UEFI Configuration String representation.
+/// Parsed UEFI configuration string.
 ///
 /// This structure contains routing information such as GUID and device path,
 /// along with the parsed configuration elements.
 #[derive(Debug)]
 pub struct ConfigurationString {
-    /// GUID used for identifying the configuration
+    /// GUID identifying the configuration.
     pub guid: Guid,
-    /// Name field (optional identifier)
+    /// Configuration name.
     pub name: String,
-    /// Associated UEFI device path
+    /// Associated UEFI device path.
     pub device_path: Box<DevicePath>,
     /// Identifier of a configuration declared in the corresponding IFR.
     pub alt_cfg_id: Option<u16>,
-    /// Parsed UEFI {ConfigElement} sections
+    /// Parsed UEFI `{ConfigElement}` sections.
     pub elements: Vec<ConfigurationStringElement>,
 }
 
@@ -134,15 +133,13 @@ impl ConfigurationString {
         parse_fn().ok_or(err)
     }
 
-    /// Parses a hexadecimal string into an iterator of bytes.
+    /// Parses `hex` into an iterator of bytes.
+    ///
+    /// Invalid byte pairs are returned as zero.
     ///
     /// # Arguments
     ///
-    /// * `hex` - The hexadecimal string representing binary data.
-    ///
-    /// # Returns
-    ///
-    /// An iterator over bytes.
+    /// - `hex`: Hexadecimal representation of the bytes.
     #[must_use]
     pub fn parse_bytes_from_hex(hex: &str) -> impl DoubleEndedIterator<Item = u8> {
         hex.as_bytes().chunks(2).map(|chunk| {
@@ -151,15 +148,15 @@ impl ConfigurationString {
         })
     }
 
-    /// Converts a hexadecimal string representation into a numeric value.
+    /// Parses `data` as a one-, two-, four-, or eight-byte number.
     ///
     /// # Arguments
     ///
-    /// * `data` - The hexadecimal string to convert.
+    /// - `data`: Big-endian hexadecimal representation of the number.
     ///
     /// # Returns
     ///
-    /// An `Option<u64>` representing the parsed number.
+    /// Returns `None` when the decoded length is unsupported.
     #[must_use]
     pub fn parse_number_from_hex(data: &str) -> Option<u64> {
         let data: Vec<_> = Self::parse_bytes_from_hex(data).collect();
@@ -172,15 +169,15 @@ impl ConfigurationString {
         }
     }
 
-    /// Converts a hexadecimal string into a UTF-16 string.
+    /// Parses `data` as a UTF-16 string.
     ///
     /// # Arguments
     ///
-    /// * `data` - The hexadecimal representation of a string.
+    /// - `data`: Hexadecimal representation of the UTF-16 bytes.
     ///
     /// # Returns
     ///
-    /// An `Option<String>` containing the parsed string.
+    /// Returns `None` if the representation or resulting string is invalid.
     #[must_use]
     pub fn parse_string_from_hex(data: &str) -> Option<String> {
         if !data.len().is_multiple_of(2) {
@@ -199,22 +196,30 @@ impl ConfigurationString {
         Some(CStr16::from_char16_with_nul(data).ok()?.to_string())
     }
 
-    /// Parses a hexadecimal string into a UEFI GUID.
+    /// Parses `data` as a UEFI GUID.
     ///
     /// # Arguments
     ///
-    /// * `data` - The hexadecimal GUID representation.
+    /// - `data`: Hexadecimal representation of the GUID bytes.
     ///
     /// # Returns
     ///
-    /// An `Option<Guid>` containing the parsed GUID.
+    /// Returns `None` unless `data` decodes to exactly 16 bytes.
     #[must_use]
     pub fn parse_guid_from_hex(data: &str) -> Option<Guid> {
         let v: Vec<_> = Self::parse_bytes_from_hex(data).collect();
         Some(Guid::from_bytes(v.try_into().ok()?))
     }
 
-    /// Parse an instance of `Peekable<ConfigurationStringIter>` from the given kv-pair iterator.
+    /// Parses a configuration string from its key-value fields.
+    ///
+    /// # Arguments
+    ///
+    /// - `splitter`: Remaining key-value fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] for a missing or malformed section.
     fn parse_from(
         splitter: &mut Peekable<ConfigurationStringIter<'_>>,
     ) -> Result<Self, ParseError> {

--- a/uefi/src/proto/hii/mod.rs
+++ b/uefi/src/proto/hii/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! HII Protocols
+//! UEFI HII protocols and data types.
 
 pub mod config;
 #[cfg(feature = "alloc")]

--- a/uefi/src/proto/loaded_image.rs
+++ b/uefi/src/proto/loaded_image.rs
@@ -64,7 +64,7 @@ impl LoadedImage {
         }
     }
 
-    /// Get the load options of the image as a [`&CStr16`].
+    /// Returns the image's load options as a [`CStr16`].
     ///
     /// Load options are typically used to pass command-line options as
     /// a null-terminated UCS-2 string. This format is not required
@@ -93,7 +93,7 @@ impl LoadedImage {
         }
     }
 
-    /// Get the load options of the image as raw bytes.
+    /// Returns the image's load options as raw bytes.
     ///
     /// UEFI allows arbitrary binary data in load options, but typically
     /// the data is a null-terminated UCS-2 string. Use
@@ -118,7 +118,7 @@ impl LoadedImage {
         }
     }
 
-    /// Set the image data address and size.
+    /// Sets the image data address and size.
     ///
     /// This is useful in the following scenario:
     /// 1. Secure boot is enabled, so images loaded with `LoadImage` must be
@@ -165,7 +165,9 @@ impl LoadedImage {
         self.0.unload = Some(unload);
     }
 
-    /// Set the load options for the image. This can be used prior to
+    /// Sets the image's load options.
+    ///
+    /// This can be used prior to
     /// calling [`boot::start_image`] to control the command line
     /// passed to the image.
     ///

--- a/uefi/src/proto/media/block.rs
+++ b/uefi/src/proto/media/block.rs
@@ -19,7 +19,7 @@ pub use uefi_raw::protocol::block::{BlockIo2Protocol, BlockIoProtocol, Lba};
 pub struct BlockIO(BlockIoProtocol);
 
 impl BlockIO {
-    /// Pointer for block IO media.
+    /// Returns block I/O media information.
     #[must_use]
     pub const fn media(&self) -> &BlockIOMedia {
         // SAFETY: The memory is valid.
@@ -29,33 +29,36 @@ impl BlockIO {
     /// Resets the block device hardware.
     ///
     /// # Arguments
-    /// * `extended_verification` Indicates that the driver may perform a more
-    ///   exhaustive verification operation of the device during reset.
+    ///
+    /// - `extended_verification`: Requests an exhaustive device verification
+    ///   during reset.
     ///
     /// # Errors
-    /// * `Status::DEVICE_ERROR`  The block device is not functioning
-    ///   correctly and could not be reset.
+    ///
+    /// - [`Status::DEVICE_ERROR`]: the device is malfunctioning and could not
+    ///   be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
-    /// Read the requested number of blocks from the device.
+    /// Reads blocks from the device.
     ///
     /// # Arguments
-    /// * `media_id` - The media ID that the read request is for.
-    /// * `lba` - The starting logical block address to read from on the device.
-    /// * `buffer` - The target buffer of the read operation
+    ///
+    /// - `media_id`: Identifier of the medium to read.
+    /// - `lba`: First logical block to read.
+    /// - `buffer`: Destination buffer; its length determines the block count.
     ///
     /// # Errors
-    /// * `Status::DEVICE_ERROR`       The device reported an error while attempting to perform the read
-    ///   operation.
-    /// * `Status::NO_MEDIA`           There is no media in the device.
-    /// * `Status::MEDIA_CHANGED`      The `media_id` is not for the current media.
-    /// * `Status::BAD_BUFFER_SIZE`    The buffer size parameter is not a multiple of the intrinsic block size of
-    ///   the device.
-    /// * `Status::INVALID_PARAMETER`  The read request contains LBAs that are not valid, or the buffer is not on
-    ///   proper alignment.
+    ///
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::BAD_BUFFER_SIZE`]: the buffer length is not a multiple of
+    ///   the block size.
+    /// - [`Status::INVALID_PARAMETER`]: an LBA is invalid or the buffer is
+    ///   incorrectly aligned.
     pub fn read_blocks(&self, media_id: u32, lba: Lba, buffer: &mut [u8]) -> Result {
         let buffer_size = buffer.len();
         // SAFETY: The memory is valid.
@@ -74,20 +77,21 @@ impl BlockIO {
     /// Writes the requested number of blocks to the device.
     ///
     /// # Arguments
-    /// * `media_id`    The media ID that the write request is for.
-    /// * `lba`         The starting logical block address to be written.
-    /// * `buffer`      Buffer to be written
+    ///
+    /// - `media_id`: Identifier of the medium to write.
+    /// - `lba`: First logical block to write.
+    /// - `buffer`: Source buffer; its length determines the block count.
     ///
     /// # Errors
-    /// * `Status::WRITE_PROTECTED`       The device cannot be written to.
-    /// * `Status::NO_MEDIA`              There is no media in the device.
-    /// * `Status::MEDIA_CHANGED`         The `media_id` is not for the current media.
-    /// * `Status::DEVICE_ERROR`          The device reported an error while attempting to perform the write
-    ///   operation.
-    /// * `Status::BAD_BUFFER_SIZE`       The buffer size parameter is not a multiple of the intrinsic block size
-    ///   of the device.
-    /// * `Status::INVALID_PARAMETER`     The write request contains LBAs that are not valid, or the buffer is not
-    ///   on proper alignment.
+    ///
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::BAD_BUFFER_SIZE`]: the buffer length is not a multiple of
+    ///   the block size.
+    /// - [`Status::INVALID_PARAMETER`]: an LBA is invalid or the buffer is
+    ///   incorrectly aligned.
     pub fn write_blocks(&mut self, media_id: u32, lba: Lba, buffer: &[u8]) -> Result {
         let buffer_size = buffer.len();
         // SAFETY: The memory is valid.
@@ -106,71 +110,74 @@ impl BlockIO {
     /// Flushes all modified data to a physical block device.
     ///
     /// # Errors
-    /// * `Status::DEVICE_ERROR`          The device reported an error while attempting to write data.
-    /// * `Status::NO_MEDIA`              There is no media in the device.
+    ///
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
     pub fn flush_blocks(&mut self) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.flush_blocks)(&mut self.0) }.to_result()
     }
 }
 
-/// Media information structure
+/// Describes the medium exposed by a block I/O device.
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct BlockIOMedia(uefi_raw::protocol::block::BlockIoMedia);
 
 impl BlockIOMedia {
-    /// The current media ID.
+    /// Returns the current media ID.
     #[must_use]
     pub const fn media_id(&self) -> u32 {
         self.0.media_id
     }
 
-    /// True if the media is removable.
+    /// Returns whether the media is removable.
     #[must_use]
     pub fn is_removable_media(&self) -> bool {
         self.0.removable_media.into()
     }
 
-    /// True if there is a media currently present in the device.
+    /// Returns whether media is currently present in the device.
     #[must_use]
     pub fn is_media_present(&self) -> bool {
         self.0.media_present.into()
     }
 
-    /// True if block IO was produced to abstract partition structure.
+    /// Returns whether block I/O abstracts a partition.
     #[must_use]
     pub fn is_logical_partition(&self) -> bool {
         self.0.logical_partition.into()
     }
 
-    /// True if the media is marked read-only.
+    /// Returns whether the media is read-only.
     #[must_use]
     pub fn is_read_only(&self) -> bool {
         self.0.read_only.into()
     }
 
-    /// True if `writeBlocks` function writes data.
+    /// Returns whether the `write_blocks` function writes data.
     #[must_use]
     pub fn is_write_caching(&self) -> bool {
         self.0.write_caching.into()
     }
 
-    /// The intrinsic block size of the device.
+    /// Returns the intrinsic block size in bytes.
     ///
-    /// If the media changes, then this field is updated. Returns the number of bytes per logical block.
+    /// This value is updated when the medium changes.
     #[must_use]
     pub const fn block_size(&self) -> u32 {
         self.0.block_size
     }
 
-    /// Supplies the alignment requirement for any buffer used in a data transfer.
+    /// Returns the alignment required for data-transfer buffers.
     #[must_use]
     pub const fn io_align(&self) -> u32 {
         self.0.io_align
     }
 
-    /// The last LBA on the device. If the media changes, then this field is updated.
+    /// Returns the last LBA on the device.
+    ///
+    /// This value is updated when the medium changes.
     #[must_use]
     pub const fn last_block(&self) -> Lba {
         self.0.last_block
@@ -219,7 +226,7 @@ pub struct BlockIO2Token {
 pub struct BlockIO2(BlockIo2Protocol);
 
 impl BlockIO2 {
-    /// Pointer for block IO media.
+    /// Returns block I/O media information.
     #[must_use]
     pub const fn media(&self) -> &BlockIOMedia {
         // SAFETY: The memory is valid.
@@ -229,10 +236,14 @@ impl BlockIO2 {
     /// Resets the block device hardware.
     ///
     /// # Arguments
-    /// * `extended_verification` - Indicates that the driver may perform a more exhaustive verification operation of the device during reset.
+    ///
+    /// - `extended_verification`: Requests an exhaustive device verification
+    ///   during reset.
     ///
     /// # Errors
-    /// * [`Status::DEVICE_ERROR`] The block device is not functioning correctly and could not be reset.
+    ///
+    /// - [`Status::DEVICE_ERROR`]: the device is malfunctioning and could not
+    ///   be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
@@ -241,23 +252,26 @@ impl BlockIO2 {
     /// Reads the requested number of blocks from the device.
     ///
     /// # Arguments
-    /// * `media_id` - The media ID that the read request is for.
-    /// * `lba` - The starting logical block address to read from on the device.
-    /// * `token` - Transaction token for asynchronous read.
-    /// * `len` - Buffer size.
-    /// * `buffer` - The target buffer of the read operation
+    ///
+    /// - `media_id`: Identifier of the medium to read.
+    /// - `lba`: First logical block to read.
+    /// - `token`: Optional transaction token for asynchronous completion.
+    /// - `len`: Number of bytes available at `buffer`.
+    /// - `buffer`: Destination buffer.
     ///
     /// # Safety
-    /// Because of the asynchronous nature of the block transaction, manual lifetime
-    /// tracking is required.
+    /// `token` and `buffer` must remain valid until the transaction completes.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The read request contains LBAs that are not valid, or the buffer is not on proper alignment.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     The `media_id` is not for the current media.
-    /// * [`Status::NO_MEDIA`]          There is no media in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the read operation.
-    /// * [`Status::BAD_BUFFER_SIZE`]   The buffer size parameter is not a multiple of the intrinsic block size of the device.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: an LBA is invalid or the buffer is
+    ///   incorrectly aligned.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::BAD_BUFFER_SIZE`]: `len` is not a multiple of the block
+    ///   size.
     pub unsafe fn read_blocks_ex(
         &self,
         media_id: u32,
@@ -275,24 +289,27 @@ impl BlockIO2 {
     /// Writes a specified number of blocks to the device.
     ///
     /// # Arguments
-    /// * `media_id` - The media ID that the write request is for.
-    /// * `lba` - The starting logical block address to be written.
-    /// * `token` - Transaction token for asynchronous write.
-    /// * `len` - Buffer size.
-    /// * `buffer` - Buffer to be written from.
+    ///
+    /// - `media_id`: Identifier of the medium to write.
+    /// - `lba`: First logical block to write.
+    /// - `token`: Optional transaction token for asynchronous completion.
+    /// - `len`: Number of bytes available at `buffer`.
+    /// - `buffer`: Source buffer.
     ///
     /// # Safety
-    /// Because of the asynchronous nature of the block transaction, manual
-    /// lifetime tracking is required.
+    /// `token` and `buffer` must remain valid until the transaction completes.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The write request contains LBAs that are not valid, or the buffer is not on proper alignment.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     The `media_id` is not for the current media.
-    /// * [`Status::NO_MEDIA`]          There is no media in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the write operation.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
-    /// * [`Status::BAD_BUFFER_SIZE`]   The buffer size parameter is not a multiple of the intrinsic block size of the device.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: an LBA is invalid or the buffer is
+    ///   incorrectly aligned.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
+    /// - [`Status::BAD_BUFFER_SIZE`]: `len` is not a multiple of the block
+    ///   size.
     pub unsafe fn write_blocks_ex(
         &mut self,
         media_id: u32,
@@ -312,14 +329,16 @@ impl BlockIO2 {
     /// Flushes all modified data to the physical device.
     ///
     /// # Arguments
-    /// * `token` - Transaction token for asynchronous flush.
+    ///
+    /// - `token`: Optional transaction token for asynchronous completion.
     ///
     /// # Errors
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     The media in the device has changed since the last access.
-    /// * [`Status::NO_MEDIA`]          There is no media in the device.
-    /// * [`Status::DEVICE_ERROR`]      The `media_id` is not for the current media.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    ///
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: the medium changed since the last access.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
     pub fn flush_blocks_ex(&mut self, token: Option<NonNull<BlockIO2Token>>) -> Result {
         let token = opt_nonnull_to_ptr(token);
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/media/disk.rs
+++ b/uefi/src/proto/media/disk.rs
@@ -25,15 +25,17 @@ impl DiskIo {
     /// Reads bytes from the disk device.
     ///
     /// # Arguments
-    /// * `media_id` - ID of the medium to be read.
-    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
-    /// * `buffer` - Pointer to a buffer to read into.
+    ///
+    /// - `media_id`: Identifier of the medium to read.
+    /// - `offset`: Byte offset at which to begin reading.
+    /// - `buffer`: Destination buffer.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The read request contains device addresses that are not valid for the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the read operation.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: the requested range is invalid.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
     pub fn read_disk(&self, media_id: u32, offset: u64, buffer: &mut [u8]) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -51,16 +53,18 @@ impl DiskIo {
     /// Writes bytes to the disk device.
     ///
     /// # Arguments
-    /// * `media_id` - ID of the medium to be written.
-    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
-    /// * `buffer` - Pointer to a buffer to write from.
+    ///
+    /// - `media_id`: Identifier of the medium to write.
+    /// - `offset`: Byte offset at which to begin writing.
+    /// - `buffer`: Source buffer.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The write request contains device addresses that are not valid for the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the write operation.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: the requested range is invalid.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
     pub fn write_disk(&mut self, media_id: u32, offset: u64, buffer: &[u8]) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -101,7 +105,9 @@ impl DiskIo2 {
     /// Terminates outstanding asynchronous requests to the device.
     ///
     /// # Errors
-    /// * [`Status::DEVICE_ERROR`] The device reported an error while performing
+    ///
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error while
+    ///   cancelling requests.
     pub fn cancel(&mut self) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.cancel)(&mut self.0) }.to_result()
@@ -110,23 +116,24 @@ impl DiskIo2 {
     /// Reads bytes from the disk device.
     ///
     /// # Arguments
-    /// * `media_id` - ID of the medium to be read from.
-    /// * `offset` - Starting byte offset on the logical block I/O device to read from.
-    /// * `token` - Transaction token for asynchronous read.
-    /// * `len` - Buffer size.
-    /// * `buffer` - Buffer to read into.
+    ///
+    /// - `media_id`: Identifier of the medium to read.
+    /// - `offset`: Byte offset at which to begin reading.
+    /// - `token`: Optional transaction token for asynchronous completion.
+    /// - `len`: Number of bytes available at `buffer`.
+    /// - `buffer`: Destination buffer.
     ///
     /// # Safety
     ///
-    /// Because of the asynchronous nature of the disk transaction, manual lifetime
-    /// tracking is required.
+    /// `token` and `buffer` must remain valid until the transaction completes.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The read request contains device addresses that are not valid for the device.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     `media_id` is not for the current medium.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the read operation.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: the requested range is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
     pub unsafe fn read_disk_raw(
         &self,
         media_id: u32,
@@ -146,24 +153,25 @@ impl DiskIo2 {
     /// Writes bytes to the disk device.
     ///
     /// # Arguments
-    /// * `media_id` - ID of the medium to write to.
-    /// * `offset` - Starting byte offset on the logical block I/O device to write to.
-    /// * `token` - Transaction token for asynchronous write.
-    /// * `len` - Buffer size.
-    /// * `buffer` - Buffer to write from.
+    ///
+    /// - `media_id`: Identifier of the medium to write.
+    /// - `offset`: Byte offset at which to begin writing.
+    /// - `token`: Optional transaction token for asynchronous completion.
+    /// - `len`: Number of bytes available at `buffer`.
+    /// - `buffer`: Source buffer.
     ///
     /// # Safety
     ///
-    /// Because of the asynchronous nature of the disk transaction, manual lifetime
-    /// tracking is required.
+    /// `token` and `buffer` must remain valid until the transaction completes.
     ///
     /// # Errors
-    /// * [`Status::INVALID_PARAMETER`] The write request contains device addresses that are not valid for the device.
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`      `media_id` is not for the current medium.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the write operation.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    ///
+    /// - [`Status::INVALID_PARAMETER`]: the requested range is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: `media_id` is not current.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
     pub unsafe fn write_disk_raw(
         &mut self,
         media_id: u32,
@@ -190,14 +198,16 @@ impl DiskIo2 {
     /// Flushes all modified data to the physical device.
     ///
     /// # Arguments
-    /// * `token` - Transaction token for the asynchronous flush.
+    ///
+    /// - `token`: Optional transaction token for asynchronous completion.
     ///
     /// # Errors
-    /// * [`Status::OUT_OF_RESOURCES`]  The request could not be completed due to a lack of resources.
-    /// * [`Status::MEDIA_CHANGED`]     The medium in the device has changed since the last access.
-    /// * [`Status::NO_MEDIA`]          There is no medium in the device.
-    /// * [`Status::DEVICE_ERROR`]      The device reported an error while performing the flush operation.
-    /// * [`Status::WRITE_PROTECTED`]   The device cannot be written to.
+    ///
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the request.
+    /// - [`Status::MEDIA_CHANGED`]: the medium changed since the last access.
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::WRITE_PROTECTED`]: the device is read-only.
     pub fn flush_disk(&mut self, token: Option<NonNull<DiskIo2Token>>) -> Result {
         let token = opt_nonnull_to_ptr(token);
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/media/disk_info.rs
+++ b/uefi/src/proto/media/disk_info.rs
@@ -9,10 +9,10 @@ use uefi_raw::protocol::disk::DiskInfoProtocol;
 #[cfg(doc)]
 use crate::Status;
 
-/// Enum representing the interface type of the disk.
+/// Interface used by a disk device.
 ///
-/// This protocol abstracts various disk interfaces, including IDE, USB, AHCI, NVME, and more.
-/// Unknown indicates an unrecognized or not yet implemented interface type.
+/// [`DiskInfoInterface::Unknown`] represents an unrecognized or unsupported
+/// interface.
 #[derive(Debug, Eq, PartialEq)]
 pub enum DiskInfoInterface {
     /// Unrecognized or unsupported interface.
@@ -33,16 +33,16 @@ pub enum DiskInfoInterface {
     SDMMC,
 }
 
-/// Structure containing metadata about the result for a call to [`DiskInfo::sense_data`].
+/// Metadata returned by [`DiskInfo::sense_data`].
 #[derive(Debug)]
 pub struct SenseDataInfo {
-    /// Amount of bytes returned by the [`DiskInfo::sense_data`].
+    /// Number of bytes returned by [`DiskInfo::sense_data`].
     pub bytes: usize,
-    /// Number of sense data messages contained in the resulting buffer from calling [`DiskInfo::sense_data`].
+    /// Number of sense-data records written to the result buffer.
     pub number: u8,
 }
 
-/// Structure containing information about the physical device location on the bus.
+/// Physical location of a device on its bus.
 ///
 /// This is not supported by all interface types.
 #[derive(Debug)]
@@ -75,10 +75,7 @@ pub struct DeviceLocationInfo {
 pub struct DiskInfo(DiskInfoProtocol);
 
 impl DiskInfo {
-    /// Retrieves the interface type of the disk device.
-    ///
-    /// # Returns
-    /// [`DiskInfoInterface`] value representing the disk interface (e.g., IDE, USB, NVME, etc.).
+    /// Returns the disk device's interface type.
     #[must_use]
     pub const fn interface(&self) -> DiskInfoInterface {
         match self.0.interface {
@@ -96,16 +93,17 @@ impl DiskInfo {
     /// Performs an inquiry command on the disk device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable byte buffer to store the inquiry data.
+    ///
+    /// - `bfr`: Buffer in which to store the inquiry data.
     ///
     /// # Returns
-    /// Length of the response (amount of bytes that were written to the given buffer).
+    ///
+    /// Returns the number of bytes written to `bfr`.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the InquiryData from the device.
-    /// - [`Status::BUFFER_TOO_SMALL`] The provided InquiryDataSize buffer is not large enough to store the required data.
+    /// - [`Status::NOT_FOUND`]: the device does not support inquiry data.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::BUFFER_TOO_SMALL`]: `bfr` is too small.
     pub fn inquiry(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         // SAFETY: The memory is valid.
@@ -118,16 +116,17 @@ impl DiskInfo {
     /// Performs an identify command on the disk device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable byte buffer to store the identification data.
+    ///
+    /// - `bfr`: Buffer in which to store the identification data.
     ///
     /// # Returns
-    /// Length of the response (amount of bytes that were written to the given buffer).
+    ///
+    /// Returns the number of bytes written to `bfr`.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the IdentifyData from the device.
-    /// - [`Status::BUFFER_TOO_SMALL`] The provided IdentifyDataSize buffer is not large enough to store the required data.
+    /// - [`Status::NOT_FOUND`]: the device does not support identify data.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::BUFFER_TOO_SMALL`]: `bfr` is too small.
     pub fn identify(&self, bfr: &mut [u8]) -> crate::Result<usize> {
         let mut len: u32 = bfr.len() as u32;
         // SAFETY: The memory is valid.
@@ -140,16 +139,17 @@ impl DiskInfo {
     /// Retrieves sense data from the disk device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable byte buffer to store the sense data.
+    ///
+    /// - `bfr`: Buffer in which to store the sense data.
     ///
     /// # Returns
-    /// [`SenseDataInfo`] struct containing the number of bytes of sense data and the number of sense data structures.
+    ///
+    /// Returns the byte count and number of sense-data records written.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The command was accepted without any errors.
-    /// - [`Status::NOT_FOUND`] The device does not support this data class.
-    /// - [`Status::DEVICE_ERROR`] An error occurred while reading the SenseData from the device.
-    /// - [`Status::BUFFER_TOO_SMALL`] The provided SenseDataSize buffer is not large enough to store the required data.
+    /// - [`Status::NOT_FOUND`]: the device does not support sense data.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::BUFFER_TOO_SMALL`]: `bfr` is too small.
     pub fn sense_data(&self, bfr: &mut [u8]) -> crate::Result<SenseDataInfo> {
         let mut len: u32 = bfr.len() as u32;
         let mut number: u8 = 0;
@@ -165,15 +165,12 @@ impl DiskInfo {
 
     /// Retrieves the physical location of the device on the bus.
     ///
-    /// This operation provides information about the channel and device identifiers, which can
-    /// help determine the device's physical connection point.
-    ///
-    /// # Returns
-    /// [`DeviceLocationInfo`] struct containing the channel and device numbers.
+    /// This operation provides the channel and device identifiers that identify
+    /// the device's physical connection point.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The `IdeChannel` and `IdeDevice` values are valid.
-    /// - [`Status::UNSUPPORTED`] Not supported by this disk's interface type.
+    /// - [`Status::UNSUPPORTED`]: the disk interface does not expose a bus
+    ///   location.
     pub fn bus_location(&self) -> crate::Result<DeviceLocationInfo> {
         let mut ide_channel: u32 = 0; // called ide, but also useful for other interfaces
         let mut ide_device: u32 = 0;

--- a/uefi/src/proto/media/file/dir.rs
+++ b/uefi/src/proto/media/file/dir.rs
@@ -17,27 +17,27 @@ use {crate::mem::make_boxed, alloc::boxed::Box};
 pub struct Directory(RegularFile);
 
 impl Directory {
-    /// Coverts a `FileHandle` into a `Directory` without checking the file type.
+    /// Converts a [`FileHandle`] without checking that it is a directory.
+    ///
     /// # Safety
-    /// This function should only be called on files which ARE directories,
-    /// doing otherwise is unsafe.
+    ///
+    /// `handle` must represent a directory.
     #[must_use]
     pub const unsafe fn new(handle: FileHandle) -> Self {
         // SAFETY: The memory is valid.
         Self(unsafe { RegularFile::new(handle) })
     }
 
-    /// Read the next directory entry.
+    /// Reads the next directory entry.
     ///
-    /// Try to read the next directory entry into `buffer`. If the buffer is too small, report the
-    /// required buffer size as part of the error. If there are no more directory entries, return
-    /// an empty optional.
+    /// If `buffer` is too small, the error contains the required size. Returns
+    /// `None` after the final entry.
     ///
-    /// The input buffer must be correctly aligned for a `FileInfo`. You can query the required
-    /// alignment through the `Align` trait (`<FileInfo as Align>::alignment()`).
+    /// The buffer must satisfy [`FileInfo`]'s [`Align`] requirement.
     ///
     /// # Arguments
-    /// * `buffer`  The target buffer of the read operation
+    ///
+    /// - `buffer`: Destination buffer for the next directory entry.
     ///
     /// # Errors
     ///
@@ -62,8 +62,10 @@ impl Directory {
         })
     }
 
-    /// Wrapper around [`Self::read_entry`] that returns an owned copy of the data. It has the same
-    /// implications and requirements. On failure, the payload of `Err` is `()´.
+    /// Reads the next directory entry into an owned allocation.
+    ///
+    /// This has the same behavior as [`Self::read_entry`], but discards the
+    /// required-size error payload.
     #[cfg(feature = "alloc")]
     pub fn read_entry_boxed(&mut self) -> Result<Option<Box<FileInfo>>> {
         let read_entry_res = self.read_entry(&mut []);
@@ -84,7 +86,7 @@ impl Directory {
         Ok(Some(file_info))
     }
 
-    /// Start over the process of enumerating directory entries
+    /// Restarts directory entry enumeration.
     ///
     /// # Errors
     ///

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -49,7 +49,7 @@ trait InfoInternal: Align + ptr_meta::Pointee<Metadata = usize> {
         unsafe { ptr.add(offset_of_str).cast::<Char16>() }
     }
 
-    /// Create a new info type in user-provided storage.
+    /// Creates an information structure in caller-provided storage.
     ///
     /// The structure will be created in-place within the provided
     /// `storage` buffer. The alignment and size of the buffer is
@@ -177,7 +177,7 @@ pub struct FileInfo {
 }
 
 impl FileInfo {
-    /// Create a `FileInfo` structure
+    /// Creates a [`FileInfo`] structure.
     ///
     /// The structure will be created in-place within the provided storage
     /// buffer. The buffer must be large enough to hold the data structure,
@@ -304,7 +304,7 @@ pub struct FileSystemInfo {
 }
 
 impl FileSystemInfo {
-    /// Create a `FileSystemInfo` structure
+    /// Creates a [`FileSystemInfo`] structure.
     ///
     /// The structure will be created in-place within the provided storage
     /// buffer. The buffer must be large enough to hold the data structure,
@@ -394,7 +394,7 @@ pub struct FileSystemVolumeLabel {
 }
 
 impl FileSystemVolumeLabel {
-    /// Create a `FileSystemVolumeLabel` structure
+    /// Creates a [`FileSystemVolumeLabel`] structure.
     ///
     /// The structure will be created in-place within the provided storage
     /// buffer. The buffer must be large enough to hold the data structure,

--- a/uefi/src/proto/media/file/info.rs
+++ b/uefi/src/proto/media/file/info.rs
@@ -217,37 +217,37 @@ impl FileInfo {
         self.file_size
     }
 
-    /// Physical space consumed by the file on the file system volume
+    /// Physical space consumed by the file on its volume.
     #[must_use]
     pub const fn physical_size(&self) -> u64 {
         self.physical_size
     }
 
-    /// Time when the file was created
+    /// Time at which the file was created.
     #[must_use]
     pub const fn create_time(&self) -> &Time {
         &self.create_time
     }
 
-    /// Time when the file was last accessed
+    /// Time at which the file was last accessed.
     #[must_use]
     pub const fn last_access_time(&self) -> &Time {
         &self.last_access_time
     }
 
-    /// Time when the file's contents were last modified
+    /// Time at which the file's contents were last modified.
     #[must_use]
     pub const fn modification_time(&self) -> &Time {
         &self.modification_time
     }
 
-    /// Attribute bits for the file
+    /// File attributes.
     #[must_use]
     pub const fn attribute(&self) -> FileAttribute {
         self.attribute
     }
 
-    /// Name of the file
+    /// File name.
     #[must_use]
     pub fn file_name(&self) -> &CStr16 {
         // SAFETY: The memory is valid.
@@ -333,31 +333,31 @@ impl FileSystemInfo {
         }
     }
 
-    /// Truth that the volume only supports read access
+    /// Whether the volume is read-only.
     #[must_use]
     pub const fn read_only(&self) -> bool {
         self.read_only
     }
 
-    /// Number of bytes managed by the file system
+    /// Number of bytes managed by the file system.
     #[must_use]
     pub const fn volume_size(&self) -> u64 {
         self.volume_size
     }
 
-    /// Number of available bytes for use by the file system
+    /// Number of bytes available for use.
     #[must_use]
     pub const fn free_space(&self) -> u64 {
         self.free_space
     }
 
-    /// Nominal block size by which files are typically grown
+    /// Nominal block size by which files are grown.
     #[must_use]
     pub const fn block_size(&self) -> u32 {
         self.block_size
     }
 
-    /// Volume label
+    /// Volume label.
     #[must_use]
     pub fn volume_label(&self) -> &CStr16 {
         // SAFETY: The memory is valid.
@@ -411,7 +411,7 @@ impl FileSystemVolumeLabel {
         unsafe { Self::new_impl(storage, volume_label, |_ptr, _size| {}) }
     }
 
-    /// Volume label
+    /// Volume label.
     #[must_use]
     pub fn volume_label(&self) -> &CStr16 {
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -40,12 +40,14 @@ pub trait File: Sized {
     #[doc(hidden)]
     fn handle(&mut self) -> &mut FileHandle;
 
-    /// Try to open a file relative to this file.
+    /// Opens a file relative to this file.
     ///
     /// # Arguments
-    /// * `filename`    Path of file to open, relative to this file
-    /// * `open_mode`   The mode to open the file with
-    /// * `attributes`  Only valid when `FILE_MODE_CREATE` is used as a mode
+    ///
+    /// - `filename`: Path to open, relative to this file.
+    /// - `open_mode`: Mode in which to open the file.
+    /// - `attributes`: Attributes for a newly created file; only used with
+    ///   [`FileMode::CreateReadWrite`].
     ///
     /// # Errors
     ///
@@ -88,10 +90,10 @@ pub trait File: Sized {
         .to_result_with_val(|| unsafe { FileHandle::new(ptr) })
     }
 
-    /// Close this file handle. Same as dropping this structure.
+    /// Closes this file handle. Equivalent to dropping it.
     fn close(self) {}
 
-    /// Closes and deletes this file
+    /// Closes and deletes this file.
     ///
     /// # Warnings
     ///
@@ -105,15 +107,16 @@ pub trait File: Sized {
         result
     }
 
-    /// Queries some information about a file
+    /// Queries information about a file.
     ///
-    /// The information will be written into a user-provided buffer.
-    /// If the buffer is too small, the required buffer size will be returned as part of the error.
+    /// The information is written into a caller-provided buffer. If the buffer
+    /// is too small, the error contains the required size.
     ///
-    /// The buffer must be aligned on an `<Info as Align>::alignment()` boundary.
+    /// The buffer must satisfy `Info`'s [`crate::data_types::Align`] requirement.
     ///
     /// # Arguments
-    /// * `buffer`  Buffer that the information should be written into
+    ///
+    /// - `buffer`: Destination buffer for the requested information.
     ///
     /// # Errors
     ///
@@ -152,15 +155,14 @@ pub trait File: Sized {
         )
     }
 
-    /// Sets some information about a file
+    /// Sets information about a file.
     ///
-    /// There are various restrictions on the information that may be modified using this method.
-    /// The simplest one is that it is usually not possible to call it on read-only media. Further
-    /// restrictions specific to a given information type are described in the corresponding
-    /// `FileProtocolInfo` type documentation.
+    /// The corresponding [`FileProtocolInfo`] implementation documents which
+    /// fields may be modified. Read-only media generally rejects changes.
     ///
     /// # Arguments
-    /// * `info`  Info that should be set for the file
+    ///
+    /// - `info`: Information to apply to the file.
     ///
     /// # Errors
     ///
@@ -181,7 +183,7 @@ pub trait File: Sized {
         unsafe { (self.imp().set_info)(self.imp(), &Info::GUID, info_size, info_ptr).to_result() }
     }
 
-    /// Flushes all modified data associated with the file handle to the device
+    /// Flushes all modified data associated with the file handle to the device.
     ///
     /// # Errors
     ///
@@ -198,7 +200,7 @@ pub trait File: Sized {
         unsafe { (self.imp().flush)(self.imp()) }.to_result()
     }
 
-    /// Read the dynamically allocated info for a file.
+    /// Reads dynamically allocated information for a file.
     #[cfg(feature = "alloc")]
     fn get_boxed_info<Info: FileProtocolInfo + ?Sized + Debug>(&mut self) -> Result<Box<Info>> {
         let fetch_data_fn = |buf| self.get_info::<Info>(buf);
@@ -206,16 +208,22 @@ pub trait File: Sized {
         Ok(file_info)
     }
 
-    /// Returns if the underlying file is a regular file.
-    /// The result is an error if the underlying file was already closed or deleted.
+    /// Returns whether the underlying file is a regular file.
     ///
     /// UEFI file system protocol only knows "regular files" and "directories".
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file was already closed or deleted.
     fn is_regular_file(&self) -> Result<bool>;
 
-    /// Returns if the underlying file is a directory.
-    /// The result is an error if the underlying file was already closed or deleted.
+    /// Returns whether the underlying file is a directory.
     ///
     /// UEFI file system protocol only knows "regular files" and "directories".
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file was already closed or deleted.
     fn is_directory(&self) -> Result<bool>;
 }
 

--- a/uefi/src/proto/media/file/mod.rs
+++ b/uefi/src/proto/media/file/mod.rs
@@ -343,13 +343,13 @@ pub enum FileType {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u64)]
 pub enum FileMode {
-    /// The file can be read from
+    /// Opens the file for reading.
     Read = 1,
 
-    /// The file can be read from and written to
+    /// Opens the file for reading and writing.
     ReadWrite = 2 | 1,
 
-    /// The file can be read, written, and will be created if it does not exist
+    /// Opens the file for reading and writing, creating it if necessary.
     CreateReadWrite = (1 << 63) | 2 | 1,
 }
 

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -42,8 +42,6 @@ impl RegularFile {
     /// * [`Status::DEVICE_ERROR`]
     /// * [`Status::VOLUME_CORRUPTED`]
     ///
-    /// # Quirks
-    ///
     /// Some UEFI implementations have a bug where large reads will incorrectly
     /// return an error. This function avoids that bug by reading in chunks of
     /// no more than 1 MiB. This is handled internally within the function;

--- a/uefi/src/proto/media/file/regular.rs
+++ b/uefi/src/proto/media/file/regular.rs
@@ -13,25 +13,26 @@ use crate::{Error, Result, Status, StatusExt};
 pub struct RegularFile(FileHandle);
 
 impl RegularFile {
-    /// A special position used to seek to the end of a file with `set_position()`.
+    /// Position used by [`Self::set_position`] to seek to the end of a file.
     pub const END_OF_FILE: u64 = u64::MAX;
 
-    /// Coverts a `FileHandle` into a `RegularFile` without checking the file kind.
+    /// Converts a [`FileHandle`] without checking that it is a regular file.
+    ///
     /// # Safety
-    /// This function should only be called on handles which ARE NOT directories,
-    /// doing otherwise is unsafe.
+    ///
+    /// `handle` must not represent a directory.
     #[must_use]
     pub const unsafe fn new(handle: FileHandle) -> Self {
         Self(handle)
     }
 
-    /// Read data from file.
+    /// Reads data from the file.
     ///
-    /// Try to read as much as possible into `buffer`. Returns the number of bytes that were
-    /// actually read.
+    /// Attempts to fill `buffer` and returns the number of bytes read.
     ///
     /// # Arguments
-    /// * `buffer`  The target buffer of the read operation
+    ///
+    /// - `buffer`: Destination buffer for the file data.
     ///
     /// # Errors
     ///
@@ -79,15 +80,16 @@ impl RegularFile {
         )
     }
 
-    /// Write data to file
+    /// Writes data to the file.
     ///
-    /// Write `buffer` to file, increment the file pointer.
+    /// Writing advances the file position.
     ///
     /// If an error occurs, returns the number of bytes that were actually written. If no error
     /// occurred, the entire buffer is guaranteed to have been written successfully.
     ///
     /// # Arguments
-    /// * `buffer`  Buffer to write to file
+    ///
+    /// - `buffer`: Data to write to the file.
     ///
     /// # Errors
     ///
@@ -106,7 +108,7 @@ impl RegularFile {
             .to_result_with_err(|_| buffer_size)
     }
 
-    /// Get the file's current position
+    /// Returns the file's current position.
     ///
     /// # Errors
     ///
@@ -119,15 +121,16 @@ impl RegularFile {
         unsafe { (self.imp().get_position)(self.imp(), &mut pos) }.to_result_with_val(|| pos)
     }
 
-    /// Sets the file's current position
+    /// Sets the file's current position.
     ///
     /// Set the position of this file handle to the absolute position specified by `position`.
     ///
     /// Seeking past the end of the file is allowed, it will trigger file growth on the next write.
-    /// Using a position of RegularFile::END_OF_FILE will seek to the end of the file.
+    /// Using [`RegularFile::END_OF_FILE`] seeks to the end of the file.
     ///
     /// # Arguments
-    /// * `position` The new absolution position of the file handle
+    ///
+    /// - `position`: New absolute file position.
     ///
     /// # Errors
     ///

--- a/uefi/src/proto/media/load_file.rs
+++ b/uefi/src/proto/media/load_file.rs
@@ -42,26 +42,26 @@ impl LoadFile {
     /// Causes the driver to load a specified file.
     ///
     /// # Arguments
-    /// - `file_path` The device specific path of the file to load.
-    /// - `boot_policy` The [`BootPolicy`] to use.
+    ///
+    /// - `file_path`: Device-specific path of the file to load.
+    /// - `boot_policy`: Policy used to locate and load the file.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The file was loaded.
-    /// - [`Status::UNSUPPORTED`] The device does not support the
+    /// - [`Status::UNSUPPORTED`]: the device does not support the
     ///   provided BootPolicy.
-    /// - [`Status::INVALID_PARAMETER`] FilePath is not a valid device
+    /// - [`Status::INVALID_PARAMETER`]: `file_path` is not a valid device
     ///   path, or BufferSize is NULL.
-    /// - [`Status::NO_MEDIA`] No medium was present to load the file.
-    /// - [`Status::DEVICE_ERROR`] The file was not loaded due to a
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the file was not loaded due to a
     ///   device error.
-    /// - [`Status::NO_RESPONSE`] The remote system did not respond.
-    /// - [`Status::NOT_FOUND`] The file was not found.
-    /// - [`Status::ABORTED`] The file load process was manually
+    /// - [`Status::NO_RESPONSE`]: the remote system did not respond.
+    /// - [`Status::NOT_FOUND`]: the file was not found.
+    /// - [`Status::ABORTED`]: the file load process was manually
     ///   cancelled.
-    /// - [`Status::BUFFER_TOO_SMALL`] The BufferSize is too small to
+    /// - [`Status::BUFFER_TOO_SMALL`]: the supplied buffer is too small to
     ///   read the current directory entry. BufferSize has been updated with the
     ///   size needed to complete the request.
-    /// - [`Status::WARN_FILE_SYSTEM`] The resulting Buffer contains
+    /// - [`Status::WARN_FILE_SYSTEM`]: the resulting buffer contains
     ///   UEFI-compliant file system.
     ///
     /// [`BootPolicy`]: uefi::proto::BootPolicy
@@ -114,21 +114,21 @@ impl LoadFile2 {
     /// Causes the driver to load a specified file.
     ///
     /// # Arguments
-    /// - `file_path` The device specific path of the file to load.
+    ///
+    /// - `file_path`: Device-specific path of the file to load.
     ///
     /// # Errors
-    /// - [`Status::SUCCESS`] The file was loaded.
-    /// - [`Status::UNSUPPORTED`] BootPolicy is TRUE.
-    /// - [`Status::INVALID_PARAMETER`] FilePath is not a valid device
+    /// - [`Status::UNSUPPORTED`]: the boot policy is `true`.
+    /// - [`Status::INVALID_PARAMETER`]: `file_path` is not a valid device
     ///   path, or BufferSize is NULL.
-    /// - [`Status::NO_MEDIA`] No medium was present to load the file.
-    /// - [`Status::DEVICE_ERROR`] The file was not loaded due to a
+    /// - [`Status::NO_MEDIA`]: no medium is present.
+    /// - [`Status::DEVICE_ERROR`]: the file was not loaded due to a
     ///   device error.
-    /// - [`Status::NO_RESPONSE`] The remote system did not respond.
-    /// - [`Status::NOT_FOUND`] The file was not found.
-    /// - [`Status::ABORTED`] The file load process was manually
+    /// - [`Status::NO_RESPONSE`]: the remote system did not respond.
+    /// - [`Status::NOT_FOUND`]: the file was not found.
+    /// - [`Status::ABORTED`]: the file load process was manually
     ///   cancelled.
-    /// - [`Status::BUFFER_TOO_SMALL`] The BufferSize is too small to
+    /// - [`Status::BUFFER_TOO_SMALL`]: the supplied buffer is too small to
     ///   read the current directory entry. BufferSize has been updated with the
     ///   size needed to complete the request.
     #[cfg(feature = "alloc")]

--- a/uefi/src/proto/media/partition.rs
+++ b/uefi/src/proto/media/partition.rs
@@ -183,7 +183,7 @@ pub struct GptPartitionEntry {
 }
 
 impl GptPartitionEntry {
-    /// Get the number of blocks in the partition. Returns `None` if the
+    /// Returns the partition's block count, or `None` if the
     /// end block is before the start block, or if the number doesn't
     /// fit in a `u64`.
     #[must_use]
@@ -249,7 +249,7 @@ impl PartitionInfo {
         self.system == 1
     }
 
-    /// Get the MBR partition record. Returns None if the partition
+    /// Returns the MBR partition record, or `None` if the partition
     /// type is not MBR.
     #[must_use]
     pub fn mbr_partition_record(&self) -> Option<&MbrPartitionRecord> {
@@ -265,7 +265,7 @@ impl PartitionInfo {
         }
     }
 
-    /// Get the GPT partition entry. Returns None if the partition
+    /// Returns the GPT partition entry, or `None` if the partition
     /// type is not GPT.
     #[must_use]
     pub fn gpt_partition_entry(&self) -> Option<&GptPartitionEntry> {

--- a/uefi/src/proto/misc.rs
+++ b/uefi/src/proto/misc.rs
@@ -13,27 +13,29 @@ use crate::{Result, StatusExt};
 ///
 /// Protocol for retrieving a high-resolution timestamp counter.
 ///
-/// # Note
-/// If your UEFI firmware not support timestamp protocol which first added at
-/// UEFI spec 2.4 2013. you also could use `RDTSC` in rust, here is a demo
-/// [Slint-UI](https://github.com/slint-ui/slint/blob/2c0ba2bc0f151eba8d1fa17839fa2ac58832ca80/examples/uefi-demo/main.rs#L28-L62)
-/// who use uefi-rs.
+/// Firmware predating UEFI 2.4 may not support this protocol. On x86, `RDTSC`
+/// can provide an alternative; the [Slint UEFI demo] shows one implementation.
 ///
 /// [`Protocol`]: uefi::proto::Protocol
+/// [Slint UEFI demo]: https://github.com/slint-ui/slint/blob/2c0ba2bc0f151eba8d1fa17839fa2ac58832ca80/examples/uefi-demo/main.rs#L28-L62
 #[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(TimestampProtocol::GUID)]
 pub struct Timestamp(TimestampProtocol);
 
 impl Timestamp {
-    /// Get the current value of the timestamp counter.
+    /// Returns the current timestamp-counter value.
     #[must_use]
     pub fn get_timestamp(&self) -> u64 {
         // SAFETY: The memory is valid.
         unsafe { (self.0.get_timestamp)() }
     }
 
-    /// Get the properties of the timestamp counter.
+    /// Returns the timestamp-counter properties.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot report the counter properties.
     pub fn get_properties(&self) -> Result<TimestampProperties> {
         let mut properties = TimestampProperties::default();
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/mod.rs
+++ b/uefi/src/proto/mod.rs
@@ -101,14 +101,14 @@ pub trait Protocol: Identify {}
 /// simply casts the pointer to the appropriate type. Protocols that
 /// are not sized must provide a custom implementation.
 pub trait ProtocolPointer: Protocol {
-    /// Create a const pointer to a [`Protocol`] from a [`c_void`] pointer.
+    /// Casts a [`c_void`] pointer to a const protocol pointer.
     ///
     /// # Safety
     ///
     /// The input pointer must point to valid data.
     unsafe fn ptr_from_ffi(ptr: *const c_void) -> *const Self;
 
-    /// Create a mutable pointer to a [`Protocol`] from a [`c_void`] pointer.
+    /// Casts a [`c_void`] pointer to a mutable protocol pointer.
     ///
     /// # Safety
     ///

--- a/uefi/src/proto/network/http.rs
+++ b/uefi/src/proto/network/http.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "alloc")]
 
-//! HTTP Protocol.
+//! UEFI HTTP protocol.
 //!
 //! See [`Http`].
 
@@ -22,7 +22,7 @@ use uefi_raw::protocol::network::http::{
     HttpRequestData, HttpResponseData, HttpStatusCode, HttpToken, HttpV4AccessPoint, HttpVersion,
 };
 
-/// HTTP [`Protocol`]. Send HTTP Requests.
+/// Sends and receives HTTP messages through the UEFI HTTP protocol.
 ///
 /// [`Protocol`]: uefi::proto::Protocol
 #[derive(Debug)]
@@ -30,7 +30,11 @@ use uefi_raw::protocol::network::http::{
 pub struct Http(HttpProtocol);
 
 impl Http {
-    /// Receive HTTP Protocol configuration.
+    /// Returns the current HTTP configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot report the configuration.
     pub fn get_mode_data(&mut self) -> uefi::Result<HttpConfigData> {
         let mut config_data = HttpConfigData::default();
         // SAFETY: The memory is valid.
@@ -41,7 +45,14 @@ impl Http {
         }
     }
 
-    /// Configure HTTP Protocol.  Must be called before sending HTTP requests.
+    /// Configures the HTTP protocol.
+    ///
+    /// This must be called before sending requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware rejects the configuration or cannot
+    /// initialize the network stack.
     pub fn configure(&mut self, config_data: &HttpConfigData) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.configure)(&mut self.0, config_data) };
@@ -52,7 +63,12 @@ impl Http {
         }
     }
 
-    /// Send HTTP request.
+    /// Queues an HTTP request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the token is invalid or firmware cannot queue the
+    /// request.
     pub fn request(&mut self, token: &mut HttpToken) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.request)(&mut self.0, token) };
@@ -70,7 +86,12 @@ impl Http {
         }
     }
 
-    /// Cancel HTTP request.
+    /// Cancels an HTTP transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the token is invalid or firmware cannot cancel the
+    /// transaction.
     pub fn cancel(&mut self, token: &mut HttpToken) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.cancel)(&mut self.0, token) };
@@ -80,7 +101,12 @@ impl Http {
         }
     }
 
-    /// Receive HTTP response.
+    /// Queues an HTTP response operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the token is invalid or firmware cannot queue the
+    /// response operation.
     pub fn response(&mut self, token: &mut HttpToken) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.response)(&mut self.0, token) };
@@ -96,7 +122,11 @@ impl Http {
         }
     }
 
-    /// Poll network stack for updates.
+    /// Polls the network stack for progress.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the protocol is not configured or polling fails.
     pub fn poll(&mut self) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.poll)(&mut self.0) };
@@ -107,13 +137,17 @@ impl Http {
     }
 }
 
-/// HTTP Service Binding Protocol.
+/// HTTP service-binding protocol.
 #[derive(Debug)]
 #[unsafe_protocol(HttpProtocol::SERVICE_BINDING_GUID)]
 pub struct HttpBinding(ServiceBindingProtocol);
 
 impl HttpBinding {
-    /// Create HTTP Protocol Handle.
+    /// Creates a child handle with an HTTP protocol instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot create the child handle.
     pub fn create_child(&mut self) -> uefi::Result<Handle> {
         let mut c_handle = ptr::null_mut();
         let status;
@@ -129,7 +163,12 @@ impl HttpBinding {
         }
     }
 
-    /// Destroy HTTP Protocol Handle.
+    /// Destroys an HTTP child handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `handle` is not a child of this binding or firmware
+    /// cannot destroy it.
     pub fn destroy_child(&mut self, handle: Handle) -> uefi::Result<()> {
         // SAFETY: The memory is valid.
         let status = unsafe { (self.0.destroy_child)(&mut self.0, handle.as_ptr()) };
@@ -140,20 +179,20 @@ impl HttpBinding {
     }
 }
 
-/// Representation of the underlying UEFI HTTP response.
+/// Response returned by [`HttpHelper`].
 ///
 /// Helper type for [`HttpHelper`].
 #[derive(Debug)]
 pub struct HttpHelperResponse {
-    /// HTTP Status
+    /// HTTP status code.
     pub status: HttpStatusCode,
-    /// HTTP Response Headers
+    /// HTTP response headers.
     pub headers: Vec<(String, String)>,
     /// Partial or entire HTTP body, depending on context.
     pub body: Vec<u8>,
 }
 
-/// HTTP Helper, makes using the [HTTP] [`Protocol`] more convenient.
+/// Convenience wrapper around the UEFI [HTTP] [`Protocol`].
 ///
 /// [HTTP]: Http
 /// [`Protocol`]: uefi::proto::Protocol
@@ -165,7 +204,12 @@ pub struct HttpHelper {
 }
 
 impl HttpHelper {
-    /// Create new HTTP helper instance for the given NIC handle.
+    /// Creates an HTTP helper for a network-interface handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the service binding cannot be opened, a child cannot
+    /// be created, or its HTTP protocol cannot be opened.
     pub fn new(nic_handle: Handle) -> uefi::Result<Self> {
         // SAFETY: The memory is valid.
         let mut binding = unsafe {
@@ -207,7 +251,12 @@ impl HttpHelper {
         })
     }
 
-    /// Configure the HTTP Protocol with some sane defaults.
+    /// Configures the HTTP protocol with IPv4 defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware rejects the configuration or cannot
+    /// initialize the network stack.
     pub fn configure(&mut self) -> uefi::Result<()> {
         let ip4 = HttpV4AccessPoint {
             use_default_addr: true.into(),
@@ -227,7 +276,22 @@ impl HttpHelper {
         Ok(())
     }
 
-    /// Send HTTP request
+    /// Sends an HTTP request and waits for completion.
+    ///
+    /// # Arguments
+    ///
+    /// - `method`: HTTP method to send.
+    /// - `url`: Absolute URL, including a host component.
+    /// - `body`: Optional request body.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the URL has no host, firmware rejects the request,
+    /// or polling fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `url` cannot be represented as a null-terminated UCS-2 string.
     pub fn request(
         &mut self,
         method: HttpMethod,
@@ -299,24 +363,40 @@ impl HttpHelper {
         Ok(())
     }
 
-    /// Send HTTP GET request
+    /// Sends an HTTP GET request and waits for completion.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors documented by [`Self::request`].
     pub fn request_get(&mut self, url: &str) -> uefi::Result<()> {
         self.request(HttpMethod::GET, url, None)?;
         Ok(())
     }
 
-    /// Send HTTP HEAD request
+    /// Sends an HTTP HEAD request and waits for completion.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors documented by [`Self::request`].
     pub fn request_head(&mut self, url: &str) -> uefi::Result<()> {
         self.request(HttpMethod::HEAD, url, None)?;
         Ok(())
     }
 
-    /// Receive the start of the http response, the headers and (parts of) the
-    /// body.
+    /// Receives the response status, headers, and initial body data.
     ///
     /// Depending on the HTTP response, its length, its encoding, and its
     /// transmission method (chunked or not), users may have to call
     /// [`Self::response_more`] afterward.
+    ///
+    /// # Arguments
+    ///
+    /// - `expect_body`: Whether to allocate a buffer for initial body data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot receive the response or polling
+    /// fails.
     pub fn response_first(&mut self, expect_body: bool) -> uefi::Result<HttpHelperResponse> {
         let mut rx_rsp = HttpResponseData {
             status_code: HttpStatusCode::STATUS_UNSUPPORTED,
@@ -383,8 +463,11 @@ impl HttpHelper {
         Ok(rsp)
     }
 
-    /// Try to receive more of the HTTP response and append any new data to the
-    /// provided  `body` vector.
+    /// Appends the next response-body chunk to `body`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot receive more data or polling fails.
     pub fn response_more<'a>(&mut self, body: &'a mut Vec<u8>) -> uefi::Result<&'a [u8]> {
         let mut body_recv_buffer = vec![0; 16 * 1024];
         let mut rx_msg = HttpMessage {

--- a/uefi/src/proto/network/snp.rs
+++ b/uefi/src/proto/network/snp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Simple Network Protocol
+//! UEFI Simple Network protocol.
 //!
 //! Provides a packet level interface to a network adapter.
 //! Once the adapter is initialized, the protocol provides services that allows
@@ -33,42 +33,79 @@ pub use uefi_raw::protocol::network::snp::{
 pub struct SimpleNetwork(SimpleNetworkProtocol);
 
 impl SimpleNetwork {
-    /// Change the state of a network from "Stopped" to "Started".
+    /// Changes the network state from stopped to started.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not stopped or cannot be started.
     pub fn start(&self) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.start)(&self.0) }.to_result()
     }
 
-    /// Change the state of a network interface from "Started" to "Stopped".
+    /// Changes the network state from started to stopped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not started or cannot be stopped.
     pub fn stop(&self) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.stop)(&self.0) }.to_result()
     }
 
-    /// Reset a network adapter and allocate the transmit and receive buffers
-    /// required by the network interface; optionally, also request allocation of
-    /// additional transmit and receive buffers.
+    /// Initializes the network adapter and its transmit and receive buffers.
+    ///
+    /// # Arguments
+    ///
+    /// - `extra_rx_buffer_size`: Additional receive-buffer bytes to allocate.
+    /// - `extra_tx_buffer_size`: Additional transmit-buffer bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not started or initialization fails.
     pub fn initialize(&self, extra_rx_buffer_size: usize, extra_tx_buffer_size: usize) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.initialize)(&self.0, extra_rx_buffer_size, extra_tx_buffer_size) }
             .to_result()
     }
 
-    /// Reset a network adapter and reinitialize it with the parameters that were
-    /// provided in the previous call to `initialize`.
+    /// Reinitializes the adapter with its previous parameters.
+    ///
+    /// # Arguments
+    ///
+    /// - `extended_verification`: Whether to perform additional diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not initialized or reset fails.
     pub fn reset(&self, extended_verification: bool) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.reset)(&self.0, Boolean::from(extended_verification)) }.to_result()
     }
 
-    /// Reset a network adapter, leaving it in a state that is safe
-    /// for another driver to initialize
+    /// Shuts down the adapter for use by another driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not initialized or shutdown fails.
     pub fn shutdown(&self) -> Result {
         // SAFETY: The memory is valid.
         unsafe { (self.0.shutdown)(&self.0) }.to_result()
     }
 
     /// Manage the multicast receive filters of a network.
+    ///
+    /// # Arguments
+    ///
+    /// - `enable`: Receive filters to enable.
+    /// - `disable`: Receive filters to disable.
+    /// - `reset_mcast_filter`: Whether to clear the multicast filter list first.
+    /// - `mcast_filter`: Multicast addresses to add to the filter list.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the flags or addresses are invalid, unsupported, or
+    /// cannot be applied.
     pub fn receive_filters(
         &self,
         enable: ReceiveFlags,
@@ -96,6 +133,15 @@ impl SimpleNetwork {
     }
 
     /// Modify or reset the current station address, if supported.
+    ///
+    /// # Arguments
+    ///
+    /// - `reset`: Whether to restore the permanent station address.
+    /// - `new`: New station address when `reset` is `false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if changing the address is unsupported or fails.
     pub fn station_address(&self, reset: bool, new: Option<&EfiMacAddr>) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -109,6 +155,10 @@ impl SimpleNetwork {
     }
 
     /// Reset statistics on a network interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if statistics are unsupported or cannot be reset.
     pub fn reset_statistics(&self) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -123,6 +173,10 @@ impl SimpleNetwork {
     }
 
     /// Collect statistics on a network interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if statistics are unsupported or cannot be read.
     pub fn collect_statistics(&self) -> Result<NetworkStatistics> {
         let mut stats_table: NetworkStatistics = Default::default();
         let mut stats_size = size_of::<NetworkStatistics>();
@@ -138,7 +192,16 @@ impl SimpleNetwork {
         status.to_result_with_val(|| stats_table)
     }
 
-    /// Convert a multicast IP address to a multicast HW MAC Address.
+    /// Converts a multicast IP address to a hardware MAC address.
+    ///
+    /// # Arguments
+    ///
+    /// - `ipv6`: Whether `ip` is interpreted as an IPv6 address.
+    /// - `ip`: Multicast address to convert.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the address is invalid or conversion is unsupported.
     pub fn mcast_ip_to_mac(&self, ipv6: bool, ip: IpAddr) -> Result<EfiMacAddr> {
         let mut mac_address = EfiMacAddr([0; 32]);
         let ip = EfiIpAddr::from(ip);
@@ -154,8 +217,12 @@ impl SimpleNetwork {
         status.to_result_with_val(|| mac_address)
     }
 
-    /// Reads data from the NVRAM device attached to the network interface into
-    /// the provided `dst_buffer`.
+    /// Reads network-interface NVRAM into `dst_buffer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is invalid, NVRAM is unsupported, or the
+    /// read fails.
     pub fn read_nv_data(&self, offset: usize, dst_buffer: &mut [u8]) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -170,8 +237,12 @@ impl SimpleNetwork {
         .to_result()
     }
 
-    /// Writes data into the NVRAM device attached to the network interface from
-    /// the provided `src_buffer`.
+    /// Writes `src_buffer` to network-interface NVRAM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is invalid, NVRAM is unsupported or
+    /// read-only, or the write fails.
     pub fn write_nv_data(&self, offset: usize, src_buffer: &[u8]) -> Result {
         // SAFETY: The memory is valid.
         unsafe {
@@ -187,8 +258,12 @@ impl SimpleNetwork {
         .to_result()
     }
 
-    /// Read the current interrupt status and recycled transmit buffer
-    /// status from a network interface.
+    /// Returns the current network interrupt status.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not initialized or status cannot be
+    /// read.
     pub fn get_interrupt_status(&self) -> Result<InterruptStatus> {
         let mut interrupt_status = InterruptStatus::empty();
         let status =
@@ -197,8 +272,12 @@ impl SimpleNetwork {
         status.to_result_with_val(|| interrupt_status)
     }
 
-    /// Read the current recycled transmit buffer status from a
-    /// network interface.
+    /// Returns the next recycled transmit buffer, if available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the interface is not initialized or status cannot be
+    /// read.
     pub fn get_recycled_transmit_buffer_status(&self) -> Result<Option<NonNull<u8>>> {
         let mut tx_buf: *mut c_void = ptr::null_mut();
         // SAFETY: The memory is valid.
@@ -232,6 +311,11 @@ impl SimpleNetwork {
     ///   `0x0800` (IPv4) or `0x0806` (ARP).
     ///
     /// [ethertype]: https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the packet parameters are invalid, the transmit queue
+    /// is full, or transmission fails.
     pub fn transmit(
         &self,
         header_size: usize,
@@ -257,7 +341,20 @@ impl SimpleNetwork {
 
     /// Receive a packet from a network interface.
     ///
-    /// On success, returns the size of bytes of the received packet.
+    /// On success, returns the number of bytes received.
+    ///
+    /// # Arguments
+    ///
+    /// - `buffer`: Destination for the packet, including its media header.
+    /// - `header_size`: Optional output for the media-header size.
+    /// - `src_addr`: Optional output for the source hardware address.
+    /// - `dest_addr`: Optional output for the destination hardware address.
+    /// - `protocol`: Optional output for the network protocol.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no packet is ready, `buffer` is too small, or receive
+    /// fails.
     pub fn receive(
         &self,
         buffer: &mut [u8],
@@ -284,8 +381,12 @@ impl SimpleNetwork {
 
     /// Event that fires once a packet is available to be received.
     ///
-    /// On QEMU, this event seems to never fire; it is suggested to verify that your implementation
-    /// of UEFI properly implements this event before using it.
+    /// On QEMU, this event seems to never fire. Verify that the target firmware
+    /// implements it correctly before relying on it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Status::UNSUPPORTED`] if firmware provides no event.
     pub fn wait_for_packet_event(&self) -> Result<Event> {
         // SAFETY: The memory is valid.
         unsafe { Event::from_ptr(self.0.wait_for_packet) }.ok_or(Error::from(Status::UNSUPPORTED))

--- a/uefi/src/proto/nvme/mod.rs
+++ b/uefi/src/proto/nvme/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! NVM Express Protocols.
+//! NVM Express protocols.
 
 use crate::mem::{AlignedBuffer, AlignmentError};
 use core::alloc::LayoutError;
@@ -13,26 +13,22 @@ use uefi_raw::protocol::nvme::{
 
 pub mod pass_thru;
 
-/// Represents the completion status of an NVMe command.
+/// Completion status of an NVMe command.
 ///
-/// This structure contains various fields related to the status and results
-/// of an executed command, including fields for error codes, specific command IDs,
-/// and general state of the NVMe device.
+/// Contains error codes, command identifiers, and controller state returned by
+/// an executed command.
 pub type NvmeCompletion = uefi_raw::protocol::nvme::NvmExpressCompletion;
 
-/// Type of queues an NVMe command can be placed into
-/// (Which queue a command should be placed into depends on the command)
+/// Queue on which to submit an NVMe command.
+///
+/// The selected command determines which queue type is valid.
 pub type NvmeQueueType = uefi_raw::protocol::nvme::NvmExpressQueueType;
 
-/// Represents a request for executing an NVMe command.
+/// Request for executing an NVMe command.
 ///
-/// This structure encapsulates the command to be sent to the NVMe device, along with
-/// optional data transfer and metadata buffers. It ensures proper alignment and safety
-/// during interactions with the NVMe protocol.
-///
-/// # Lifetime
-/// `'buffers`: Makes sure the io-buffers bound to the built request
-/// stay alive until the response was interpreted.
+/// Contains the command and optional transfer and metadata buffers. The
+/// `'buffers` lifetime keeps attached I/O buffers alive while the response is
+/// interpreted.
 #[derive(Debug)]
 pub struct NvmeRequest<'buffers> {
     io_align: u32,
@@ -49,17 +45,14 @@ pub struct NvmeRequest<'buffers> {
 // This macro generates one such setter method.
 macro_rules! define_nvme_command_builder_with_cdw {
     ($fnname:ident: $fieldname:ident => $flagmask:expr) => {
-        /// Set the $fieldname parameter on the constructed nvme command.
-        /// This also automatically flags the parameter as valid in the command's `flags` field.
+        /// Sets the `$fieldname` field and marks it valid in the command's
+        /// `flags` field.
         ///
-        /// # About NVMe commands
-        /// NVMe commands are constructed of a bunch of numbered CDWs (command data words) and a `flags` field.
-        /// The `flags´ field tells the NVMe controller which CDWs was set and whether it should respect
-        /// the corresponding CDWs value.
-        /// CDWs have no fixed interpretation - the interpretation depends on the command to execute.
-        /// Which CDWs have to be supplied (and enabled in the `flags` field) depends on the command that
-        /// should be sent to and executed by the controller.
-        /// See: <https://nvmexpress.org/specifications/>
+        /// Command data words (CDWs) are interpreted by the selected command.
+        /// Consult the [NVMe specifications] to determine which CDWs it
+        /// requires.
+        ///
+        /// [NVMe specifications]: https://nvmexpress.org/specifications/
         #[must_use]
         pub const fn $fnname(mut self, $fieldname: u32) -> Self {
             self.req.cmd.$fieldname = $fieldname;
@@ -71,29 +64,21 @@ macro_rules! define_nvme_command_builder_with_cdw {
 
 /// Builder for constructing an NVMe request.
 ///
-/// This structure provides convenient methods for configuring NVMe commands,
-/// including parameters like command-specific data words (CDWs)
-/// and optional buffers for transfer and metadata operations.
-///
-/// It ensures safe and ergonomic setup of NVMe requests.
-///
-/// # Lifetime
-/// `'buffers`: Makes sure the io-buffers bound to the built request
-/// stay alive until the response was interpreted.
+/// Its methods configure command data words (CDWs), transfer buffers, and
+/// metadata buffers. The `'buffers` lifetime keeps attached buffers alive
+/// while the response is interpreted.
 #[derive(Debug)]
 pub struct NvmeRequestBuilder<'buffers> {
     req: NvmeRequest<'buffers>,
 }
 impl<'buffers> NvmeRequestBuilder<'buffers> {
-    /// Creates a new builder for configuring an NVMe request.
+    /// Creates a new builder for an NVMe command.
     ///
     /// # Arguments
-    /// - `io_align`: Memory alignment requirements for buffers.
-    /// - `opcode`: The opcode for the NVMe command.
-    /// - `queue_type`: Specifies the type of queue the command should be placed into.
     ///
-    /// # Returns
-    /// An instance of [`NvmeRequestBuilder`] for further configuration.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    /// - `opcode`: Opcode placed in command data word zero.
+    /// - `queue_type`: Queue on which to submit the command.
     #[must_use]
     pub fn new(io_align: u32, opcode: u8, queue_type: NvmeQueueType) -> Self {
         Self {
@@ -120,7 +105,7 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
         }
     }
 
-    /// Configure the given timeout for this request.
+    /// Sets this request's timeout in 100-nanosecond units.
     #[must_use]
     pub const fn with_timeout(mut self, timeout: Duration) -> Self {
         self.req.packet.command_timeout = (timeout.as_nanos() / 100) as u64;
@@ -140,17 +125,15 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
     // # TRANSFER BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied buffer for reading data from the device.
+    /// Uses a caller-provided transfer buffer.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] that will be used to store data read from the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Buffer used for the command's data transfer.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `transfer_buffer` of the underlying [`NvmeRequest`].
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not satisfy the required alignment.
     pub fn use_transfer_buffer(
         mut self,
         bfr: &'buffers mut AlignedBuffer,
@@ -163,13 +146,16 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
         Ok(self)
     }
 
-    /// Adds a newly allocated transfer buffer to the built NVMe request.
+    /// Allocates a transfer buffer for the NVMe request.
     ///
     /// # Arguments
-    /// - `len`: The size of the buffer (in bytes) to allocate for receiving data.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `len`: Number of bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn with_transfer_buffer(mut self, len: usize) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(len, self.req.io_align as usize)?;
         self.req.packet.transfer_buffer = bfr.ptr_mut().cast();
@@ -184,14 +170,12 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
     /// Uses a user-supplied metadata buffer.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] that will be used to store metadata.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Metadata buffer to attach to the request.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `meta_data_buffer` of the underlying [`NvmeRequest`].
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not satisfy the required alignment.
     pub fn use_metadata_buffer(
         mut self,
         bfr: &'buffers mut AlignedBuffer,
@@ -204,13 +188,16 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
         Ok(self)
     }
 
-    /// Adds a newly allocated metadata buffer to the built NVMe request.
+    /// Allocates a metadata buffer for the NVMe request.
     ///
     /// # Arguments
-    /// - `len`: The size of the buffer (in bytes) to allocate for storing metadata.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `len`: Number of bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn with_metadata_buffer(mut self, len: usize) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(len, self.req.io_align as usize)?;
         self.req.packet.meta_data_buffer = bfr.ptr_mut().cast();
@@ -219,33 +206,24 @@ impl<'buffers> NvmeRequestBuilder<'buffers> {
         Ok(self)
     }
 
-    /// Build the final [`NvmeRequest`].
-    ///
-    /// # Returns
-    /// A fully-configured [`NvmeRequest`] ready for execution.
+    /// Builds the configured [`NvmeRequest`].
     #[must_use]
     pub fn build(self) -> NvmeRequest<'buffers> {
         self.req
     }
 }
 
-/// Represents the response from executing an NVMe command.
+/// Response returned after executing an NVMe command.
 ///
-/// This structure encapsulates the original request, as well as the command's completion status.
-///
-/// # Lifetime
-/// `'buffers`: Makes sure the io-buffers bound to the built request
-/// stay alive until the response was interpreted.
+/// Contains the original request and command completion status. The `'buffers`
+/// lifetime keeps attached I/O buffers alive while the response is interpreted.
 #[derive(Debug)]
 pub struct NvmeResponse<'buffers> {
     req: NvmeRequest<'buffers>,
     completion: NvmeCompletion,
 }
 impl<'buffers> NvmeResponse<'buffers> {
-    /// Returns the buffer containing transferred data from the device (if any).
-    ///
-    /// # Returns
-    /// `Option<&[u8]>`: A slice of the transfer buffer, or `None` if the request was started without.
+    /// Returns the transfer buffer, if one was assigned to the request.
     #[must_use]
     pub const fn transfer_buffer(&self) -> Option<&'buffers [u8]> {
         if self.req.packet.transfer_buffer.is_null() {
@@ -260,10 +238,7 @@ impl<'buffers> NvmeResponse<'buffers> {
         }
     }
 
-    /// Returns the buffer containing metadata data from the device (if any).
-    ///
-    /// # Returns
-    /// `Option<&[u8]>`: A slice of the metadata buffer, or `None` if the request was started without.
+    /// Returns the metadata buffer, if one was assigned to the request.
     #[must_use]
     pub const fn metadata_buffer(&self) -> Option<&'buffers [u8]> {
         if self.req.packet.meta_data_buffer.is_null() {
@@ -278,10 +253,7 @@ impl<'buffers> NvmeResponse<'buffers> {
         }
     }
 
-    /// Provides access to the completion structure of the NVMe command.
-    ///
-    /// # Returns
-    /// A reference to the [`NvmeCompletion`] structure containing the status and results of the command.
+    /// Returns the completion status of the NVMe command.
     #[must_use]
     pub const fn completion(&self) -> &NvmeCompletion {
         &self.completion

--- a/uefi/src/proto/nvme/pass_thru.rs
+++ b/uefi/src/proto/nvme/pass_thru.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! NVM Express Pass Thru Protocol.
+//! NVM Express Pass Thru protocol.
 
 use super::{NvmeRequest, NvmeResponse};
 use crate::StatusExt;
@@ -14,10 +14,9 @@ use uefi_raw::Status;
 use uefi_raw::protocol::device_path::DevicePathProtocol;
 use uefi_raw::protocol::nvme::{NvmExpressCompletion, NvmExpressPassThruProtocol};
 
-/// Nvme Pass Thru Protocol Mode structure.
+/// NVMe Pass Thru mode.
 ///
-/// This contains information regarding the specific capabilities and requirements
-/// of the NVMe controller, such as buffer alignment constraints.
+/// Describes controller capabilities and requirements such as buffer alignment.
 pub type NvmePassThruMode = uefi_raw::protocol::nvme::NvmExpressPassThruMode;
 
 /// Identifier for an NVMe namespace.
@@ -30,9 +29,9 @@ pub type NvmeNamespaceId = u32;
 /// One protocol instance corresponds to one NVMe controller
 /// (which, most of the time, corresponds to one SSD).
 ///
-/// This API offers a safe and convenient, yet still low-level interface to NVMe devices.
-/// It is designed as a foundational layer, leaving higher-level abstractions responsible for implementing
-/// richer storage semantics, device-specific commands, and advanced use cases.
+/// This is a safe, convenient, but still low-level interface. Higher-level
+/// abstractions remain responsible for storage semantics and device-specific
+/// commands.
 ///
 /// # UEFI Specification
 /// The `EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL` provides essential functionality for interacting
@@ -44,10 +43,7 @@ pub type NvmeNamespaceId = u32;
 pub struct NvmePassThru(UnsafeCell<NvmExpressPassThruProtocol>);
 
 impl NvmePassThru {
-    /// Retrieves the mode of the NVMe Pass Thru protocol.
-    ///
-    /// # Returns
-    /// An instance of [`NvmePassThruMode`] describing the NVMe controller's capabilities.
+    /// Returns the NVMe Pass Thru mode.
     #[must_use]
     pub fn mode(&self) -> NvmePassThruMode {
         // SAFETY: The memory is valid.
@@ -56,40 +52,32 @@ impl NvmePassThru {
         mode
     }
 
-    /// Retrieves the alignment requirements for I/O buffers.
-    ///
-    /// # Returns
-    /// An alignment value (in bytes) that all I/O buffers must adhere to for successful operation.
+    /// Returns the required I/O buffer alignment in bytes.
     #[must_use]
     pub fn io_align(&self) -> u32 {
         self.mode().io_align
     }
 
-    /// Allocates an I/O buffer with the necessary alignment for this NVMe Controller.
+    /// Allocates an I/O buffer with the alignment required by this controller.
     ///
-    /// You can alternatively do this yourself using the [`AlignedBuffer`] helper directly.
-    /// The `nvme` api will validate that your buffers have the correct alignment and error
-    /// if they don't.
+    /// Callers can instead allocate an [`AlignedBuffer`] directly. NVMe request
+    /// builders validate user-provided buffer alignment.
     ///
     /// # Arguments
-    /// - `len`: The size (in bytes) of the buffer to allocate.
     ///
-    /// # Returns
-    /// [`AlignedBuffer`] containing the allocated memory.
+    /// - `len`: Number of bytes to allocate.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn alloc_io_buffer(&self, len: usize) -> Result<AlignedBuffer, LayoutError> {
         AlignedBuffer::from_size_align(len, self.io_align() as usize)
     }
 
-    /// Iterate over all valid namespaces on this NVMe controller.
+    /// Returns an iterator over all valid namespaces on this NVMe controller.
     ///
-    /// This ignores the 0-namespaces, which corresponds to the controller itself.
-    /// The iterator yields [`NvmeNamespace`] instances representing individual namespaces.
-    ///
-    /// # Returns
-    /// A [`NvmeNamespaceIterator`] for iterating through the namespaces.
+    /// This omits namespace zero, which represents the controller itself.
     #[must_use]
     pub const fn iter_namespaces(&self) -> NvmeNamespaceIterator<'_> {
         NvmeNamespaceIterator {
@@ -98,11 +86,8 @@ impl NvmePassThru {
         }
     }
 
-    /// Get the controller namespace (id = 0).
-    /// This can be used to send ADMIN commands.
-    ///
-    /// # Returns
-    /// A [`NvmeNamespace`] addressing the controller (nsid = 0).
+    /// Returns the controller namespace (ID 0), which can receive admin
+    /// commands.
     #[must_use]
     pub const fn controller(&self) -> NvmeNamespace<'_> {
         NvmeNamespace {
@@ -111,10 +96,7 @@ impl NvmePassThru {
         }
     }
 
-    /// Get the broadcast namespace (id = 0xffffffff).
-    ///
-    /// # Returns
-    /// A [`NvmeNamespace`] with nsid = 0xffffffff.
+    /// Returns the broadcast namespace (ID `0xffff_ffff`).
     #[must_use]
     pub const fn broadcast(&self) -> NvmeNamespace<'_> {
         NvmeNamespace {
@@ -126,8 +108,8 @@ impl NvmePassThru {
 
 /// Represents one namespace on an NVMe controller.
 ///
-/// A namespace is a shard of storage that the controller can be partitioned into.
-/// Typically, consumer devices only have a single namespace where all the data resides (id 1).
+/// A namespace is a partition of the controller's storage. Consumer devices
+/// typically expose one namespace with ID 1.
 #[derive(Debug)]
 pub struct NvmeNamespace<'a> {
     proto: &'a UnsafeCell<NvmExpressPassThruProtocol>,
@@ -135,16 +117,20 @@ pub struct NvmeNamespace<'a> {
 }
 
 impl NvmeNamespace<'_> {
-    /// Retrieves the namespace identifier (NSID) associated with this NVMe namespace.
+    /// Returns this namespace's identifier (NSID).
     #[must_use]
     pub const fn namespace_id(&self) -> NvmeNamespaceId {
         self.namespace_id
     }
 
-    /// Get the final device path node for this namespace.
+    /// Returns the final device path node for this namespace.
     ///
-    /// For a full [`crate::proto::device_path::DevicePath`] pointing to this namespace on the
-    /// corresponding NVMe controller.
+    /// Append this node to the controller's device path to form a complete
+    /// [`crate::proto::device_path::DevicePath`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot build the node or allocation fails.
     pub fn path_node(&self) -> crate::Result<PoolDevicePathNode> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -161,28 +147,16 @@ impl NvmeNamespace<'_> {
         }
     }
 
-    /// Sends an NVM Express command to this namespace (Namespace ID ≥ 1).
-    ///
-    /// # Arguments
-    /// - `req`: The [`NvmeRequest`] containing the command and associated data to send to the namespace.
-    ///
-    /// # Returns
-    /// - [`NvmeResponse`] containing the results of the operation, such as data and status.
+    /// Sends an NVM Express command to this namespace.
     ///
     /// # Errors
-    /// - [`Status::BAD_BUFFER_SIZE`] The NVM Express Command Packet was not executed. The number
-    ///   of bytes that could be transferred is returned in `TransferLength`.
-    /// - [`Status::NOT_READY`] The NVM Express Command Packet could not be sent because the controller
-    ///   is not ready. The caller may retry later.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to send the NVM Express
-    ///   Command Packet. Additional status information is available in `NvmeCompletion`.
-    /// - [`Status::INVALID_PARAMETER`] The Namespace ID or the contents of the Command Packet are invalid.
-    ///   The NVM Express Command Packet was not sent, and no additional status information is available.
-    /// - [`Status::UNSUPPORTED`] The command described by the NVM Express Command Packet is not supported
-    ///   by the NVM Express controller. The Command Packet was not sent, and no additional status
-    ///   information is available.
-    /// - [`Status::TIMEOUT`] A timeout occurred while executing the NVM Express Command Packet.
-    ///   Additional status information is available in `NvmeCompletion`.
+    /// - [`Status::BAD_BUFFER_SIZE`]: a buffer exceeds the allowed transfer
+    ///   size.
+    /// - [`Status::NOT_READY`]: the controller is not ready; retry later.
+    /// - [`Status::DEVICE_ERROR`]: the controller reported an error.
+    /// - [`Status::INVALID_PARAMETER`]: the namespace ID or request is invalid.
+    /// - [`Status::UNSUPPORTED`]: the controller does not support the command.
+    /// - [`Status::TIMEOUT`]: the command timed out.
     pub fn execute_command<'req>(
         &mut self,
         mut req: NvmeRequest<'req>,
@@ -207,8 +181,7 @@ impl NvmeNamespace<'_> {
 
 /// An iterator over the namespaces of an NVMe controller.
 ///
-/// The iterator yields [`NvmeNamespace`] instances, each representing one namespace
-/// on the NVMe controller.
+/// Each item represents one namespace on the controller.
 #[derive(Debug)]
 pub struct NvmeNamespaceIterator<'a> {
     proto: &'a UnsafeCell<NvmExpressPassThruProtocol>,

--- a/uefi/src/proto/pci/enumeration.rs
+++ b/uefi/src/proto/pci/enumeration.rs
@@ -49,7 +49,7 @@ struct PciHeader1Register6 {
     secondary_latency_timer: u8,
 }
 
-/// Read the 4byte pci register with the given `addr` and cast it into the given structured representation.
+/// Reads a four-byte PCI register and converts it to `T`.
 fn read_device_register_u32<T: Sized + Copy>(
     proto: &mut PciRootBridgeIo,
     addr: PciIoAddress,
@@ -149,7 +149,7 @@ impl PciTree {
         self.devices.iter()
     }
 
-    /// Get the segment number of this PCI tree.
+    /// Returns the segment number of this PCI tree.
     #[must_use]
     pub const fn segment_nr(&self) -> u32 {
         self.segment

--- a/uefi/src/proto/pci/enumeration.rs
+++ b/uefi/src/proto/pci/enumeration.rs
@@ -171,12 +171,11 @@ impl PciTree {
             .cloned()
     }
 
-    /// Construct a device path for the given PCI `addr` and append it to the given `root_path`.
+    /// Constructs a device path for `addr` below `root_path`.
     ///
     /// # Arguments
-    /// - `root_path`: The [`DevicePath`] instance corresponding to the [`PciRootBridgeIo`] instance that
-    ///   produced this [`PciTree`]. This path is prepended to the generated device paths.
-    /// - `addr`: [`PciIoAddress`] of the device
+    /// - `root_path`: Path of the [`PciRootBridgeIo`] that produced this tree.
+    /// - `addr`: Address of the PCI device.
     pub fn device_path(
         &self,
         root_path: &DevicePath,

--- a/uefi/src/proto/pci/enumeration.rs
+++ b/uefi/src/proto/pci/enumeration.rs
@@ -67,11 +67,11 @@ fn read_device_register_u32<T: Sized + Copy>(
 /// Error type used by the device path construction of [`PciTree`].
 #[derive(Debug)]
 pub enum PciDevicePathBuildError {
-    /// The given [`PciIoAddress`] was invalid or not path of the enumeration.
+    /// The address was invalid or not part of the enumeration.
     InvalidAddress,
-    /// Error while constructing the pci device DevicePath.
+    /// The PCI device path could not be built.
     PathBuildError(BuildError),
-    /// Error while
+    /// The Device Path Utilities protocol returned an error.
     DevicePathUtilitiesError(DevicePathUtilitiesError),
 }
 impl From<BuildError> for PciDevicePathBuildError {

--- a/uefi/src/proto/pci/mod.rs
+++ b/uefi/src/proto/pci/mod.rs
@@ -40,7 +40,7 @@ impl PciIoAddress {
         }
     }
 
-    /// Construct a new address with the bus address set to the given value
+    /// Creates an address with the given bus number.
     #[must_use]
     pub const fn with_bus(&self, bus: u8) -> Self {
         let mut addr = *self;
@@ -48,7 +48,7 @@ impl PciIoAddress {
         addr
     }
 
-    /// Construct a new address with the device address set to the given value
+    /// Creates an address with the given device number.
     #[must_use]
     pub const fn with_device(&self, dev: u8) -> Self {
         let mut addr = *self;
@@ -56,7 +56,7 @@ impl PciIoAddress {
         addr
     }
 
-    /// Construct a new address with the function address set to the given value
+    /// Creates an address with the given function number.
     #[must_use]
     pub const fn with_function(&self, fun: u8) -> Self {
         let mut addr = *self;

--- a/uefi/src/proto/pci/root_bridge.rs
+++ b/uefi/src/proto/pci/root_bridge.rs
@@ -30,13 +30,13 @@ use crate::Status;
 pub struct PciRootBridgeIo(PciRootBridgeIoProtocol);
 
 impl PciRootBridgeIo {
-    /// Get the segment number where this PCI root bridge resides.
+    /// Returns the segment number where this PCI root bridge resides.
     #[must_use]
     pub const fn segment_nr(&self) -> u32 {
         self.0.segment_number
     }
 
-    /// Access PCI controller registers in the configuration space on this root bridge.
+    /// Returns access to PCI configuration space on this root bridge.
     pub const fn pci(&mut self) -> PciIoAccess<'_, PciConfigurationSpace> {
         PciIoAccess {
             proto: &mut self.0,
@@ -45,7 +45,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Access PCI controller registers in the memory space on this root bridge.
+    /// Returns access to PCI memory space on this root bridge.
     pub const fn memory(&mut self) -> PciIoAccess<'_, PciMemorySpace> {
         PciIoAccess {
             proto: &mut self.0,
@@ -54,7 +54,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Access PCI controller registers in the I/O space on this root bridge.
+    /// Returns access to PCI I/O space on this root bridge.
     pub const fn io(&mut self) -> PciIoAccess<'_, PciIoSpace> {
         PciIoAccess {
             proto: &mut self.0,
@@ -63,18 +63,16 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Flush all PCI posted write transactions from a PCI host bridge to system memory.
+    /// Flushes all posted PCI writes from the host bridge to system memory.
     ///
     /// # Errors
-    /// - [`Status::DEVICE_ERROR`] The PCI posted write transactions were not flushed from the PCI host bridge
-    ///   due to a hardware error.
+    /// - [`Status::DEVICE_ERROR`]: a hardware error prevented the flush.
     pub fn flush(&mut self) -> crate::Result<()> {
         // SAFETY: The memory is valid.
         unsafe { (self.0.flush)(&mut self.0).to_result() }
     }
 
-    /// Returns the set of [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge
-    /// supports.
+    /// Returns the attributes supported by this PCI root bridge.
     pub fn supported_attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
         let mut supported = 0;
 
@@ -86,7 +84,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Returns the [`PciRootBridgeIoProtocolAttributes`] that this PCI root bridge is currently using.
+    /// Returns the attributes currently used by this PCI root bridge.
     pub fn attributes(&self) -> crate::Result<PciRootBridgeIoProtocolAttributes> {
         let mut current = 0;
 
@@ -97,7 +95,7 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge.
+    /// Sets the attributes used by this PCI root bridge.
     ///
     /// # Safety
     ///
@@ -119,12 +117,16 @@ impl PciRootBridgeIo {
         }
     }
 
-    /// Sets [`PciRootBridgeIoProtocolAttributes`] for this PCI root bridge (supporting attributes
-    /// that require a resource range). For instance, modifying the cache settings of a PCI
-    /// memory range requires the use of this function.
+    /// Sets attributes for a resource range of this PCI root bridge.
     ///
-    /// The provided base and length are set to the actual base and length of the region whose
-    /// attributes were changed (due to granularity or other requirements).
+    /// Use this method for attributes that require a range, such as cache
+    /// settings for PCI memory.
+    ///
+    /// # Arguments
+    ///
+    /// - `attributes`: Attributes to apply.
+    /// - `base`: Requested base address; updated to the base actually changed.
+    /// - `length`: Requested length; updated to the length actually changed.
     ///
     /// # Safety
     ///
@@ -144,13 +146,14 @@ impl PciRootBridgeIo {
     // TODO: map & unmap & copy memory
     // TODO: buffer management
 
-    /// Retrieves the current resource settings of this PCI root bridge in the form of a set of ACPI resource descriptors.
+    /// Returns the current resources assigned to this PCI root bridge.
     ///
-    /// The returned list of descriptors contains information about bus, memory and io ranges that were set up
+    /// The ACPI descriptors identify the bus, memory, and I/O ranges configured
     /// by the firmware.
     ///
     /// # Errors
-    /// - [`Status::UNSUPPORTED`] The current configuration of this PCI root bridge could not be retrieved.
+    /// - [`Status::UNSUPPORTED`]: the current configuration could not be
+    ///   retrieved.
     #[cfg(feature = "alloc")]
     pub fn configuration(&self) -> crate::Result<Vec<QwordAddressSpaceDescriptor>> {
         use crate::proto::pci::configuration;
@@ -167,17 +170,19 @@ impl PciRootBridgeIo {
     // ###################################################
     // # Convenience functionality
 
-    /// Recursively enumerate all devices, device functions and pci(e)-to-pci(e) bridges, starting from this pci root.
+    /// Recursively enumerates devices and bridges below this PCI root bridge.
     ///
-    /// The returned addresses might overlap with the addresses returned by another [`PciRootBridgeIo`] instance.
-    /// Make sure to perform some form of cross-[`PciRootBridgeIo`] deduplication on the discovered addresses.
-    /// **WARNING:** Only use the returned addresses with the respective [`PciRootBridgeIo`] instance that returned them.
+    /// Addresses can overlap with those returned by another
+    /// [`PciRootBridgeIo`], so callers may need to deduplicate them.
     ///
-    /// # Returns
-    /// An ordered list of addresses containing all present devices below this RootBridge.
+    /// # Warnings
+    ///
+    /// Use each returned address only with the [`PciRootBridgeIo`] instance
+    /// that returned it.
     ///
     /// # Errors
-    /// This can basically fail with all the IO errors found in [`PciIoAccess`] methods.
+    ///
+    /// Propagates I/O errors from [`PciIoAccess`] methods.
     #[cfg(feature = "alloc")]
     pub fn enumerate(&mut self) -> crate::Result<super::enumeration::PciTree> {
         use super::enumeration::{self, PciTree};
@@ -214,15 +219,9 @@ pub struct PciIoAccess<'a, S: PciIoAddressSpace> {
 impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
     /// Reads a single value of type `U` from the specified PCI address.
     ///
-    /// # Arguments
-    /// - `addr` - The PCI address to read from.
-    ///
-    /// # Returns
-    /// - The read value of type `U`.
-    ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The read request could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the read.
     pub fn read_one<U: PciIoUnit>(&self, addr: S::Address) -> crate::Result<U> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         let mut result = U::default();
@@ -241,13 +240,9 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
 
     /// Writes a single value of type `U` to the specified PCI address.
     ///
-    /// # Arguments
-    /// - `addr` - The PCI address to write to.
-    /// - `data` - The value to write.
-    ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The write request could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the write.
     pub fn write_one<U: PciIoUnit>(&self, addr: S::Address, data: U) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         // SAFETY: The memory is valid.
@@ -265,13 +260,9 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
 
     /// Reads multiple values from the specified PCI address range.
     ///
-    /// # Arguments
-    /// - `addr` - The starting PCI address to read from.
-    /// - `data` - A mutable slice to store the read values.
-    ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the read.
     pub fn read<U: PciIoUnit>(&self, addr: S::Address, data: &mut [U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         // SAFETY: The memory is valid.
@@ -289,13 +280,9 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
 
     /// Writes multiple values to the specified PCI address range.
     ///
-    /// # Arguments
-    /// - `addr` - The starting PCI address to write to.
-    /// - `data` - A slice containing the values to write.
-    ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the write.
     pub fn write<U: PciIoUnit>(&self, addr: S::Address, data: &[U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Normal);
         // SAFETY: The memory is valid.
@@ -313,14 +300,9 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
 
     /// Fills a PCI address range with the specified value.
     ///
-    /// # Arguments
-    /// - `addr` - The starting PCI address to fill.
-    /// - `count` - The number of units to write.
-    /// - `data` - The value to fill the address range with.
-    ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the write.
     pub fn fill_write<U: PciIoUnit>(
         &self,
         addr: S::Address,
@@ -341,19 +323,14 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
         }
     }
 
-    /// Reads a sequence of values of type `U` from the specified PCI address by repeatedly accessing it.
+    /// Repeatedly reads values of type `U` from one PCI address.
     ///
-    /// # Arguments
-    /// - `addr` - The PCI address to read from.
-    /// - `data` - A mutable slice to store the read values.
-    ///
-    /// # Behavior
-    /// This reads from the same memory region (starting at `addr` and ending at `addr + size_of::<U>()`) repeatedly.
-    /// The resulting `data` buffer will contain the elements returned by reading the same address multiple times sequentially.
+    /// Repeatedly reads the same `U`-sized address range starting at `addr`
+    /// into `data`.
     ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The read operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the read.
     pub fn fifo_read<U: PciIoUnit>(&self, addr: S::Address, data: &mut [U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Fifo);
         // SAFETY: The memory is valid.
@@ -369,19 +346,14 @@ impl<S: PciIoAddressSpace> PciIoAccess<'_, S> {
         }
     }
 
-    /// Writes a sequence of values of type `U` to the specified PCI address repeatedly.
+    /// Repeatedly writes values of type `U` to one PCI address.
     ///
-    /// # Arguments
-    /// - `addr` - The PCI address to write to.
-    /// - `data` - A slice containing the values to write.
-    ///
-    /// # Behavior
-    /// This sequentially writes all elements within the given `data` buffer to the same memory region
-    /// (starting at `addr` and ending at `addr + size_of::<U>()`) sequentially.
+    /// Repeatedly writes values from `data` to the same `U`-sized address range
+    /// starting at `addr`.
     ///
     /// # Errors
-    /// - [`Status::INVALID_PARAMETER`] The requested width is invalid for this PCI root bridge.
-    /// - [`Status::OUT_OF_RESOURCES`] The write operation could not be completed due to a lack of resources.
+    /// - [`Status::INVALID_PARAMETER`]: the requested width is invalid.
+    /// - [`Status::OUT_OF_RESOURCES`]: insufficient resources for the write.
     pub fn fifo_write<U: PciIoUnit>(&self, addr: S::Address, data: &[U]) -> crate::Result<()> {
         let width_mode = encode_io_mode_and_unit::<U>(super::PciIoMode::Fifo);
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/rng.rs
+++ b/uefi/src/proto/rng.rs
@@ -18,6 +18,12 @@ pub struct Rng(uefi_raw::protocol::rng::RngProtocol);
 
 impl Rng {
     /// Returns information about the random number generation implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot enumerate its algorithms. For
+    /// [`Status::BUFFER_TOO_SMALL`], the error payload contains the required
+    /// buffer size in bytes.
     pub fn get_info<'buf>(
         &mut self,
         algorithm_list: &'buf mut [RngAlgorithmType],
@@ -47,7 +53,17 @@ impl Rng {
         }
     }
 
-    /// Returns the next set of random numbers
+    /// Fills `buffer` with random bytes.
+    ///
+    /// # Arguments
+    ///
+    /// - `algorithm`: Requested algorithm, or `None` for the firmware default.
+    /// - `buffer`: Destination for the generated random bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the algorithm is unsupported or firmware cannot
+    /// generate the requested random data.
     pub fn get_rng(&mut self, algorithm: Option<RngAlgorithmType>, buffer: &mut [u8]) -> Result {
         let buffer_length = buffer.len();
 

--- a/uefi/src/proto/scsi/mod.rs
+++ b/uefi/src/proto/scsi/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! SCSI Bus specific protocols.
+//! SCSI bus protocols.
 
 use crate::mem::{AlignedBuffer, AlignmentError};
 use core::alloc::LayoutError;
@@ -11,19 +11,16 @@ use uefi_raw::protocol::scsi::{
     ScsiIoDataDirection, ScsiIoHostAdapterStatus, ScsiIoScsiRequestPacket, ScsiIoTargetStatus,
 };
 
-#[cfg(doc)]
-use crate::Status;
-
 pub mod pass_thru;
 
-/// Represents the data direction for a SCSI request.
+/// Data direction for a SCSI request.
 ///
-/// Used to specify whether the request involves reading, writing, or bidirectional data transfer.
+/// Specifies whether a request reads, writes, or transfers data bidirectionally.
 pub type ScsiRequestDirection = uefi_raw::protocol::scsi::ScsiIoDataDirection;
 
 /// Represents a SCSI request packet.
 ///
-/// This structure encapsulates the necessary data for sending a command to a SCSI device.
+/// Contains the command and buffers needed to communicate with a SCSI device.
 #[derive(Debug)]
 pub struct ScsiRequest<'a> {
     packet: ScsiIoScsiRequestPacket,
@@ -35,20 +32,21 @@ pub struct ScsiRequest<'a> {
     _phantom: PhantomData<&'a u8>,
 }
 
-/// A builder for constructing [`ScsiRequest`] instances.
+/// Builder for constructing [`ScsiRequest`] values.
 ///
-/// Provides a safe and ergonomic interface for configuring SCSI request packets, including timeout,
-/// data buffers, and command descriptor blocks.
+/// Its methods configure the timeout, data buffers, sense buffer, and command
+/// descriptor block (CDB).
 #[derive(Debug)]
 pub struct ScsiRequestBuilder<'a> {
     req: ScsiRequest<'a>,
 }
 impl ScsiRequestBuilder<'_> {
-    /// Creates a new instance with the specified data direction and alignment.
+    /// Creates a new request builder.
     ///
     /// # Arguments
-    /// - `direction`: Specifies the direction of data transfer (READ, WRITE, or BIDIRECTIONAL).
-    /// - `io_align`: Specifies the required alignment for data buffers. (SCSI Controller specific!)
+    ///
+    /// - `direction`: Direction of data transfer for the request.
+    /// - `io_align`: Controller I/O buffer alignment requirement.
     #[must_use]
     pub fn new(direction: ScsiRequestDirection, io_align: u32) -> Self {
         Self {
@@ -85,7 +83,9 @@ impl ScsiRequestBuilder<'_> {
     /// - MODE_SENSE
     ///
     /// # Arguments
-    /// - `io_align`: Specifies the required alignment for data buffers.
+    ///
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    ///
     #[must_use]
     pub fn read(io_align: u32) -> Self {
         Self::new(ScsiIoDataDirection::READ, io_align)
@@ -98,7 +98,9 @@ impl ScsiRequestBuilder<'_> {
     /// - MODE_SELECT
     ///
     /// # Arguments
-    /// - `io_align`: Specifies the required alignment for data buffers.
+    ///
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    ///
     #[must_use]
     pub fn write(io_align: u32) -> Self {
         Self::new(ScsiIoDataDirection::WRITE, io_align)
@@ -110,7 +112,9 @@ impl ScsiRequestBuilder<'_> {
     /// - SEND DIAGNOSTIC
     ///
     /// # Arguments
-    /// - `io_align`: Specifies the required alignment for data buffers.
+    ///
+    /// - `io_align`: Controller I/O buffer alignment requirement.
+    ///
     #[must_use]
     pub fn bidirectional(io_align: u32) -> Self {
         Self::new(ScsiIoDataDirection::BIDIRECTIONAL, io_align)
@@ -120,14 +124,8 @@ impl ScsiRequestBuilder<'_> {
 impl<'a> ScsiRequestBuilder<'a> {
     /// Sets a timeout for the SCSI request.
     ///
-    /// # Arguments
-    /// - `timeout`: A [`Duration`] representing the maximum time allowed for the request.
-    ///   The value is converted to 100-nanosecond units.
-    ///
-    /// # Description
-    /// By default (without calling this method, or by calling with [`Duration::ZERO`]),
-    /// SCSI requests have no timeout.
-    /// Setting a timeout here will cause SCSI commands to potentially fail with [`Status::TIMEOUT`].
+    /// Sets this request's timeout in 100-nanosecond units. A zero duration
+    /// disables the timeout.
     #[must_use]
     pub const fn with_timeout(mut self, timeout: Duration) -> Self {
         self.req.packet.timeout = (timeout.as_nanos() / 100) as u64;
@@ -137,17 +135,15 @@ impl<'a> ScsiRequestBuilder<'a> {
     // # IN BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied buffer for reading data from the device.
+    /// Uses a caller-provided buffer to receive data from the device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] that will be used to store data read from the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Buffer in which to receive data.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `in_data_buffer` of the underlying `ScsiRequest`.
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not satisfy the required alignment.
     pub fn use_read_buffer(mut self, bfr: &'a mut AlignedBuffer) -> Result<Self, AlignmentError> {
         // check alignment of externally supplied buffer
         bfr.check_alignment(self.req.io_align as usize)?;
@@ -157,13 +153,16 @@ impl<'a> ScsiRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Adds a newly allocated read buffer to the built SCSI request.
+    /// Allocates a read buffer for the SCSI request.
     ///
     /// # Arguments
-    /// - `len`: The size of the buffer (in bytes) to allocate for receiving data.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `len`: Number of bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn with_read_buffer(mut self, len: usize) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(len, self.req.io_align as usize)?;
         self.req.packet.in_data_buffer = bfr.ptr_mut().cast();
@@ -175,13 +174,16 @@ impl<'a> ScsiRequestBuilder<'a> {
     // # SENSE BUFFER
     // ########################################################################################
 
-    /// Adds a newly allocated sense buffer to the built SCSI request.
+    /// Allocates a sense-data buffer for the SCSI request.
     ///
     /// # Arguments
-    /// - `len`: The size of the buffer (in bytes) to allocate for receiving sense data.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `len`: Number of bytes to allocate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn with_sense_buffer(mut self, len: u8) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(len as usize, self.req.io_align as usize)?;
         self.req.packet.sense_data = bfr.ptr_mut().cast();
@@ -193,17 +195,15 @@ impl<'a> ScsiRequestBuilder<'a> {
     // # WRITE BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied buffer for writing data to the device.
+    /// Uses a caller-provided buffer to send data to the device.
     ///
     /// # Arguments
-    /// - `bfr`: A mutable reference to an [`AlignedBuffer`] containing the data to be written to the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `bfr`: Buffer containing the data to send.
     ///
-    /// # Description
-    /// This method checks the alignment of the buffer against the protocol's requirements and assigns it to
-    /// the `out_data_buffer` of the underlying `ScsiRequest`.
+    /// # Errors
+    ///
+    /// Returns an error if `bfr` does not satisfy the required alignment.
     pub fn use_write_buffer(mut self, bfr: &'a mut AlignedBuffer) -> Result<Self, AlignmentError> {
         // check alignment of externally supplied buffer
         bfr.check_alignment(self.req.io_align as usize)?;
@@ -213,14 +213,16 @@ impl<'a> ScsiRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Adds a newly allocated write buffer to the built SCSI request that is filled from the
-    /// given data buffer. (Done for memory alignment and lifetime purposes)
+    /// Allocates an aligned write buffer and copies `data` into it.
     ///
     /// # Arguments
-    /// - `data`: A slice of bytes representing the data to be written.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `data`: Data to copy into the request buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn with_write_data(mut self, data: &[u8]) -> Result<Self, LayoutError> {
         let mut bfr = AlignedBuffer::from_size_align(data.len(), self.req.io_align as usize)?;
         bfr.copy_from_slice(data);
@@ -233,16 +235,19 @@ impl<'a> ScsiRequestBuilder<'a> {
     // # COMMAND BUFFER
     // ########################################################################################
 
-    /// Uses a user-supplied Command Data Block (CDB) buffer.
+    /// Uses a caller-provided command descriptor block (CDB).
     ///
     /// # Arguments
-    /// - `data`: A mutable reference to an [`AlignedBuffer`] containing the CDB to be sent to the device.
     ///
-    /// # Returns
-    /// `Result<Self, AlignmentError>` indicating success or an alignment issue with the provided buffer.
+    /// - `data`: CDB to attach to the request.
     ///
-    /// # Notes
-    /// The maximum length of a CDB is 255 bytes.
+    /// # Errors
+    ///
+    /// Returns an error if `data` does not satisfy the required alignment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` is longer than 255 bytes.
     pub fn use_command_buffer(
         mut self,
         data: &'a mut AlignedBuffer,
@@ -256,17 +261,20 @@ impl<'a> ScsiRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Adds a newly allocated Command Data Block (CDB) buffer to the built SCSI request that is filled from the
-    /// given data buffer. (Done for memory alignment and lifetime purposes)
+    /// Allocates an aligned command descriptor block and copies `data` into it.
     ///
     /// # Arguments
-    /// - `data`: A slice of bytes representing the command to be sent.
     ///
-    /// # Returns
-    /// `Result<Self, LayoutError>` indicating success or a memory allocation error.
+    /// - `data`: CDB to copy into the request.
     ///
-    /// # Notes
-    /// The maximum length of a CDB is 255 bytes.
+    /// # Errors
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` is longer than 255 bytes.
     pub fn with_command_data(mut self, data: &[u8]) -> Result<Self, LayoutError> {
         assert!(data.len() <= 255);
         let mut bfr = AlignedBuffer::from_size_align(data.len(), self.req.io_align as usize)?;
@@ -277,31 +285,22 @@ impl<'a> ScsiRequestBuilder<'a> {
         Ok(self)
     }
 
-    /// Build the final `ScsiRequest`.
-    ///
-    /// # Returns
-    /// A fully-configured [`ScsiRequest`] ready for execution.
+    /// Builds the configured [`ScsiRequest`].
     #[must_use]
     pub fn build(self) -> ScsiRequest<'a> {
         self.req
     }
 }
 
-/// Represents the response of a SCSI request.
+/// Response returned after executing a SCSI request.
 ///
-/// This struct encapsulates the results of a SCSI operation, including data buffers
-/// for read and sense data, as well as status codes returned by the host adapter and target device.
+/// Contains read and sense-data buffers together with status codes from the
+/// host adapter and target device.
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct ScsiResponse<'a>(ScsiRequest<'a>);
 impl<'a> ScsiResponse<'a> {
-    /// Retrieves the buffer containing data read from the device (if any).
-    ///
-    /// # Returns
-    /// `Option<&[u8]>`: A slice of the data read from the device, or `None` if no read buffer was assigned.
-    ///
-    /// # Safety
-    /// - If the buffer pointer is `NULL`, the method returns `None` and avoids dereferencing it.
+    /// Returns data read from the device, if a read buffer was assigned.
     #[must_use]
     pub const fn read_buffer(&self) -> Option<&'a [u8]> {
         if self.0.packet.in_data_buffer.is_null() {
@@ -316,13 +315,7 @@ impl<'a> ScsiResponse<'a> {
         }
     }
 
-    /// Retrieves the buffer containing sense data returned by the device (if any).
-    ///
-    /// # Returns
-    /// `Option<&[u8]>`: A slice of the sense data, or `None` if no sense data buffer was assigned.
-    ///
-    /// # Safety
-    /// - If the buffer pointer is `NULL`, the method returns `None` and avoids dereferencing it.
+    /// Returns sense data from the device, if a sense buffer was assigned.
     #[must_use]
     pub const fn sense_data(&self) -> Option<&'a [u8]> {
         if self.0.packet.sense_data.is_null() {
@@ -337,19 +330,13 @@ impl<'a> ScsiResponse<'a> {
         }
     }
 
-    /// Retrieves the status of the host adapter after executing the SCSI request.
-    ///
-    /// # Returns
-    /// [`ScsiIoHostAdapterStatus`]: The status code indicating the result of the operation from the host adapter.
+    /// Returns the host adapter's status after executing the request.
     #[must_use]
     pub const fn host_adapter_status(&self) -> ScsiIoHostAdapterStatus {
         self.0.packet.host_adapter_status
     }
 
-    /// Retrieves the status of the target device after executing the SCSI request.
-    ///
-    /// # Returns
-    /// [`ScsiIoTargetStatus`]: The status code returned by the target device.
+    /// Returns the target device's status after executing the request.
     #[must_use]
     pub const fn target_status(&self) -> ScsiIoTargetStatus {
         self.0.packet.target_status

--- a/uefi/src/proto/scsi/pass_thru.rs
+++ b/uefi/src/proto/scsi/pass_thru.rs
@@ -16,10 +16,10 @@ use uefi_raw::protocol::scsi::{
     ExtScsiPassThruMode, ExtScsiPassThruProtocol, SCSI_TARGET_MAX_BYTES,
 };
 
-/// Structure representing a SCSI target address.
+/// SCSI target address.
 pub type ScsiTarget = [u8; SCSI_TARGET_MAX_BYTES];
 
-/// Structure representing a fully-qualified device address, consisting of SCSI target and LUN.
+/// Fully qualified SCSI target and logical unit number (LUN).
 #[derive(Clone, Debug)]
 pub struct ScsiTargetLun(ScsiTarget, u64);
 impl Default for ScsiTargetLun {
@@ -33,9 +33,9 @@ impl Default for ScsiTargetLun {
 /// This protocol allows communication with SCSI devices connected to the system,
 /// providing methods to send commands, reset devices, and enumerate SCSI targets.
 ///
-/// This API offers a safe and convenient, yet still low-level interface to SCSI devices.
-/// It is designed as a foundational layer, leaving higher-level abstractions responsible for implementing
-/// richer storage semantics, device-specific commands, and advanced use cases.
+/// This is a safe, convenient, but still low-level interface. Higher-level
+/// abstractions remain responsible for storage semantics and device-specific
+/// commands.
 ///
 /// # UEFI Specification
 /// Provides services that allow SCSI Pass Thru commands to be sent to SCSI devices attached to a SCSI channel. It also
@@ -46,10 +46,7 @@ impl Default for ScsiTargetLun {
 pub struct ExtScsiPassThru(UnsafeCell<ExtScsiPassThruProtocol>);
 
 impl ExtScsiPassThru {
-    /// Retrieves the mode structure for the Extended SCSI Pass Thru protocol.
-    ///
-    /// # Returns
-    /// The [`ExtScsiPassThruMode`] structure containing configuration details of the protocol.
+    /// Returns the Extended SCSI Pass Thru mode.
     #[must_use]
     pub fn mode(&self) -> ExtScsiPassThruMode {
         // SAFETY: The memory is valid.
@@ -58,42 +55,36 @@ impl ExtScsiPassThru {
         mode
     }
 
-    /// Retrieves the I/O buffer alignment required by this SCSI channel.
-    ///
-    /// # Returns
-    /// - A `u32` value representing the required I/O alignment.
+    /// Returns the required I/O buffer alignment in bytes.
     #[must_use]
     pub fn io_align(&self) -> u32 {
         self.mode().io_align
     }
 
-    /// Allocates an I/O buffer with the necessary alignment for this SCSI channel.
+    /// Allocates an I/O buffer with the alignment required by this channel.
     ///
-    /// You can alternatively do this yourself using the [`AlignedBuffer`] helper directly.
-    /// The Scsi api will validate that your buffers have the correct alignment and crash
-    /// if they don't.
+    /// Callers can instead allocate an [`AlignedBuffer`] directly. SCSI request
+    /// builders validate user-provided buffer alignment.
     ///
     /// # Arguments
-    /// - `len`: The size (in bytes) of the buffer to allocate.
     ///
-    /// # Returns
-    /// [`AlignedBuffer`] containing the allocated memory.
+    /// - `len`: Number of bytes to allocate.
     ///
     /// # Errors
-    /// This method can fail due to alignment or memory allocation issues.
+    ///
+    /// Returns an error if the buffer cannot be allocated with the required
+    /// alignment.
     pub fn alloc_io_buffer(&self, len: usize) -> Result<AlignedBuffer, LayoutError> {
         AlignedBuffer::from_size_align(len, self.io_align() as usize)
     }
 
-    /// Iterate over all potential SCSI devices on this channel.
+    /// Returns an iterator over all potential SCSI devices on this channel.
     ///
     /// # Warnings
-    /// Depending on the UEFI implementation, this does not only return all actually available devices.
-    /// Most implementations instead return a list of all possible fully-qualified device addresses.
-    /// You have to probe for availability yourself, using [`ScsiDevice::execute_command`].
     ///
-    /// # Returns
-    /// [`ScsiTargetLunIterator`] to iterate through connected SCSI devices.
+    /// Firmware may return every possible fully qualified address, not only
+    /// addresses with a connected device. Probe each address with
+    /// [`ScsiDevice::execute_command`].
     #[must_use]
     pub fn iter_devices(&self) -> ScsiTargetLunIterator<'_> {
         ScsiTargetLunIterator {
@@ -104,29 +95,26 @@ impl ExtScsiPassThru {
 
     /// Resets the SCSI channel associated with the protocol.
     ///
-    /// The EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetChannel() function resets a SCSI channel.
-    /// This operation resets all the SCSI devices connected to the SCSI channel.
-    ///
-    /// # Returns
-    /// [`Result`] indicating the success or failure of the operation.
+    /// This also resets every SCSI device connected to the channel.
     ///
     /// # Errors
-    /// - [`Status::UNSUPPORTED`] The SCSI channel does not support a channel reset operation.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to reset the SCSI channel.
-    /// - [`Status::TIMEOUT`] A timeout occurred while attempting to reset the SCSI channel.
+    /// - [`Status::UNSUPPORTED`]: the channel does not support reset.
+    /// - [`Status::DEVICE_ERROR`]: a device reported an error.
+    /// - [`Status::TIMEOUT`]: the reset timed out.
     pub fn reset_channel(&mut self) -> crate::Result<()> {
         // SAFETY: The memory is valid.
         unsafe { ((*self.0.get()).reset_channel)(self.0.get()).to_result() }
     }
 }
 
-/// Structure representing a potential ScsiDevice.
+/// Potential SCSI device identified by a target and LUN.
 ///
 /// In the UEFI Specification, this corresponds to a (SCSI target, LUN) tuple.
 ///
 /// # Warnings
-/// This does not actually have to correspond to an actual device!
-/// You have to probe for availability before doing anything meaningful with it.
+///
+/// This address need not correspond to a connected device. Probe it before
+/// use.
 #[derive(Clone, Debug)]
 pub struct ScsiDevice<'a> {
     proto: &'a UnsafeCell<ExtScsiPassThruProtocol>,
@@ -145,10 +133,14 @@ impl ScsiDevice<'_> {
         self.target_lun.1
     }
 
-    /// Get the final device path node for this device.
+    /// Returns the final device path node for this device.
     ///
-    /// For a full [`crate::proto::device_path::DevicePath`] pointing to this device, this needs to be appended to
-    /// the controller's device path.
+    /// Append this node to the controller's device path to form a complete
+    /// [`crate::proto::device_path::DevicePath`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if firmware cannot build the node or allocation fails.
     pub fn path_node(&self) -> crate::Result<PoolDevicePathNode> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -166,23 +158,16 @@ impl ScsiDevice<'_> {
         }
     }
 
-    /// Resets the potential SCSI device represented by this instance.
+    /// Resets this potential SCSI device.
     ///
-    /// The `EFI_EXT_SCSI_PASS_THRU_PROTOCOL.ResetTargetLun()` function resets the SCSI logical unit
-    /// specified by `Target` and `Lun`. This allows for recovering a device that may be in an error state
-    /// or requires reinitialization. The function behavior is dependent on the SCSI channel's capability
-    /// to perform target resets.
-    ///
-    /// # Returns
-    /// [`Result`] indicating the success or failure of the operation.
+    /// This can recover a device that is in an error state or requires
+    /// reinitialization, if the channel supports target resets.
     ///
     /// # Errors
-    /// - [`Status::UNSUPPORTED`] The SCSI channel does not support a target reset operation.
-    /// - [`Status::INVALID_PARAMETER`] The `Target` or `Lun` values are invalid.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to reset the SCSI device
-    ///   specified by `Target` and `Lun`.
-    /// - [`Status::TIMEOUT`] A timeout occurred while attempting to reset the SCSI device specified
-    ///   by `Target` and `Lun`.
+    /// - [`Status::UNSUPPORTED`]: the channel does not support target reset.
+    /// - [`Status::INVALID_PARAMETER`]: the target or LUN is invalid.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::TIMEOUT`]: the reset timed out.
     pub fn reset(&mut self) -> crate::Result<()> {
         // SAFETY: The memory is valid.
         unsafe {
@@ -195,34 +180,19 @@ impl ScsiDevice<'_> {
         }
     }
 
-    /// Sends a SCSI command to the potential target device and retrieves the response.
+    /// Sends a SCSI command to this potential target device.
     ///
-    /// This method sends a SCSI Request Packet to a SCSI device attached to the SCSI channel.
-    /// It supports both blocking and nonblocking I/O. Blocking I/O is mandatory, while
-    /// nonblocking I/O is optional and dependent on the driver's implementation.
-    ///
-    /// # Arguments
-    /// - `scsi_req`: The [`ScsiRequest`] containing the command and data to send to the device.
-    ///
-    /// # Returns
-    /// [`ScsiResponse`] containing the results of the operation, such as data and status.
+    /// This wrapper performs blocking I/O.
     ///
     /// # Errors
-    /// - [`Status::BAD_BUFFER_SIZE`] The SCSI Request Packet was not executed because the data
-    ///   buffer size exceeded the allowed transfer size for a single command. The number of bytes
-    ///   that could be transferred is returned in `InTransferLength` or `OutTransferLength`.
-    /// - [`Status::NOT_READY`] The SCSI Request Packet could not be sent because too many packets
-    ///   are already queued. The caller may retry later.
-    /// - [`Status::DEVICE_ERROR`] A device error occurred while attempting to send the SCSI Request Packet.
-    ///   Additional status information is available in `HostAdapterStatus`, `TargetStatus`, `SenseDataLength`,
-    ///   and `SenseData`.
-    /// - [`Status::INVALID_PARAMETER`] The `Target`, `Lun`, or the contents of `ScsiRequestPacket` are invalid.
-    ///   The SCSI Request Packet was not sent, and no additional status information is available.
-    /// - [`Status::UNSUPPORTED`] The command described by the SCSI Request Packet is not supported by the
-    ///   host adapter, including unsupported bi-directional SCSI commands. The SCSI Request Packet was not
-    ///   sent, and no additional status information is available.
-    /// - [`Status::TIMEOUT`] A timeout occurred while executing the SCSI Request Packet. Additional status
-    ///   information is available in `HostAdapterStatus`, `TargetStatus`, `SenseDataLength`, and `SenseData`.
+    /// - [`Status::BAD_BUFFER_SIZE`]: a data buffer exceeds the allowed
+    ///   transfer size.
+    /// - [`Status::NOT_READY`]: too many requests are queued; retry later.
+    /// - [`Status::DEVICE_ERROR`]: the device reported an error.
+    /// - [`Status::INVALID_PARAMETER`]: the target, LUN, or request is invalid.
+    /// - [`Status::UNSUPPORTED`]: the host adapter does not support the
+    ///   command.
+    /// - [`Status::TIMEOUT`]: the command timed out.
     pub fn execute_command<'req>(
         &mut self,
         mut scsi_req: ScsiRequest<'req>,

--- a/uefi/src/proto/shell/mod.rs
+++ b/uefi/src/proto/shell/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! EFI Shell Protocol v2.2
+//! EFI Shell Protocol version 2.2.
 
 use crate::proto::unsafe_protocol;
 use crate::{CStr16, Char16, Error, Result, Status, StatusExt};
@@ -9,26 +9,26 @@ use core::marker::PhantomData;
 use core::ptr;
 use uefi_raw::protocol::shell::ShellProtocol;
 
-/// Shell Protocol
+/// EFI Shell protocol.
 #[derive(Debug)]
 #[repr(transparent)]
 #[unsafe_protocol(ShellProtocol::GUID)]
 pub struct Shell(ShellProtocol);
 
-/// Trait for implementing the var function
+/// Provides access to shell environment variables.
 pub trait ShellVarProvider {
-    /// Gets the value of the specified environment variable
+    /// Returns the value of `name`, if it exists.
     fn var(&self, name: &CStr16) -> Option<&CStr16>;
 }
 
-/// Iterator over the names of environmental variables obtained from the Shell protocol.
+/// Iterator over shell environment variable names and values.
 #[derive(Debug)]
 pub struct Vars<'a, T: ShellVarProvider> {
-    /// Char16 containing names of environment variables
+    /// Pointer to the current environment variable name.
     names: *const Char16,
-    /// Reference to Shell Protocol
+    /// Environment variable provider.
     protocol: *const T,
-    /// Marker to attach a lifetime to `Vars`
+    /// Associates the iterator with the returned strings.
     _marker: PhantomData<&'a CStr16>,
 }
 
@@ -51,23 +51,23 @@ impl<'a, T: ShellVarProvider + 'a> Iterator for Vars<'a, T> {
 }
 
 impl ShellVarProvider for Shell {
-    /// Gets the value of the specified environment variable
+    /// Returns the value of `name`, if it exists.
     fn var(&self, name: &CStr16) -> Option<&CStr16> {
         self.var(name)
     }
 }
 
 impl Shell {
-    /// Returns the current directory on the specified device.
+    /// Returns a current directory maintained by the shell.
     ///
     /// # Arguments
     ///
-    /// * `file_system_mapping` - The file system mapping for which to get
-    ///   the current directory
+    /// - `file_system_mapping`: Mapping whose directory to return. `None`
+    ///   selects the current working directory.
     ///
     /// # Errors
     ///
-    /// * [`Status::NOT_FOUND`] - Could not retrieve current directory
+    /// - [`Status::NOT_FOUND`]: the requested current directory does not exist.
     pub fn current_dir(&self, file_system_mapping: Option<&CStr16>) -> Result<&CStr16> {
         let mapping_ptr: *const Char16 = file_system_mapping.map_or(ptr::null(), CStr16::as_ptr);
         // SAFETY: The memory is valid.
@@ -80,17 +80,18 @@ impl Shell {
         }
     }
 
-    /// Changes the current directory on the specified device
+    /// Changes a current directory maintained by the shell.
     ///
     /// # Arguments
     ///
-    /// * `file_system` - File system's mapped name.
-    /// * `directory` - Directory on the device specified by
-    ///   `file_system`.
+    /// - `file_system`: Mapping to change. `None` selects the current working
+    ///   directory or the mapping included in `directory`.
+    /// - `directory`: Directory to select. `None` changes only the current
+    ///   file-system mapping.
     ///
     /// # Errors
     ///
-    /// * [`Status::NOT_FOUND`] - The directory does not exist
+    /// - [`Status::NOT_FOUND`]: the directory does not exist.
     pub fn set_current_dir(
         &self,
         file_system: Option<&CStr16>,
@@ -102,18 +103,11 @@ impl Shell {
         unsafe { (self.0.set_cur_dir)(fs_ptr.cast(), dir_ptr.cast()) }.to_result()
     }
 
-    /// Gets the value of the specified environment variable
+    /// Returns the value of the environment variable `name`, if it exists.
     ///
     /// # Arguments
     ///
-    /// * `name` - The environment variable name of which to retrieve the
-    ///   value.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(<env_value>)` - &CStr16 containing the value of the
-    ///   environment variable
-    /// * `None` - If environment variable does not exist
+    /// - `name`: Environment variable name.
     #[must_use]
     pub fn var(&self, name: &CStr16) -> Option<&CStr16> {
         let name_ptr: *const Char16 = name.as_ptr();
@@ -127,11 +121,7 @@ impl Shell {
         }
     }
 
-    /// Gets an iterator over the names of all environment variables
-    ///
-    /// # Returns
-    ///
-    /// * `Vars` - Iterator over the names of the environment variables
+    /// Returns an iterator over all environment variable names.
     #[must_use]
     pub fn vars(&self) -> Vars<'_, Self> {
         // SAFETY: The memory is valid.
@@ -143,18 +133,16 @@ impl Shell {
         }
     }
 
-    /// Sets the environment variable
+    /// Sets the environment variable `name` to `value`.
+    ///
+    /// An empty `value` deletes an existing variable. `volatile` controls
+    /// whether the value survives a system reset.
     ///
     /// # Arguments
     ///
-    /// * `name` - The environment variable for which to set the value
-    /// * `value` - The new value of the environment variable
-    /// * `volatile` - Indicates whether the variable is volatile or
-    ///   not
-    ///
-    /// # Returns
-    ///
-    /// * `Status::SUCCESS` - The variable was successfully set
+    /// - `name`: Environment variable name.
+    /// - `value`: New value, or an empty string to delete the variable.
+    /// - `volatile`: Whether the variable is volatile.
     pub fn set_var(&self, name: &CStr16, value: &CStr16, volatile: bool) -> Result {
         let name_ptr: *const Char16 = name.as_ptr();
         let value_ptr: *const Char16 = value.as_ptr();

--- a/uefi/src/proto/shell/mod.rs
+++ b/uefi/src/proto/shell/mod.rs
@@ -181,7 +181,7 @@ mod tests {
         }
     }
 
-    /// Testing Vars struct
+    /// Test fixture for shell environment variables.
     #[test]
     fn test_vars() {
         // Empty Vars

--- a/uefi/src/proto/shell_params.rs
+++ b/uefi/src/proto/shell_params.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! `ShellParams` protocol
+//! UEFI Shell Parameters protocol.
 
 use crate::proto::unsafe_protocol;
 use crate::{Char16, data_types};
@@ -24,7 +24,7 @@ impl ShellParameters {
         self.0.argc
     }
 
-    /// Get an iterator of the shell parameter arguments
+    /// Returns an iterator over the shell arguments.
     pub fn args(&self) -> impl Iterator<Item = &CStr16> {
         self.args_slice()
             .iter()
@@ -32,7 +32,7 @@ impl ShellParameters {
             .map(|x| unsafe { CStr16::from_ptr(*x) })
     }
 
-    /// Get a slice of the args, as Char16 pointers
+    /// Returns the argument pointers as a slice.
     #[must_use]
     const fn args_slice(&self) -> &[*const Char16] {
         // SAFETY: The memory is valid.

--- a/uefi/src/proto/shell_params.rs
+++ b/uefi/src/proto/shell_params.rs
@@ -18,7 +18,7 @@ use crate::CStr16;
 pub struct ShellParameters(ShellParametersProtocol);
 
 impl ShellParameters {
-    /// Get the number of shell parameter arguments
+    /// Returns the number of shell arguments.
     #[must_use]
     pub const fn args_len(&self) -> usize {
         self.0.argc

--- a/uefi/src/result/error.rs
+++ b/uefi/src/result/error.rs
@@ -5,9 +5,9 @@
 use super::Status;
 use core::fmt::{Debug, Display};
 
-/// An UEFI-related error with optionally additional payload data. The error
-/// kind is encoded in the `status` field (see [`Status`]). Additional payload
-/// may be inside the `data` field.
+/// UEFI error with optional additional data.
+///
+/// [`Status`] identifies the error kind and `Data` carries contextual payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error<Data: Debug = ()> {
     status: Status,
@@ -15,7 +15,7 @@ pub struct Error<Data: Debug = ()> {
 }
 
 impl<Data: Debug> Error<Data> {
-    /// Create an `Error`.
+    /// Creates an [`Error`].
     ///
     /// # Panics
     ///
@@ -25,17 +25,17 @@ impl<Data: Debug> Error<Data> {
         Self { status, data }
     }
 
-    /// Get error `Status`.
+    /// Returns the error status.
     pub const fn status(&self) -> Status {
         self.status
     }
 
-    /// Get error data.
+    /// Returns the error data.
     pub const fn data(&self) -> &Data {
         &self.data
     }
 
-    /// Split this error into its inner status and error data
+    /// Splits this error into its status and data.
     pub fn split(self) -> (Status, Data) {
         (self.status, self.data)
     }
@@ -56,11 +56,9 @@ impl<Data: Debug> Display for Error<Data> {
 }
 
 impl<Data: Debug> Error<Data> {
-    /// Transforms the generic payload of an error to `()`. This is useful if
-    /// you want
-    /// - to retain the erroneous status code,
-    /// - do not care about the payload, and
-    /// - refrain from generic type complexity in a higher API level.
+    /// Returns this error without its payload.
+    ///
+    /// This retains the status while simplifying the error type to [`Error<()>`].
     pub const fn to_err_without_payload(&self) -> Error<()> {
         Error {
             status: self.status,

--- a/uefi/src/result/mod.rs
+++ b/uefi/src/result/mod.rs
@@ -4,11 +4,11 @@
 
 use core::fmt::Debug;
 
-/// The error type that we use, essentially a status code + optional additional data
+/// UEFI status error with optional additional data.
 mod error;
 pub use error::Error;
 
-/// Definition of UEFI's standard status codes
+/// UEFI status code and conversion helpers.
 mod status;
 pub use status::{Status, StatusExt};
 
@@ -28,10 +28,10 @@ pub type Result<Output = (), ErrData = ()> = core::result::Result<Output, Error<
 
 /// Extension trait which provides some convenience methods for [`Result`].
 pub trait ResultExt<Output, ErrData: Debug> {
-    /// Extract the UEFI status from this result
+    /// Returns the UEFI status represented by this result.
     fn status(&self) -> Status;
 
-    /// Transform the ErrData value to ()
+    /// Discards any error payload.
     fn discard_errdata(self) -> Result<Output>;
 
     /// Calls `op` if the result contains a warning, otherwise returns

--- a/uefi/src/runtime/mod.rs
+++ b/uefi/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub fn get_time_and_caps() -> Result<(Time, TimeCapabilities)> {
     unsafe { (rt.get_time)(time_ptr.cast(), &mut caps) }.to_result_with_val(|| (time, caps))
 }
 
-/// Sets the current local time and date information
+/// Sets the current local time and date.
 ///
 /// During runtime, if a PC-AT CMOS device is present in the platform, the
 /// caller must synchronize access to the device before calling `set_time`.
@@ -402,8 +402,7 @@ pub fn delete_variable(name: &CStr16, vendor: &VariableVendor) -> Result {
     set_variable(name, vendor, VariableAttributes::empty(), &[])
 }
 
-/// Get information about UEFI variable storage space for the type
-/// of variable specified in `attributes`.
+/// Returns storage information for variables with `attributes`.
 ///
 /// This operation is only supported starting with UEFI 2.0.
 ///

--- a/uefi/src/runtime/time/mod.rs
+++ b/uefi/src/runtime/time/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Module for UEFI time-related types and definitions and convenience and
-//! abstractions build around these.
+//! UEFI time types and conversions.
 
 #[cfg(feature = "time03")]
 pub use integration_common::TimeConversionError;
@@ -74,8 +73,7 @@ pub struct TimeParams {
     pub daylight: Daylight,
 }
 
-/// Error returned by [`Time`] methods. A bool value of `true` means
-/// the specified field is outside its valid range.
+/// Reports which fields of a [`Time`] are outside their valid ranges.
 #[expect(missing_docs)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TimeError {
@@ -132,8 +130,11 @@ impl Time {
     /// Unspecified Timezone/local time.
     const UNSPECIFIED_TIMEZONE: i16 = uefi_raw::time::Time::UNSPECIFIED_TIMEZONE;
 
-    /// Create a `Time` value. If a field is not in the valid range,
-    /// [`TimeError`] is returned.
+    /// Creates a validated [`Time`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimeError`] with each out-of-range field marked.
     pub fn new(params: TimeParams) -> core::result::Result<Self, TimeError> {
         let time = Self(uefi_raw::time::Time {
             year: params.year,
@@ -152,9 +153,10 @@ impl Time {
         time.is_valid().map(|_| time)
     }
 
-    /// Create an invalid `Time` with all fields set to zero. This can
-    /// be used with [`FileInfo`] to indicate a field should not be
-    /// updated when calling [`File::set_info`].
+    /// Creates an invalid [`Time`] with every field set to zero.
+    ///
+    /// This value can be used with [`FileInfo`] to leave a field unchanged when
+    /// calling [`File::set_info`].
     ///
     /// [`FileInfo`]: uefi::proto::media::file::FileInfo
     /// [`File::set_info`]: uefi::proto::media::file::File::set_info
@@ -163,7 +165,11 @@ impl Time {
         Self(uefi_raw::time::Time::invalid())
     }
 
-    /// `Ok()` if all fields are within valid ranges, `Err(TimeError)` otherwise.
+    /// Validates that every field is in its required range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimeError`] with each out-of-range field marked.
     pub fn is_valid(&self) -> core::result::Result<(), TimeError> {
         let mut err = TimeError::default();
         if !(1900..=9999).contains(&self.year()) {

--- a/uefi/src/system.rs
+++ b/uefi/src/system.rs
@@ -28,7 +28,7 @@ pub fn firmware_vendor() -> &'static CStr16 {
     unsafe { CStr16::from_ptr(vendor) }
 }
 
-/// Get the firmware revision.
+/// Returns the firmware revision.
 #[must_use]
 pub fn firmware_revision() -> u32 {
     let st = table::system_table_raw_panicking();
@@ -38,7 +38,9 @@ pub fn firmware_revision() -> u32 {
     st.firmware_revision
 }
 
-/// Get the revision of the system table, which is defined to be the revision of
+/// Returns the system table's UEFI revision.
+///
+/// This is the revision of
 /// the UEFI specification implemented by the firmware.
 #[must_use]
 pub fn uefi_revision() -> Revision {
@@ -49,8 +51,9 @@ pub fn uefi_revision() -> Revision {
     st.header.revision
 }
 
-/// Call `f` with a slice of [`ConfigTableEntry`]. Each entry provides access to
-/// a vendor-specific table.
+/// Calls `f` with the system configuration table.
+///
+/// Each [`ConfigTableEntry`] provides access to a vendor-specific table.
 ///
 /// # Example
 ///
@@ -88,7 +91,7 @@ where
     f(slice)
 }
 
-/// Call `f` with the [`Input`] protocol attached to stdin.
+/// Calls `f` with the [`Input`] protocol attached to stdin.
 ///
 /// # Panics
 ///
@@ -113,7 +116,7 @@ where
     f(stdin)
 }
 
-/// Call `f` with the [`Output`] protocol attached to stdout.
+/// Calls `f` with the [`Output`] protocol attached to stdout.
 ///
 /// # Panics
 ///
@@ -138,7 +141,7 @@ where
     f(stdout)
 }
 
-/// Call `f` with the [`Output`] protocol attached to stderr.
+/// Calls `f` with the [`Output`] protocol attached to stderr.
 ///
 /// # Panics
 ///

--- a/uefi/src/system.rs
+++ b/uefi/src/system.rs
@@ -15,7 +15,7 @@ use crate::table::{self, Revision};
 use crate::{CStr16, Char16};
 use core::slice;
 
-/// Get the firmware vendor string.
+/// Returns the firmware vendor string.
 #[must_use]
 pub fn firmware_vendor() -> &'static CStr16 {
     let st = table::system_table_raw_panicking();

--- a/uefi/src/table/mod.rs
+++ b/uefi/src/table/mod.rs
@@ -16,7 +16,7 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 static SYSTEM_TABLE: AtomicPtr<uefi_raw::table::system::SystemTable> =
     AtomicPtr::new(ptr::null_mut());
 
-/// Get the raw system table pointer.
+/// Returns the raw system-table pointer.
 ///
 /// If called before `set_system_table` has been called, this will return `None`.
 pub fn system_table_raw() -> Option<NonNull<uefi_raw::table::system::SystemTable>> {
@@ -24,7 +24,9 @@ pub fn system_table_raw() -> Option<NonNull<uefi_raw::table::system::SystemTable
     NonNull::new(ptr)
 }
 
-/// Get the raw system table pointer. This may only be called after
+/// Returns the raw system-table pointer.
+///
+/// This may only be called after
 /// `set_system_table` has been used to set the global pointer.
 ///
 /// # Panics

--- a/uefi/src/util.rs
+++ b/uefi/src/util.rs
@@ -28,7 +28,7 @@ pub const fn usize_from_u32(val: u32) -> usize {
     val as usize
 }
 
-/// Get the raw pointer from `opt`, defaulting to `null_mut`.
+/// Returns the raw pointer in `opt`, or null for `None`.
 pub fn opt_nonnull_to_ptr<T>(opt: Option<NonNull<T>>) -> *mut T {
     opt.map(NonNull::as_ptr).unwrap_or(ptr::null_mut())
 }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -167,7 +167,7 @@ impl Feature {
 /// of types or some more specific combo.
 #[derive(Clone, Copy, Debug)]
 pub enum TargetTypes {
-    /// Use this to not specify any target types in the cargo command
+    /// Omits explicit target types from the Cargo command
     /// line; this will enable bins, libs, and tests if they are present.
     Default,
 
@@ -210,8 +210,9 @@ pub enum CargoAction {
     Test,
 }
 
-/// Get a modified PATH to remove entries added by rustup. This is
-/// necessary on Windows, see
+/// Returns `PATH` without entries added by rustup.
+///
+/// This is necessary on Windows; see
 /// <https://github.com/rust-lang/rustup/issues/3031>.
 fn sanitized_path(orig_path: OsString) -> OsString {
     // Modify the PATH to remove entries added by rustup. This is

--- a/xtask/src/check_raw.rs
+++ b/xtask/src/check_raw.rs
@@ -136,8 +136,7 @@ impl Error {
     }
 }
 
-/// True if the visibility is public without restriction (i.e. just `pub`, not
-/// `pub(crate)` or similar).
+/// Returns whether visibility is unrestricted `pub`.
 fn is_pub(vis: &Visibility) -> bool {
     matches!(vis, Visibility::Public(_))
 }
@@ -158,8 +157,7 @@ enum Repr {
     Transparent,
 }
 
-/// A restricted view of `Attribute`, limited to just the attributes that are
-/// expected in `uefi-raw`.
+/// Restricted view of the attributes expected in `uefi-raw`.
 #[derive(Debug, Clone, Copy)]
 enum ParsedAttr {
     Allow(Allow),

--- a/xtask/src/device_path/field.rs
+++ b/xtask/src/device_path/field.rs
@@ -154,7 +154,7 @@ pub enum GetFunc {
     /// Autogenerate the getter.
     Auto,
 
-    /// Autogenerate the getter, but call a custom function to get the
+    /// Autogenerates the getter but uses a custom function for the
     /// return value.
     Custom,
 }
@@ -294,7 +294,9 @@ impl NodeField {
         ))
     }
 
-    /// Generate code to calculate the size of DST fields. Returns
+    /// Generates code that calculates the size of DST fields.
+    ///
+    /// Returns
     /// `None` for non-DST fields.
     pub fn gen_builder_dynamic_size(&self) -> Option<TokenStream> {
         if self.attr.custom_build_size_impl {
@@ -356,8 +358,9 @@ impl Default for FieldNodeAttr {
 }
 
 impl FieldNodeAttr {
-    /// Parse a field `node` attribute as described in the
-    /// readme. Returns `None` if the attribute does not exactly match
+    /// Parses a field `node` attribute as described in the readme.
+    ///
+    /// Returns `None` if the attribute does not exactly match
     /// the expected format.
     fn from_attr(attr: &Attribute) -> Option<Self> {
         if !attr.path().is_ident("node") {

--- a/xtask/src/device_path/node.rs
+++ b/xtask/src/device_path/node.rs
@@ -87,7 +87,9 @@ impl Node {
         self.fields.iter().filter(|field| field.is_slice()).count() > 1
     }
 
-    /// Calculate the static size of the packed structure. This should
+    /// Calculates the static size of the packed structure.
+    ///
+    /// This should
     /// give the same value as the `static_size` attribute.
     fn calculate_static_size(&self) -> usize {
         let header_size: usize = 4;
@@ -521,7 +523,9 @@ struct NodeAttr {
     sub_type: Option<String>,
 }
 
-/// Parse a `node` attribute. Returns `None` for any other attribute, or
+/// Parses a `node` attribute.
+///
+/// Returns `None` for any other attribute, or
 /// if the contents don't match the expected format.
 fn parse_node_attr(attr: &Attribute) -> Option<NodeAttr> {
     if !attr.path().is_ident("node") {
@@ -554,8 +558,7 @@ fn parse_node_attr(attr: &Attribute) -> Option<NodeAttr> {
     })
 }
 
-/// Returns `true` if the attribute is a valid `node` attribute, false
-/// otherwise.
+/// Returns whether the attribute is a valid `node` attribute.
 pub fn is_node_attr(attr: &Attribute) -> bool {
     parse_node_attr(attr).is_some()
 }

--- a/xtask/src/device_path/util.rs
+++ b/xtask/src/device_path/util.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use syn::Attribute;
 
-/// Returns true if the attribute is a `#[doc = "..."]` attribute,
+/// Returns whether the attribute is a `#[doc = "..."]` attribute,
 /// otherwise returns false.
 pub fn is_doc_attr(attr: &Attribute) -> bool {
     attr.path().is_ident("doc")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -193,7 +193,9 @@ fn run_vm_tests(opt: &QemuOpt) -> Result<()> {
     qemu::run_qemu(*opt.target, opt)
 }
 
-/// Run unit tests and doctests on the host. Most of uefi-rs is tested
+/// Runs unit tests and doctests on the host.
+///
+/// Most of uefi-rs is tested
 /// with VM tests, but a few things like macros and data types can be
 /// tested with regular tests.
 fn run_host_tests(test_opt: &TestOpt) -> Result<()> {

--- a/xtask/src/net.rs
+++ b/xtask/src/net.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-/// Run a simple echo service that listens on UDP port 21572 and
-/// reverses the incoming messages.
+/// Runs a simple echo service on UDP port 21572.
+///
+/// The service reverses incoming messages.
 pub struct EchoService {
     stop_requested: Arc<Mutex<bool>>,
 

--- a/xtask/src/opt.rs
+++ b/xtask/src/opt.rs
@@ -88,7 +88,7 @@ pub struct BuildOpt {
     #[clap(flatten)]
     pub build_mode: BuildModeOpt,
 
-    /// Build multiple times to check that different feature
+    /// Builds multiple times to check that different feature
     /// combinations work.
     #[clap(long, action)]
     pub feature_permutations: bool,
@@ -130,8 +130,9 @@ pub struct DocOpt {
     #[clap(long, action)]
     pub open: bool,
 
-    /// Tells whether private items should be documented. This is convenient to check for
-    /// broken intra-doc links in private items.
+    /// Controls whether private items are documented.
+    ///
+    /// This is useful for finding broken intra-doc links in private items.
     #[clap(long, action)]
     pub document_private_items: bool,
 

--- a/xtask/src/pipe.rs
+++ b/xtask/src/pipe.rs
@@ -15,7 +15,9 @@ pub struct Pipe {
 }
 
 impl Pipe {
-    /// Prepare to set up a two-way communication pipe. This is called
+    /// Prepares a two-way communication pipe.
+    ///
+    /// This is called
     /// before launching QEMU. On Unix this uses `mkfifo` to create two
     /// pipes; on Windows QEMU itself will create the duplex pipe.
     pub fn new(dir: &Path, base_name: &'static str) -> Result<Self> {

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -100,7 +100,7 @@ impl OvmfPaths {
         }
     }
 
-    /// Find path to OVMF files by the strategy documented for
+    /// Finds OVMF files using the strategy documented for
     /// [`Self::find_ovmf_file`].
     fn find(opt: &QemuOpt, arch: UefiArch) -> Result<Self> {
         let prebuilt_source = ovmf_prebuilt_source(arch);

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -36,7 +36,7 @@ pub fn command_to_string(cmd: &Command) -> String {
     parts.into_iter().collect::<Vec<_>>().join(" ")
 }
 
-/// Print a `Command` and run it, then check that it completes
+/// Prints and runs a command, then checks that it succeeds.
 /// successfully.
 pub fn run_cmd(mut cmd: Command) -> Result<()> {
     println!("run_cmd: '{}'", command_to_string(&cmd));


### PR DESCRIPTION
Heavily AI-driven streamlining of all documentation to clean up the inconsistencies that grew over the years. Nothing fundamentally new, just style adjustments and rephrasings.

  - Established documentation conventions in CONTRIBUTING.md:39.
  - Streamlined public and internal documentation across uefi, uefi-raw, tooling, and test code.
  - Added consistent `# Arguments`, `# Errors`, `# Panics`, and `# Safety` contracts.
  - Standardized summaries, examples, protocol fields, flags, error variants, and FFI types.
  - Aligned README, Cargo description, and crate-level introductions.
  - Preserved generated device-path output and verified generator consistency.

I think fighting these inconsistencies is a major win and step forward, and a perfect use of an LLM. As we do not generate any logic or code, I also do not see any legal risks.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
