### PR TITLE
clippy: adjust latest nightly findings

### DIFF
--- a/uefi-test-runner/src/proto/ata/pass_thru.rs
+++ b/uefi-test-runner/src/proto/ata/pass_thru.rs
@@ -39,6 +39,7 @@ fn is_testdrive_present() -> bool {
                 let bfr = result.read_buffer().unwrap();
                 // ATA uses wchar16 big endian strings for serial numbers
                 let mut serial_bfr = [0u8; 20];
+                #[expect(clippy::chunks_exact_to_as_chunks)]
                 bfr[20..40]
                     .chunks_exact(2)
                     .zip(serial_bfr.chunks_exact_mut(2))

--- a/uefi/src/boot.rs
+++ b/uefi/src/boot.rs
@@ -1984,28 +1984,20 @@ impl LoadImageSource<'_> {
         *const u8, /* buffer */
         usize,     /* buffer length */
     ) {
-        let boot_policy;
-        let device_path;
-        let source_buffer;
-        let source_size;
-        match self {
+        let (boot_policy, device_path, source_buffer, source_size) = match self {
             LoadImageSource::FromBuffer { buffer, file_path } => {
                 // Boot policy is ignored when loading from source buffer.
-                boot_policy = BootPolicy::default();
-
-                device_path = file_path.map(|p| p.as_ffi_ptr()).unwrap_or(ptr::null());
-                source_buffer = buffer.as_ptr();
-                source_size = buffer.len();
+                (
+                    BootPolicy::default(),
+                    file_path.map(|p| p.as_ffi_ptr()).unwrap_or(ptr::null()),
+                    buffer.as_ptr(),
+                    buffer.len(),
+                )
             }
             LoadImageSource::FromDevicePath {
                 device_path: d_path,
                 boot_policy: b_policy,
-            } => {
-                boot_policy = *b_policy;
-                device_path = d_path.as_ffi_ptr();
-                source_buffer = ptr::null();
-                source_size = 0;
-            }
+            } => (*b_policy, d_path.as_ffi_ptr(), ptr::null(), 0),
         };
         (boot_policy, device_path, source_buffer, source_size)
     }

--- a/uefi/src/proto/hii/config_str.rs
+++ b/uefi/src/proto/hii/config_str.rs
@@ -143,7 +143,7 @@ impl ConfigurationString {
     /// # Returns
     ///
     /// An iterator over bytes.
-    #[must_use]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
     pub fn parse_bytes_from_hex(hex: &str) -> impl DoubleEndedIterator<Item = u8> {
         hex.as_bytes().chunks(2).map(|chunk| {
             let chunk = str::from_utf8(chunk).unwrap_or_default();
@@ -190,6 +190,7 @@ impl ConfigurationString {
         let size_chars = size_bytes / 2;
         let mut bfr = AlignedBuffer::from_size_align(size_bytes, 2).ok()?;
         bfr.copy_from_iter(Self::parse_bytes_from_hex(data).chain([0, 0]));
+        #[expect(clippy::chunks_exact_to_as_chunks)]
         bfr.as_slice_mut()
             .chunks_exact_mut(2)
             .for_each(|c| c.swap(0, 1));


### PR DESCRIPTION
Adjust to latest nightly findings. Unfortunately, this is incompatible with latest stable and we need a few `allow()`. 
## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
