### PR TITLE
release: uefi-raw-0.16.0 and uefi-0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "uguid",

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uefi = { version = "0.39.0", features = ["panic_handler"] }
+uefi = { version = "0.40.0", features = ["panic_handler"] }

--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi-raw - [Unreleased]
 
+
+# uefi-raw - v0.16.0 (2026-08-25)
+
 ## Added
 - Added the revision constants `BlockIoProtocol::{REVISION, REVISION_2,
   REVISION_3}`.

--- a/uefi-raw/Cargo.toml
+++ b/uefi-raw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi-raw"
-version = "0.15.1"
+version = "0.16.0"
 readme = "README.md"
 description = """
 Raw UEFI types and bindings for protocols, boot, and runtime services. This can

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+
+# uefi - v0.40.0 (2026-08-25)
+
 ## Added
 - Added `proto::pi::mp::{CpuPhysicalLocation2, CPU_V2_EXTENDED_TOPOLOGY}` for
   the extended processor topology.

--- a/uefi/Cargo.toml
+++ b/uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uefi"
-version = "0.39.0"
+version = "0.40.0"
 readme = "README.md"
 description = """
 This crate makes it easy to develop Rust software that leverages safe,
@@ -50,7 +50,7 @@ uguid.workspace = true
 cfg-if = "1.0.0"
 ucs2 = "0.3.3"
 uefi-macros = "0.19.0"
-uefi-raw = "0.15.1"
+uefi-raw = "0.16.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
We have many great bug fixes in both crates, so let's ship them.

- CHANGELOG of uefi: https://github.com/rust-osdev/uefi-rs/blob/a830de7fcf377606f254b88c6310cccfd237718b/uefi/CHANGELOG.md
- CHANGELOG of uefi-raw: https://github.com/rust-osdev/uefi-rs/blob/a830de7fcf377606f254b88c6310cccfd237718b/uefi-raw/CHANGELOG.md

## Checklist
- [ ] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [ ] Update the changelog (if necessary)
