### PR TITLE
uefi-raw: fix MemoryDescriptor layout on 32-bit

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Added
 
 ## Changed
+- **Breaking**: `MemoryDescriptor` now has a new member to ensure correct
+  padding on 32-bit targets.
 
 ## Removed
 

--- a/uefi-raw/src/table/boot.rs
+++ b/uefi-raw/src/table/boot.rs
@@ -364,6 +364,8 @@ bitflags! {
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
     pub ty: MemoryType,
+    /// Reserved field that must be set to 0.
+    pub reserved: u32,
     // Implicit 32-bit padding.
     /// Starting physical address.
     pub phys_start: PhysicalAddress,
@@ -384,6 +386,7 @@ impl Default for MemoryDescriptor {
     fn default() -> Self {
         Self {
             ty: MemoryType::RESERVED,
+            reserved: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,

--- a/uefi/src/mem/memory_map/impl_.rs
+++ b/uefi/src/mem/memory_map/impl_.rs
@@ -471,6 +471,7 @@ mod tests {
     const BASE_MMAP_UNSORTED: [MemoryDescriptor; 3] = [
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x3000,
             virt_start: 0x3000,
             page_count: 1,
@@ -478,6 +479,7 @@ mod tests {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x2000,
             virt_start: 0x2000,
             page_count: 1,
@@ -485,6 +487,7 @@ mod tests {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x1000,
             virt_start: 0x1000,
             page_count: 1,

--- a/uefi/src/mem/memory_map/mod.rs
+++ b/uefi/src/mem/memory_map/mod.rs
@@ -133,6 +133,7 @@ mod tests_mmap_artificial {
 
         const BASE: MemoryDescriptor = MemoryDescriptor {
             ty: TY,
+            reserved: 0,
             phys_start: 0,
             virt_start: 0,
             page_count: 0,
@@ -170,6 +171,7 @@ mod tests_mmap_artificial {
         const TY: MemoryType = MemoryType::RESERVED;
 
         const BASE: MemoryDescriptor = MemoryDescriptor {
+            reserved: 0,
             ty: TY,
             phys_start: 0,
             virt_start: 0,
@@ -274,6 +276,7 @@ mod tests_mmap_real {
         let expected = [
             MemoryDescriptor {
                 ty: MemoryType::BOOT_SERVICES_CODE,
+                reserved: 0,
                 phys_start: 0x0,
                 virt_start: 0x0,
                 page_count: 0x1,
@@ -284,6 +287,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
+                reserved: 0,
                 phys_start: 0x1000,
                 virt_start: 0x0,
                 page_count: 0x86,
@@ -294,6 +298,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::BOOT_SERVICES_DATA,
+                reserved: 0,
                 phys_start: 0x87000,
                 virt_start: 0x0,
                 page_count: 0x1,
@@ -304,6 +309,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
+                reserved: 0,
                 phys_start: 0x88000,
                 virt_start: 0x0,
                 page_count: 0x18,
@@ -314,6 +320,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
+                reserved: 0,
                 phys_start: 0x100000,
                 virt_start: 0x0,
                 page_count: 0x700,
@@ -324,6 +331,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
+                reserved: 0,
                 phys_start: 0x800000,
                 virt_start: 0x0,
                 page_count: 0x8,
@@ -334,6 +342,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
+                reserved: 0,
                 phys_start: 0x808000,
                 virt_start: 0x0,
                 page_count: 0x3,
@@ -344,6 +353,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
+                reserved: 0,
                 phys_start: 0x80b000,
                 virt_start: 0x0,
                 page_count: 0x1,
@@ -354,6 +364,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::CONVENTIONAL,
+                reserved: 0,
                 phys_start: 0x80c000,
                 virt_start: 0x0,
                 page_count: 0x4,
@@ -364,6 +375,7 @@ mod tests_mmap_real {
             },
             MemoryDescriptor {
                 ty: MemoryType::ACPI_NON_VOLATILE,
+                reserved: 0,
                 phys_start: 0x810000,
                 virt_start: 0x0,
                 page_count: 0xf0,

--- a/uefi/tests/memory_map.rs
+++ b/uefi/tests/memory_map.rs
@@ -10,6 +10,7 @@ fn parse_boot_information_efi_mmap() {
     let mut mmap_source = [
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x3000,
             virt_start: 0x3000,
             page_count: 1,
@@ -17,6 +18,7 @@ fn parse_boot_information_efi_mmap() {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x2000,
             virt_start: 0x2000,
             page_count: 1,
@@ -24,6 +26,7 @@ fn parse_boot_information_efi_mmap() {
         },
         MemoryDescriptor {
             ty: MemoryType::CONVENTIONAL,
+            reserved: 0,
             phys_start: 0x1000,
             virt_start: 0x1000,
             page_count: 1,


### PR DESCRIPTION
On 64-bit, there is implicit padding. On 32-bit targets, this is missing and makes parsing the memory map impossible.

Found the issue in https://github.com/rust-osdev/multiboot2/pull/225.

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
