### PR TITLE
pxe: use PxeBaseCodeBootType newtype in PxeBaseCodeSrvlist

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -19,6 +19,9 @@
   `HiiKeyboardLayout` fields after `layout_length` were at wrong offsets.
 - **Breaking**: `IfrTypeValue`, `HiiRef`, `HiiTime`, and `HiiDate` are now
   packed to match the size and alignment mandated by the UEFI specification.
+- **Breaking**: Changed `PxeBaseCodeSrvlist::server_type` from `u16` to
+  `PxeBaseCodeBootType`. Accordingly, `PxeBaseCodeSrvlist::new` takes a
+  `PxeBaseCodeBootType` as its first argument.
 
 ## Removed
 

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -160,8 +160,7 @@ pub struct PxeBaseCodeDiscoverInfo {
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct PxeBaseCodeSrvlist {
-    // TODO add newtype
-    pub server_type: u16,
+    pub server_type: PxeBaseCodeBootType,
     pub accept_any_response: Boolean,
     pub reserved: u8,
     pub ip_addr: IpAddress,
@@ -171,7 +170,7 @@ impl PxeBaseCodeSrvlist {
     /// Construct a [`PxeBaseCodeSrvlist`] for a boot server reply type. If `ip_addr` is not `None`,
     /// only boot server replies matching the provided IP address will be accepted.
     #[must_use]
-    pub fn new(server_type: u16, ip_addr: Option<IpAddress>) -> Self {
+    pub fn new(server_type: PxeBaseCodeBootType, ip_addr: Option<IpAddress>) -> Self {
         Self {
             server_type,
             accept_any_response: Boolean::from(ip_addr.is_none()),

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -32,6 +32,9 @@
 - `UnicodeCollation::str_to_fat` now zeroes the output buffer before the
   conversion. Previously, the result could contain garbage from the
   uninitialized buffer, or reference one byte past its end.
+- **Breaking:** The `proto::network::pxe::Server::server_type` field and the
+  first parameter of `Server::new` changed from `u16` to the `BootstrapType`
+  newtype.
 
 ## Removed
 

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1147,7 +1147,10 @@ mod tests {
         // As in EDK2
         assert_eq!(4, DiscoverInfo::base_struct_alignment());
 
-        let server_list = [Server::new(123, None), Server::new(456, None)];
+        let server_list = [
+            Server::new(BootstrapType(123), None),
+            Server::new(BootstrapType(456), None),
+        ];
         let info = DiscoverInfo::new_in_buffer(
             &mut buffer.0,
             false,


### PR DESCRIPTION
Replace the bare u16 `server_type` with the existing `PxeBaseCodeBootType`
newtype enum, as the field semantically holds an `EFI_PXE_BASE_CODE_BOOT_TYPE`
value. This removes the TODO left by upstream commit a2bcaf6, and records the
breaking change in both changelogs.

Closes #2047

## Validation

- `cargo check -p uefi-raw -p uefi` passes locally on host.
- Unit tests of the `uefi` crate fail to compile on my local toolchain even
  without this change (pre-existing errors in unrelated modules, e.g. TCG),
  so I could not run them locally.

## Checklist

- [x] Descriptive git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary).

## AI disclosure

This contribution was implemented and validated with AI coding assistance,
as required by CONTRIBUTING.md. I reviewed and understood every change.

## About me

I'm a graduate student at Hangzhou Dianzi University, currently learning
Rust and OS internals through rCore-Tutorial. I host my code on CNB
(cnb.cool), and I keep my exercises and notes from the tutorial in a
public repo: https://cnb.cool/u/cnb.bs8OWBnfgJA

First contribution to this project — happy to adjust anything per review.
