### PR TITLE
uefi-raw: type PXE server bootstrap values

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -5,6 +5,8 @@
   REVISION_3}`.
 
 ## Changed
+- **Breaking**: `PxeBaseCodeSrvlist::server_type` and
+  `PxeBaseCodeSrvlist::new` now use `PxeBaseCodeBootType` instead of `u16`.
 - **Breaking**: `MemoryDescriptor` now has a new member to ensure correct
   layout on all non-UEFI 32-bit targets.
 - **Breaking**: Corrected the `volatile` parameter of

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -101,6 +101,10 @@ impl PxeBaseCodeProtocol {
 }
 
 newtype_enum! {
+    /// PXE bootstrap server type used during discovery.
+    ///
+    /// The newtype representation preserves vendor-defined and future values
+    /// that are not represented by the associated constants.
     pub enum PxeBaseCodeBootType: u16 => {
         BOOTSTRAP = 0,
         MS_WINNT_RIS = 1,
@@ -160,18 +164,20 @@ pub struct PxeBaseCodeDiscoverInfo {
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct PxeBaseCodeSrvlist {
-    // TODO add newtype
-    pub server_type: u16,
+    /// Bootstrap type provided by this server.
+    pub server_type: PxeBaseCodeBootType,
     pub accept_any_response: Boolean,
     pub reserved: u8,
     pub ip_addr: IpAddress,
 }
 
 impl PxeBaseCodeSrvlist {
-    /// Construct a [`PxeBaseCodeSrvlist`] for a boot server reply type. If `ip_addr` is not `None`,
-    /// only boot server replies matching the provided IP address will be accepted.
+    /// Construct a [`PxeBaseCodeSrvlist`] for a boot server reply type.
+    ///
+    /// If `ip_addr` is not `None`, only boot server replies matching the
+    /// provided IP address will be accepted.
     #[must_use]
-    pub fn new(server_type: u16, ip_addr: Option<IpAddress>) -> Self {
+    pub fn new(server_type: PxeBaseCodeBootType, ip_addr: Option<IpAddress>) -> Self {
         Self {
             server_type,
             accept_any_response: Boolean::from(ip_addr.is_none()),
@@ -189,6 +195,19 @@ impl PxeBaseCodeSrvlist {
         } else {
             Some(&self.ip_addr)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_list_preserves_vendor_boot_type() {
+        let vendor_boot_type = PxeBaseCodeBootType(32768);
+        let server = PxeBaseCodeSrvlist::new(vendor_boot_type, None);
+
+        assert_eq!(server.server_type, vendor_boot_type);
     }
 }
 

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1147,7 +1147,10 @@ mod tests {
         // As in EDK2
         assert_eq!(4, DiscoverInfo::base_struct_alignment());
 
-        let server_list = [Server::new(123, None), Server::new(456, None)];
+        let server_list = [
+            Server::new(BootstrapType::REDHAT_INSTALL, None),
+            Server::new(BootstrapType::BEOBOOT, None),
+        ];
         let info = DiscoverInfo::new_in_buffer(
             &mut buffer.0,
             false,


### PR DESCRIPTION
## Summary

- use `PxeBaseCodeBootType` for `PxeBaseCodeSrvlist::server_type` and its constructor instead of an untyped `u16`
- document that the transparent newtype preserves vendor-defined and future bootstrap values
- cover a vendor-range value and update the high-level PXE ABI test to use named bootstrap constants
- record the breaking raw-API change in the changelog

## Why

UEFI 2.11 defines the server-list `Type` field as a 16-bit PXE bootstrap type. The raw binding already models those values with the forward-compatible `PxeBaseCodeBootType` newtype for `Discover`, so accepting any `u16` in server-list entries loses type safety without adding compatibility.

Reusing the transparent newtype keeps the firmware ABI unchanged and still permits reserved, vendor, and future values through its public integer representation.

Spec: https://uefi.org/specs/UEFI/2.11/24_Network_Protocols_SNP_PXE_BIS.html#efi-pxe-base-code-protocol-discover

EDK2 reference: https://github.com/tianocore/edk2/blob/7735ed4f8eb3afaf1a97d27a8862f382c387f0bc/MdePkg/Include/Protocol/PxeBaseCode.h#L118

Closes #2047.

## Validation

- `cargo fmt --all -- --check`
- canonical host suite for `uefi` and `uefi-raw`: 139 unit/integration tests passed, plus all runnable doctests
- `cargo clippy -p uefi-raw --all-targets -- -D warnings`
- warning-free docs for `uefi` and `uefi-raw`
- `cargo check -p uefi-raw` for `x86_64-unknown-uefi`, `i686-unknown-uefi`, and `aarch64-unknown-uefi`

AI-assisted: OpenAI Codex helped implement and validate this change. I reviewed the patch and test results and am responsible for the submission.