### PR TITLE
uefi: Add AbsolutePointerProtocol

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -12,6 +12,8 @@
 - **Breaking**: Use `PxeBaseCodeBootType` (newtype-enum) instead of `u16` for
 `PxeBaseCodeSrvlist::server_type` and for the `server_type` parameter of
 `PxeBaseCodeSrvlist::new`.
+- **Breaking**: Changed `this` parameter of `SimplePointerProtocol::get_state`
+from `*mut Self` to `*const Self`.
 
 
 # uefi-raw - v0.16.0 (2026-08-25)

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -203,7 +203,7 @@ pub struct SimplePointerState {
 pub struct SimplePointerProtocol {
     pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: Boolean) -> Status,
     pub get_state:
-        unsafe extern "efiapi" fn(this: *mut Self, state: *mut SimplePointerState) -> Status,
+        unsafe extern "efiapi" fn(this: *const Self, state: *mut SimplePointerState) -> Status,
     pub wait_for_input: Event,
     pub mode: *const SimplePointerMode,
 }

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -11,7 +11,8 @@ pub fn test() {
         serial::test();
         gop::test();
     }
-    pointer::test();
+    pointer::test_pointer();
+    pointer::test_absolute_pointer();
 }
 
 mod gop;

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use uefi::boot;
-use uefi::proto::console::pointer::Pointer;
+use uefi::proto::console::pointer::{AbsolutePointer, Pointer};
 
