### PR TITLE
uefi: some string and path improvements

### DIFF
--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Exported `data_types::FromSliceUntilNulError`.
 - Added `proto::console::pointer::AbsolutePointer` protocol.
 - Added `CString::clear` and `PathBuf::clear` functions.
+- Added `CString16::extend` function.
 
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -9,7 +9,9 @@
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter
   of `Server::new` from `u16` to `BootstrapType`.
-
+- **Breaking**: Changed `fs::path::Components::Item` from `CString16` to `&[Char16]`,
+  which avoids heap allocation during iteration. Users can use the recently added
+  `CString16::extend` function to add a `&[Char16]` value to a `CString16`.
 
 # uefi - v0.40.0 (2026-08-25)
 

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Exported `data_types::FromSliceUntilNulError`.
 - Added `proto::console::pointer::AbsolutePointer` protocol.
+- Added `CString::clear` and `PathBuf::clear` functions.
 
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -61,6 +61,14 @@ impl CString16 {
         Self(vec![NUL_16])
     }
 
+    /// Truncates this string, removing all contents except for the mandatory NUL.
+    ///
+    /// While this means the string will have a length of zero, it does not touch its capacity.
+    pub fn clear(&mut self) {
+        self.0.clear();
+        self.0.push(NUL_16);
+    }
+
     /// Inserts a character at the end of the string, right before the null
     /// character.
     ///
@@ -373,5 +381,17 @@ mod tests {
 
         let input = String::from(&input);
         assert_eq!(input, "foo\\bar\\foobar\\\\")
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut str = CString16::try_from("a").unwrap();
+        assert_eq!(str.0, [char16!('a'), NUL_16]);
+
+        str.clear();
+        assert_eq!(str.0, [NUL_16]);
+
+        str.clear();
+        assert_eq!(str.0, [NUL_16]);
     }
 }

--- a/uefi/src/data_types/owned_strs.rs
+++ b/uefi/src/data_types/owned_strs.rs
@@ -87,10 +87,7 @@ impl CString16 {
     /// Extends the string with the given [`CStr16`]. The null character is
     /// automatically kept at the end.
     pub fn push_str(&mut self, str: &CStr16) {
-        str.as_slice()
-            .iter()
-            .copied()
-            .for_each(|char| self.push(char));
+        self.extend(str.as_slice());
     }
 
     /// Replaces all chars in the string with the replace value in-place.
@@ -123,6 +120,14 @@ impl CString16 {
 impl Default for CString16 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<'a> Extend<&'a Char16> for CString16 {
+    /// Extends the string with the contents of an iterator. The null
+    /// character is automatically kept at the end.
+    fn extend<T: IntoIterator<Item = &'a Char16>>(&mut self, iter: T) {
+        iter.into_iter().copied().for_each(|char| self.push(char));
     }
 }
 
@@ -345,7 +350,7 @@ mod tests {
     /// This tests the following UCS-2 string functions:
     /// - runtime constructor
     /// - len()
-    /// - push() / push_str()
+    /// - push() / push_str() / extend()
     /// - to rust string
     #[test]
     fn test_push_str() {
@@ -360,10 +365,11 @@ mod tests {
         str2.push(char16!('!'));
 
         str2.push_str(str1.as_ref());
-        assert_eq!(str2.num_chars(), 3);
+        str2.extend(&[char16!('!')]);
+        assert_eq!(str2.num_chars(), 4);
 
         let rust_str = String::from(&str2);
-        assert_eq!(rust_str, "!hi");
+        assert_eq!(rust_str, "!hi!");
     }
 
     #[test]

--- a/uefi/src/fs/path/path.rs
+++ b/uefi/src/fs/path/path.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::module_inception)]
 
 use crate::fs::path::{PathBuf, SEPARATOR};
-use crate::{CStr16, CString16};
+use crate::{CStr16, CString16, Char16};
 use core::fmt::{Display, Formatter};
 use core::ptr;
 
@@ -74,7 +74,7 @@ impl Path {
                     if !acc.is_empty() && *acc.as_slice().last().unwrap() != SEPARATOR {
                         acc.push(SEPARATOR);
                     }
-                    acc.push_str(next.as_ref());
+                    acc.extend(next);
                     acc
                 });
         let path = PathBuf::from(path);
@@ -121,10 +121,8 @@ pub struct Components<'a> {
     i: usize,
 }
 
-impl Iterator for Components<'_> {
-    // Attention. We can't iterate over &'Ctr16, as we would break any guarantee
-    // made for the terminating null character.
-    type Item = CString16;
+impl<'a> Iterator for Components<'a> {
+    type Item = &'a [Char16];
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.path.is_empty() {
@@ -156,12 +154,10 @@ impl Iterator for Components<'_> {
         } else {
             // select the next component and build an owned string
             let part = &self.path.as_slice()[self.i..self.i + len];
-            let mut string = CString16::new();
-            part.iter().for_each(|c| string.push(*c));
 
             // +1: skip the separator
             self.i = progress + 1;
-            Some(string)
+            Some(part)
         }
     }
 }
