### PR TITLE
data_types: export FromSliceUntilNulError

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -1,5 +1,8 @@
 # uefi - [Unreleased]
 
+## Added
+- Exported `data_types::FromSliceUntilNulError`.
+
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter
   of `Server::new` from `u16` to `BootstrapType`.

--- a/uefi/src/data_types/mod.rs
+++ b/uefi/src/data_types/mod.rs
@@ -19,8 +19,8 @@ pub use guid::{Guid, Identify};
 #[cfg(feature = "alloc")]
 pub use owned_strs::{CString16, FromStrError};
 pub use strs::{
-    CStr8, CStr16, EqStrUntilNul, FromSliceWithNulError, FromStrWithBufError, PoolString,
-    UnalignedCStr16Error,
+    CStr8, CStr16, EqStrUntilNul, FromSliceUntilNulError, FromSliceWithNulError,
+    FromStrWithBufError, PoolString, UnalignedCStr16Error,
 };
 /// These functions are used in the implementation of the [`cstr8!`] macro.
 ///


### PR DESCRIPTION
`FromSliceUntilNulError` was defined in the private `strs` module and omitted from the public re-exports in `uefi::data_types`. The resulted in consumers not being able to name the error type. Re-export `FromSliceUntilNulError`, similar to other string conversion errors from `uefi::data_types`.

Closes #1928

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
