### PR TITLE
pxe: use PxeBaseCodeBootType in PxeBaseCodeSrvlist

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -1,5 +1,10 @@
 # uefi-raw - [Unreleased]
 
+## Changed
+- **Breaking**: Use `PxeBaseCodeBootType` (newtype-enum) instead of `u16` for
+`PxeBaseCodeSrvlist::server_type` and for the `server_type` parameter of
+`PxeBaseCodeSrvlist::new`.
+
 
 # uefi-raw - v0.16.0 (2026-08-25)
 

--- a/uefi-raw/src/protocol/network/pxe.rs
+++ b/uefi-raw/src/protocol/network/pxe.rs
@@ -160,8 +160,7 @@ pub struct PxeBaseCodeDiscoverInfo {
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct PxeBaseCodeSrvlist {
-    // TODO add newtype
-    pub server_type: u16,
+    pub server_type: PxeBaseCodeBootType,
     pub accept_any_response: Boolean,
     pub reserved: u8,
     pub ip_addr: IpAddress,
@@ -171,7 +170,7 @@ impl PxeBaseCodeSrvlist {
     /// Construct a [`PxeBaseCodeSrvlist`] for a boot server reply type. If `ip_addr` is not `None`,
     /// only boot server replies matching the provided IP address will be accepted.
     #[must_use]
-    pub fn new(server_type: u16, ip_addr: Option<IpAddress>) -> Self {
+    pub fn new(server_type: PxeBaseCodeBootType, ip_addr: Option<IpAddress>) -> Self {
         Self {
             server_type,
             accept_any_response: Boolean::from(ip_addr.is_none()),

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # uefi - [Unreleased]
 
+## Changed
+- **Breaking**: Changed `Server::server_type` and the `server_type` parameter
+  of `Server::new` from `u16` to `BootstrapType`.
+
 
 # uefi - v0.40.0 (2026-08-25)
 

--- a/uefi/src/proto/network/pxe.rs
+++ b/uefi/src/proto/network/pxe.rs
@@ -1147,7 +1147,10 @@ mod tests {
         // As in EDK2
         assert_eq!(4, DiscoverInfo::base_struct_alignment());
 
-        let server_list = [Server::new(123, None), Server::new(456, None)];
+        let server_list = [
+            Server::new(BootstrapType(123), None),
+            Server::new(BootstrapType(456), None),
+        ];
         let info = DiscoverInfo::new_in_buffer(
             &mut buffer.0,
             false,


### PR DESCRIPTION
Update `PxeBaseCodeSrvlist::server_type` and `PxeBaseCodeSrvlist::new` to use `PxeBaseCodeBootType` instead of `u16`, and removed the TODO. The `PxeBaseCodeBootType` already exists in `uefi-raw` nd `PxeBaseCodeProtocol::dissover` already uses it.

Closes #2047

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