@@ -231,38 +227,46 @@ mod tests {
     fn components_iter() {
         let path = Path::new(cstr16!("foo\\bar\\hello"));
         let components = path.components().collect::<Vec<_>>();
-        let components: Vec<&CStr16> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
-        let expected: &[&CStr16] = &[cstr16!("foo"), cstr16!("bar"), cstr16!("hello")];
+        let components: Vec<&[Char16]> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+        let expected: &[&[Char16]] = &[
+            cstr16!("foo").as_slice(),
+            cstr16!("bar").as_slice(),
+            cstr16!("hello").as_slice(),
+        ];
         assert_eq!(components.as_slice(), expected);
 
         // In case there is a leading slash, it should be ignored.
         let path = Path::new(cstr16!("\\foo\\bar\\hello"));
         let components = path.components().collect::<Vec<_>>();
-        let components: Vec<&CStr16> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
-        let expected: &[&CStr16] = &[cstr16!("foo"), cstr16!("bar"), cstr16!("hello")];
+        let components: Vec<&[Char16]> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+        let expected: &[&[Char16]] = &[
+            cstr16!("foo").as_slice(),
+            cstr16!("bar").as_slice(),
+            cstr16!("hello").as_slice(),
+        ];
         assert_eq!(components.as_slice(), expected);
 
         // empty path iteration should be just fine
         let empty_cstring16 = CString16::try_from("").unwrap();
         let path = Path::new(empty_cstring16.as_ref());
         let components = path.components().collect::<Vec<_>>();
-        let expected: &[CString16] = &[];
+        let expected: &[&[Char16]] = &[];
         assert_eq!(components.as_slice(), expected);
 
         // test empty path
         let _path = Path::new(cstr16!());
         let path = Path::new(cstr16!(""));
         let components = path.components().collect::<Vec<_>>();
-        let components: Vec<&CStr16> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
-        let expected: &[&CStr16] = &[];
+        let components: Vec<&[Char16]> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+        let expected: &[&[Char16]] = &[];
         assert_eq!(components.as_slice(), expected);
 
         // test path that has only root component. Treated as empty path by
         // the components iterator.
         let path = Path::new(cstr16!("\\"));
         let components = path.components().collect::<Vec<_>>();
-        let components: Vec<&CStr16> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
-        let expected: &[&CStr16] = &[];
+        let components: Vec<&[Char16]> = components.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+        let expected: &[&[Char16]] = &[];
         assert_eq!(components.as_slice(), expected);
     }
 

--- a/uefi/src/fs/path/pathbuf.rs
+++ b/uefi/src/fs/path/pathbuf.rs
@@ -19,6 +19,11 @@ impl PathBuf {
         Self::default()
     }
 
+    /// Truncates the path to zero length.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
     /// Constructor that replaces all occurrences of `/` with `\`.
     fn new_from_cstring16(mut string: CString16) -> Self {
         const SEARCH: Char16 = char16!('/');
@@ -184,5 +189,18 @@ mod tests {
 
         assert_eq!(pathbuf2, pathbuf2);
         assert_ne!(pathbuf1, pathbuf2);
+    }
+
+    #[test]
+    fn clear() {
+        let mut pathbuf = PathBuf::new();
+        pathbuf.push(cstr16!("first"));
+        assert_eq!(cstr16!("first"), pathbuf.to_cstr16());
+
+        pathbuf.clear();
+        assert_eq!(cstr16!(""), pathbuf.to_cstr16());
+
+        pathbuf.clear();
+        assert_eq!(cstr16!(""), pathbuf.to_cstr16());
     }
 }

--- a/uefi/src/fs/path/validation.rs
+++ b/uefi/src/fs/path/validation.rs
@@ -53,11 +53,7 @@ pub fn validate_path<P: AsRef<Path>>(path: P) -> Result<(), PathError> {
     for component in path.components() {
         if component.is_empty() {
             return Err(PathError::EmptyComponent);
-        } else if let Some(char) = component
-            .as_slice()
-            .iter()
-            .find(|c| CHARACTER_DENY_LIST.contains(c))
-        {
+        } else if let Some(char) = component.iter().find(|c| CHARACTER_DENY_LIST.contains(c)) {
             return Err(PathError::IllegalChar(*char));
         }
     }


### PR DESCRIPTION
- Added `CString::clear` and `PathBuf::clear` functions.
- Added `CString16::extend` function.
- Changed `fs::path::Components::Item` from `CString16` to `&[Char16]`,
  which avoids heap allocation during iteration. Users can use the
  `CString16::extend` function to add a `&[Char16]` value to a `CString16`.

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
