### PR TITLE
Add EdidDiscovered protocol

### DIFF
--- a/uefi-raw/CHANGELOG.md
+++ b/uefi-raw/CHANGELOG.md
@@ -7,6 +7,7 @@
   `EFI_PCI_ATTRIBUTE_MEMORY`, `EFI_PCI_ATTRIBUTE_BUS_MASTER`,
   `EFI_PCI_ATTRIBUTE_EMBEDDED_DEVICE`, and `EFI_PCI_ATTRIBUTE_EMBEDDED_ROM`
   to `PciRootBridgeIoProtocolAttributes`.
+- Added `EdidDiscoveredProtocol`.
 
 ## Changed
 - **Breaking**: Use `PxeBaseCodeBootType` (newtype-enum) instead of `u16` for

--- a/uefi-raw/src/protocol/console.rs
+++ b/uefi-raw/src/protocol/console.rs
@@ -325,3 +325,14 @@ newtype_enum! {
         GRAPHICS_OUTPUT_BLT_OPERATION_MAX = 4,
     }
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct EdidDiscoveredProtocol {
+    pub size_of_edid: u32,
+    pub edid: *const u8,
+}
+
+impl EdidDiscoveredProtocol {
+    pub const GUID: Guid = guid!("1c0c34f6-d380-41fa-a049-8ad06c1a66aa");
+}

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -2,9 +2,11 @@
 
 use crate::{HostRequest, send_request_to_host};
 use uefi::boot::{self, OpenProtocolAttributes, OpenProtocolParams};
-use uefi::proto::console::gop::{BltOp, BltPixel, FrameBuffer, GraphicsOutput, PixelFormat};
+use uefi::proto::console::gop::{
+    BltOp, BltPixel, EdidDiscovered, FrameBuffer, GraphicsOutput, PixelFormat,
+};
 
-pub unsafe fn test() {
+pub unsafe fn gop_test() {
     info!("Running graphics output protocol test");
     let handle =
         boot::get_handle_for_protocol::<GraphicsOutput>().expect("missing GraphicsOutput protocol");
@@ -105,4 +107,21 @@ fn draw_fb(gop: &mut GraphicsOutput) {
 
     fill_rectangle((50, 30), (150, 600), [250, 128, 64]);
     fill_rectangle((400, 120), (750, 450), [16, 128, 255]);
+}
+
+pub fn test_edid_discovered() {
+    info!("Running EDID discovered protocol test");
+
+    let Ok(handle) = boot::get_handle_for_protocol::<EdidDiscovered>() else {
+        info!("No EdidDiscovered protocol handle found, skipping EDID test");
+        return;
+    };
+
+    let edid = boot::open_protocol_exclusive::<EdidDiscovered>(handle)
+        .expect("failed to open EdidDiscovered protocol");
+
+    match edid.edid() {
+        Some(bytes) => info!("Discovered EDID: {} bytes", bytes.len()),
+        None => info!("EdidDiscovered protocol present but no EDID was discovered"),
+    }
 }

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -9,10 +9,11 @@ pub fn test() {
 
     unsafe {
         serial::test();
-        gop::test();
+        gop::gop_test();
     }
     pointer::test_pointer();
     pointer::test_absolute_pointer();
+    gop::test_edid_discovered();
 }
 
 mod gop;

--- a/uefi/CHANGELOG.md
+++ b/uefi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Exported `data_types::FromSliceUntilNulError`.
 - Added `proto::console::pointer::AbsolutePointer` protocol.
+- Added `proto::console::gop::EdidDiscovered` protocol.
 
 ## Changed
 - **Breaking**: Changed `Server::server_type` and the `server_type` parameter

--- a/uefi/src/proto/console/gop.rs
+++ b/uefi/src/proto/console/gop.rs
@@ -59,8 +59,8 @@ use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull};
 use uefi_raw::protocol::console::{
-    GraphicsOutputBltOperation, GraphicsOutputBltPixel, GraphicsOutputModeInformation,
-    GraphicsOutputProtocol, GraphicsOutputProtocolMode,
+    EdidDiscoveredProtocol, GraphicsOutputBltOperation, GraphicsOutputBltPixel,
+    GraphicsOutputModeInformation, GraphicsOutputProtocol, GraphicsOutputProtocolMode,
 };
 
 pub use uefi_raw::protocol::console::PixelBitmask;
@@ -666,5 +666,40 @@ impl FrameBuffer<'_> {
         );
         // SAFETY: The source layout matches the target view.
         unsafe { (self.base.add(index) as *const T).read_volatile() }
+    }
+}
+
+/// EDID Discovered [`Protocol`]. Exposes the EDID information that was
+/// discovered for the device backing a [`GraphicsOutput`] handle.
+///
+/// This protocolis installed on the same handle as [`GraphicsOutput`], since
+/// both are produced by the same output device driver.
+///
+/// [`Protocol`]: uefi::proto::Protocol
+/// [`GraphicsOutput`]: crate::proto::console::gop::GraphicsOutput
+#[derive(Debug)]
+#[repr(transparent)]
+#[unsafe_protocol(EdidDiscoveredProtocol::GUID)]
+pub struct EdidDiscovered(EdidDiscoveredProtocol);
+
+impl EdidDiscovered {
+    /// Get the discovered EDID as raw bytes.
+    ///
+    /// Return `None` if no EDID was discovered for this display device.
+    #[must_use]
+    pub const fn edid(&self) -> Option<&[u8]> {
+        if self.0.edid.is_null() {
+            None
+        } else {
+            // SAFETY:
+            // The memory is valid for `size_of_edid` bytes for the
+            // lifetime of the protocol, matching the lifetime of `&self`.
+            unsafe {
+                Some(core::slice::from_raw_parts(
+                    self.0.edid,
+                    usize_from_u32(self.0.size_of_edid),
+                ))
+            }
+        }
     }
 }


### PR DESCRIPTION
- Adds `EdidDiscoveredProtocol` bindings in `uefi-raw`.
- Adds safe wrapper `EdidDiscovered` in `uefi`.
- Adds test for `EdidDiscovered` protocol.

reference:
- UEFI Spec : https://uefi.org/specs/UEFI/2.10/12_Protocols_Console_Support.html#efi-edid-discovered-protocol

Closes #2072  

<!-- Descriptive summary of your bugfix, feature, or refactoring. -->

## Checklist
- [x] Sensible git history (for example, squash "typo" or "fix" commits). See the [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) guide for help.
- [x] Update the changelog (if necessary)