-pub fn test() {
+pub fn test_pointer() {
     info!("Running pointer protocol test");
     let handle = boot::get_handle_for_protocol::<Pointer>().expect("missing Pointer protocol");
     let mut pointer =
@@ -21,5 +21,30 @@ pub fn test() {
         info!("New pointer State: {state:#?}");
     } else {
         info!("Pointer state has not changed since the last query");
+    }
+}
+
+pub fn test_absolute_pointer() {
+    info!("Running absolute pointer protocol test");
+    let handle = boot::get_handle_for_protocol::<AbsolutePointer>()
+        .expect("missing AbsolutePointer protocol");
+    let mut pointer = boot::open_protocol_exclusive::<AbsolutePointer>(handle)
+        .expect("failed to open absolute pointer protocol");
+
+    pointer
+        .reset(false)
+        .expect("Failed to reset absolute pointer device");
+
+    let mode = pointer.mode();
+    info!("Absolute pointer mode: {mode:#?}");
+
+    let state = pointer
+        .read_state()
+        .expect("Failed to retrieve absolute pointer state");
+
+    if let Some(state) = state {
+        info!("New absolute pointer state: {state:#?}");
+    } else {
+        info!("Absolute pointer state has not changed since the last query");
     }
 }

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Exported `data_types::FromSliceUntilNulError`.
+- Added `proto::console::pointer::AbsolutePointer` protocol.
 
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -45,7 +45,7 @@ impl Pointer {
         let pointer_state_ptr: *mut _ = &mut pointer_state;
 
         // SAFETY: The memory is valid.
-        match unsafe { (self.0.get_state)(&mut self.0, pointer_state_ptr.cast()) } {
+        match unsafe { (self.0.get_state)(&self.0, pointer_state_ptr.cast()) } {
             Status::NOT_READY => Ok(None),
             other => other.to_result_with_val(|| Some(pointer_state)),
         }

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -26,7 +26,8 @@ impl Pointer {
     /// # Errors
     /// - `DeviceError` if the device is malfunctioning and cannot be reset.
     pub fn reset(&mut self, extended_verification: bool) -> Result {
-        // SAFETY: The memory is valid.
+        // SAFETY: We have an exclusive reference to `self`, and `&mut
+        // self.0` is a valid protocol pointer.
         unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
     }
 
@@ -44,7 +45,9 @@ impl Pointer {
         let mut pointer_state = PointerState::default();
         let pointer_state_ptr: *mut _ = &mut pointer_state;
 
-        // SAFETY: The memory is valid.
+        // SAFETY: We have an exclusive reference to `self`, `&self.0` is a
+        // valid protocol pointer and `pointer_state_ptr` is a valid pointer to
+        // stack memory initialized to receive the output.
         match unsafe { (self.0.get_state)(&self.0, pointer_state_ptr.cast()) } {
             Status::NOT_READY => Ok(None),
             other => other.to_result_with_val(|| Some(pointer_state)),
@@ -56,14 +59,20 @@ impl Pointer {
     ///
     /// [`boot::wait_for_event`]: crate::boot::wait_for_event
     pub fn wait_for_input_event(&self) -> Result<Event> {
-        // SAFETY: The memory is valid.
+        // SAFETY:
+        // 1. If null (unsupported), `Event::from_ptr` safely returns `None`.
+        // 2. If non-null, the UEFI spec guarantees the driver created a valid `EFI_EVENT`.
         unsafe { Event::from_ptr(self.0.wait_for_input) }.ok_or(Error::from(Status::UNSUPPORTED))
     }
 
     /// Returns a reference to the pointer device information.
     #[must_use]
     pub const fn mode(&self) -> &PointerMode {
-        // SAFETY: The memory is valid.
+        // SAFETY:
+        // 1. `mode` points to valid, initialized memory for the lifetime of the
+        //    protocol, matching the lifetime of `&self`.
+        // 2. `PointerMode` is `#[repr(C)]` with exact same size, field offsets,
+        //    and alignment as `SimplePointerMode`.
         unsafe { &*self.0.mode.cast() }
     }
 }

--- a/uefi/src/proto/console/pointer/mod.rs
+++ b/uefi/src/proto/console/pointer/mod.rs
@@ -4,11 +4,14 @@
 
 use crate::proto::unsafe_protocol;
 use crate::{Error, Event, Result, Status, StatusExt};
-use uefi_raw::protocol::console::SimplePointerProtocol;
+use uefi_raw::protocol::console::{
+    AbsolutePointerMode, AbsolutePointerProtocol, AbsolutePointerState, SimplePointerProtocol,
+};
 
 /// Simple Pointer [`Protocol`]. Provides information about a pointer device.
 ///
-/// Pointer devices are mouses, touchpads, and touchscreens.
+/// Pointer devices are report relative movement, such as mice. For absolute
+/// pointing devices, such as touchscreens, see [`AbsolutePointer`].
 ///
 /// [`Protocol`]: uefi::proto::Protocol
 #[derive(Debug)]
@@ -100,4 +103,75 @@ pub struct PointerState {
     ///
     /// If `PointerMode` indicates a button is not supported, it must be ignored.
     pub button: [bool; 2],
+}
+
+/// Absolute Pointer [`Protocol`]. Provides coordinate pointing (e.g. touchscreens, tablets).
+///
+/// For relative pointing devices such as mice, see [`Pointer`].
+///
+/// [`Protocol`]: uefi::proto::Protocol
+#[derive(Debug)]
+#[repr(transparent)]
+#[unsafe_protocol(AbsolutePointerProtocol::GUID)]
+pub struct AbsolutePointer(AbsolutePointerProtocol);
+
+impl AbsolutePointer {
+    /// Resets the pointer device hardware.
+    ///
+    /// # Arguments
+    /// The `extended_verification` parameter is used to request that UEFI
+    /// performs an extended check and reset of the input device.
+    ///
+    /// # Errors
+    /// - `DeviceError` if the device is malfunctioning and cannot be reset.
+    pub fn reset(&mut self, extended_verification: bool) -> Result {
+        // SAFETY: We have an exclusive reference to `self`, and `&mut
+        // self.0` is a valid protocol pointer.
+        unsafe { (self.0.reset)(&mut self.0, extended_verification.into()) }.to_result()
+    }
+
+    /// Retrieves the pointer device's current state, if a state change occurred
+    /// since the last time this function was called.
+    ///
+    /// Use `wait_for_input_event()` with the [`Self::wait_for_input_event`]
+    /// interface in order to wait for input from the pointer device.
+    ///
+    /// # Errors
+    /// - `DeviceError` if there was an issue with the pointer device.
+    ///
+    /// [`boot::wait_for_event`]: crate::boot::wait_for_event
+    pub fn read_state(&mut self) -> Result<Option<AbsolutePointerState>> {
+        let mut state = AbsolutePointerState::default();
+        let state_ptr: *mut _ = &mut state;
+
+        // SAFETY: We have an exclusive reference to `self`, `&self.0` is a
+        // valid protocol pointer and `pointer_state_ptr` is a valid pointer to
+        // stack memory initialized to receive the output.
+        match unsafe { (self.0.get_state)(&mut self.0, state_ptr) } {
+            Status::NOT_READY => Ok(None),
+            other => other.to_result_with_val(|| Some(state)),
+        }
+    }
+
+    /// Event to be used with [`boot::wait_for_event`] in order to wait
+    /// for input from the pointer device
+    ///
+    /// [`boot::wait_for_event`]: crate::boot::wait_for_event
+    pub fn wait_for_input_event(&self) -> Result<Event> {
+        // SAFETY:
+        // 1. If null (unsupported), `Event::from_ptr` safely returns `None`.
+        // 2. If non-null, the UEFI spec guarantees the driver created a valid `EFI_EVENT`.
+        unsafe { Event::from_ptr(self.0.wait_for_input) }.ok_or(Error::from(Status::UNSUPPORTED))
+    }
+
+    /// Returns a reference to the pointer device information.
+    #[must_use]
+    pub const fn mode(&self) -> &AbsolutePointerMode {
+        // SAFETY:
+        // 1. `mode` points to valid, initialized memory for the lifetime of the
+        //    protocol, matching the lifetime of `&self`.
+        // 2. `PointerMode` is `#[repr(C)]` with exact same size, field offsets,
+        //    and alignment as `SimplePointerMode`.
+        unsafe { &*self.0.mode }
+    }
 }


### PR DESCRIPTION
Adds safe wrapper for `AbsolutePointerProtocol` (which was already available in uefi-raw), in line with `SimplePointerProtocol`.

Also fixed the signature of `AbsolutePointerProtocol::get_state()` to take a `*mut Self` instead of a `*const Self`.

And fixed the docs of `Pointer` to indicate that it is for relative pointing devices and not for fixed pointing devices like touchscreens.

Closes #2060

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
