### PR TITLE
uefi-raw: use boot type for PXE servers

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -5,6 +5,8 @@
   REVISION_3}`.
 
 ## Changed
+- **Breaking**: `PxeBaseCodeSrvlist::server_type` and
+  `PxeBaseCodeSrvlist::new` now use `PxeBaseCodeBootType` instead of `u16`.
 - **Breaking**: `MemoryDescriptor` now has a new member to ensure correct
   layout on all non-UEFI 32-bit targets.
 - **Breaking**: Corrected the `volatile` parameter of

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -160,8 +160,7 @@ pub struct PxeBaseCodeDiscoverInfo {
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct PxeBaseCodeSrvlist {
-    // TODO add newtype
-    pub server_type: u16,
+    pub server_type: PxeBaseCodeBootType,
     pub accept_any_response: Boolean,
     pub reserved: u8,
     pub ip_addr: IpAddress,
@@ -171,7 +170,7 @@ impl PxeBaseCodeSrvlist {
     /// Construct a [`PxeBaseCodeSrvlist`] for a boot server reply type. If `ip_addr` is not `None`,
     /// only boot server replies matching the provided IP address will be accepted.
     #[must_use]
-    pub fn new(server_type: u16, ip_addr: Option<IpAddress>) -> Self {
+    pub fn new(server_type: PxeBaseCodeBootType, ip_addr: Option<IpAddress>) -> Self {
         Self {
             server_type,
             accept_any_response: Boolean::from(ip_addr.is_none()),

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -5,6 +5,8 @@
   the extended processor topology.
 
 ## Changed
+- **Breaking:** `proto::network::pxe::Server::server_type` and `Server::new`
+  now use `BootstrapType` instead of `u16`.
 - Made memory map types `#[repr(C)]`
 - Added `char16!` const-compatible macro as convenient replacement for `Char16::try_from().unwrap()`
 - `proto::debug::SystemContextARM` now contains the trailing `IFAR` field

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1147,7 +1147,11 @@ mod tests {
         // As in EDK2
         assert_eq!(4, DiscoverInfo::base_struct_alignment());
 
-        let server_list = [Server::new(123, None), Server::new(456, None)];
+        let server_list = [
+            Server::new(BootstrapType::BOOTSTRAP, None),
+            Server::new(BootstrapType::REDHAT_BOOT, None),
+        ];
+        assert_eq!(server_list[1].server_type, BootstrapType::REDHAT_BOOT);
         let info = DiscoverInfo::new_in_buffer(
             &mut buffer.0,
             false,


### PR DESCRIPTION
## Summary

- use the existing `PxeBaseCodeBootType` newtype for `PxeBaseCodeSrvlist::server_type` and `PxeBaseCodeSrvlist::new`
- exercise named `BootstrapType` constants in the high-level PXE ABI test
- document the breaking API type change in both affected changelogs

`PxeBaseCodeBootType` is transparent over `u16`, so this strengthens type safety without changing the UEFI ABI layout.

Closes #2047

## Testing

- `cargo +stable xtask fmt --check`
- `cargo +stable xtask clippy --warnings-as-errors`
- `cargo +stable xtask doc --warnings-as-errors --document-private-items`
- `cargo +stable xtask gen-code --check`
- `cargo +stable xtask check-raw`
- `cargo +stable xtask build`
- `cargo +stable xtask test`
- `cargo +1.91.0 build --target x86_64-unknown-uefi -p uefi-test-runner`
- `cargo +1.85.1 build -p uefi-raw`

## AI assistance

OpenAI Codex assisted with repository analysis, implementation drafting, test execution, and PR wording. The resulting diff was reviewed against the UEFI 2.11 and EDK2 definitions and validated with the commands above.

## Checklist

- [x] Sensible git history
- [x] Update the changelog (if necessary)